### PR TITLE
Fix blueprint submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "blueprint"]
 	path = blueprint
-	url = ../../blueprint
+	url = ../../google/blueprint


### PR DESCRIPTION
Add the missing path component 'google' to the relative path from
'ARM-software/bob-build' to 'google/blueprint'.

Change-Id: If0207181006c1f84dc23b955e618c26df1c8c664
Signed-off-by: Chris Diamand <chris.diamand@arm.com>