### PR TITLE
Don't use readlink on OS X

### DIFF
--- a/bob.bash
+++ b/bob.bash
@@ -30,11 +30,14 @@ cd "${WORKDIR}"
 # Generate config.go from Mconfig
 python "${BOB_DIR}/scripts/generate_config_json.py" --database "${SRCDIR}/Mconfig" --output "${BUILDDIR}/config.json" ${BOB_CONFIG_OPTS} "${BUILDDIR}/${CONFIGNAME}"
 
+# Source the pathtools script - we need bob_realpath for CCACHE_BASEDIR.
+source "${BOB_DIR}/pathtools.bash"
+
 # If enabled, the following environment variables optimize the performance
 # of ccache. Otherwise they have no effect.
 # To build with ccache, set the environment variable CCACHE_DIR to where the
 # cache is to reside and add CCACHE=y to the build config to enable.
-export CCACHE_BASEDIR="$(readlink -f "${SRCDIR}")"
+export CCACHE_BASEDIR="$(bob_realpath ${SRCDIR})"
 export CCACHE_CPP2=y
 export CCACHE_SLOPPINESS=file_macro,time_macros
 

--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -68,7 +68,7 @@ WORKDIR=$(relative_path "${BUILDDIR}" $(pwd))
 
 # Calculate Bob directory relative to working directory and absolute
 BOB_DIR="$(relative_path $(pwd) "${SCRIPT_DIR}")"
-BOB_DIR_ABS="$(readlink -f "${SCRIPT_DIR}")"
+BOB_DIR_ABS="$(bob_realpath "${SCRIPT_DIR}")"
 
 export BOOTSTRAP="${BOB_DIR}/bootstrap.bash"
 export BLUEPRINTDIR="${BOB_DIR}/blueprint"

--- a/pathtools.bash
+++ b/pathtools.bash
@@ -38,13 +38,25 @@ function shortest_path() {
     fi
 }
 
+# Portable version of readlink. There are no requirements on path components existing.
+if which realpath >&/dev/null &&
+   [[ -n "$(realpath --version 2>&1 | grep 'GNU coreutils')" ]]; then
+    function bob_realpath {
+        realpath -m "$1"
+    }
+else
+    function bob_realpath() {
+        python -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$1"
+    }
+fi
+
 # Return a path that references $2 from $1
 # $1 and $2 must exist
 # This is a simple implementation. We rely on readlink to sort out symlink issues for us.
 # If there are fewer path elements in the absolute version, return that instead.
 function relative_path() {
-    SRC_ABS=$(readlink -f $1)
-    TGT_ABS=$(readlink -f $2)
+    SRC_ABS=$(bob_realpath $1)
+    TGT_ABS=$(bob_realpath $2)
 
     BACK=
     # ${TGT_ABS#SRC_ABS} removes the SRC_ABS from TGT_ABS

--- a/tests/bootstrap_utils.sh
+++ b/tests/bootstrap_utils.sh
@@ -34,5 +34,5 @@ function create_link() {
         echo "Can't create link from $linkname to $target - $linkname already exists and is not a symbolic link"
         return 1
     fi
-    ln -s -T "$target" "$linkname"
+    ln -s "$target" "$linkname"
 }


### PR DESCRIPTION
Provide a readlink wrapper in pathtools.bash which works on OS X,
which doesn't support the usual readlink options.

Also, don't use the '-T' flag with 'ln', because it is not supported
on OS X.

Change-Id: Ibefc54d17ad5aa16c58a18e8f5316d371223bc63