### PR TITLE
Android generated libs

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -36,7 +36,7 @@ build environment that we don't want imposed on Linux builds.
 
 When the code base contains lots of optional behaviour, it's important that:
 
-* users can identify what the options there are and select them
+* users can identify what options there are and select them
 
   Bob's menuconfig is expected to solve this part of the problem,
   negating the need to document all the options somewhere else.
@@ -86,3 +86,23 @@ must match Android's expectation of where it needs to be.
 At the moment Bob provides minimal scripts that projects can call for
 each phase. It's expected that projects will implement their own
 scripts that do project specific things in each phase.
+
+## Supported Android versions
+
+The Android build system changes with each Android release, which can
+break some features in Bob. In general Bob will support the current
+release and the one before that.
+
+| Version | Status |
+|---|---|
+| Nougat | Some features may no longer work |
+| Oreo | Supported |
+| Pie | Supported |
+| Q | In progress |
+| earlier | not supported |
+
+Note that not all Bob features are supported on Android. This includes:
+
+* Aliases
+* Versioned libraries
+* Forwarding libraries

--- a/tests/generate_libs/build.bp
+++ b/tests/generate_libs/build.bp
@@ -38,9 +38,9 @@ bob_install_group {
 bob_generate_shared_library {
     name: "libblah_shared",
     srcs: ["libblah/libblah.c"],
-    headers: ["libblah.h"],
+    headers: ["include/libblah.h"],
     always_enabled_feature: {
-        headers: ["libblah_feature.h"],
+        headers: ["include/libblah_feature.h"],
     },
     install_group: "ig_genlib_lib",
     export_gen_include_dirs: ["include"],
@@ -61,17 +61,14 @@ bob_binary {
     host_supported: true,
     target_supported: false,
     build_by_default: true,
-    android: {
-        enabled: false,
-    },
 }
 
 bob_generate_static_library {
     name: "libblah_static",
     srcs: ["libblah/libblah.c"],
-    headers: ["libblah.h"],
+    headers: ["include/libblah.h"],
     always_enabled_feature: {
-        headers: ["libblah_feature.h"],
+        headers: ["include/libblah_feature.h"],
     },
     export_gen_include_dirs: ["include"],
 
@@ -91,9 +88,6 @@ bob_binary {
     host_supported: true,
     target_supported: false,
     build_by_default: true,
-    android: {
-        enabled: false,
-    },
 }
 
 bob_alias {

--- a/tests/generate_libs/main.c
+++ b/tests/generate_libs/main.c
@@ -1,7 +1,7 @@
 #include "libblah.h"
 #include "libblah_feature.h"
 
-int main(int argc, const char **argv)
+int main()
 {
 	return output() == 42 ? 0 : 1;
 }


### PR DESCRIPTION
The tests for generated libraries were disabled on Android as they weren't working. Fix this up on Android O and P, and re-enable the tests.

Also document which Android versions are documented