### PR TITLE
Add helpers to get config values

### DIFF
--- a/config_system/__init__.py
+++ b/config_system/__init__.py
@@ -13,5 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .general import init_config, get_config, get_config_list, read_config, set_config, \
-    can_enable, warn_on_selected_depends
+from .general import init_config, get_config, get_config_bool, \
+    get_config_int, get_config_string,  get_config_list, read_config, \
+    set_config, can_enable, warn_on_selected_depends

--- a/config_system/general.py
+++ b/config_system/general.py
@@ -576,6 +576,27 @@ def force_config(key, value, source):
 def get_config(key):
     return configuration['config'][key]
 
+def get_config_bool(key):
+    c = get_config(key)
+    assert c['datatype'] == 'bool', \
+           'Config option %s is not a bool (has type %s)' % (key, c['datatype'])
+    if c['value'] == 'y':
+        return True
+    else:
+        return False
+
+def get_config_int(key):
+    c = get_config(key)
+    assert c['datatype'] == 'int', \
+           'Config option %s is not an int (has type %s)' % (key, c['datatype'])
+    return int(c['value'])
+
+def get_config_string(key):
+    c = get_config(key)
+    assert c['datatype'] == 'string', \
+           'Config option %s is not a string (has type %s)' % (key, c['datatype'])
+    return c['value']
+
 def get_menu_depends(type, value):
     if type in ["config","menuconfig"]:
         return configuration['config'][value].get('depends')


### PR DESCRIPTION
Add helpers to access the values of configuration options, and verify
their types, instead of writing get_config(...)['value'] everywhere.

Change-Id: Ib2d6b5ba4da00bfb508411b3186e442d0376aab3
Signed-off-by: Chris Diamand <chris.diamand@arm.com>