### PR TITLE
Translate names of LOCAL_REQUIRED_MODULES

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -459,6 +459,9 @@ func (m *library) GenerateBuildAction(binType int, ctx blueprint.ModuleContext) 
 
 		requiredModuleNames := m.getInstallDepPhonyNames(ctx)
 		if len(requiredModuleNames) > 0 {
+			for i, v := range requiredModuleNames {
+				requiredModuleNames[i] = androidModuleName(v)
+			}
 			text += "LOCAL_REQUIRED_MODULES:=" + newlineSeparatedList(requiredModuleNames)
 		}
 	} else {


### PR DESCRIPTION
When `out` is specified, the modules returned by
getInstallDepPhonyNames will be the Bob names. Convert to the name
requested by `out` so that Android installs the relevant modules.