### PR TITLE
Improve libstdc++ header path discovery

### DIFF
--- a/example/Mconfig
+++ b/example/Mconfig
@@ -50,11 +50,6 @@ config TARGET_GNU_TOOLCHAIN_PREFIX
 config PKG_CONFIG
 	bool "PKG_CONFIG"
 
-config TARGET_GNU_TOOLCHAIN_VERSION
-	string "Version reported by the underlying GNU cross-compiler"
-	depends on TARGET_TOOLCHAIN_CLANG
-	default "4.9.1"
-
 config CLANG_CC_BINARY
 	string
 	default "clang"

--- a/scripts/host_explore.py
+++ b/scripts/host_explore.py
@@ -89,8 +89,6 @@ def compiler_config():
 
             cross_sysroot = check_output([cross_gcc] + flags + ['-print-sysroot'])
             set_config('TARGET_SYSROOT', cross_sysroot)
-            cross_version = check_output([cross_gcc] + flags + ['-dumpversion'])
-            set_config('TARGET_GNU_TOOLCHAIN_VERSION', cross_version)
             target_libstdcxx_path = check_output([cross_gcc] + flags + ['-print-file-name=libstdc++.so'])
             crt_path = os.path.split(check_output([cross_gcc] + flags + ['-print-file-name=crt1.o']))[0]
             if crt_path != '':

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -53,11 +53,6 @@ config TARGET_GNU_TOOLCHAIN_PREFIX
 config PKG_CONFIG
 	bool "PKG_CONFIG"
 
-config TARGET_GNU_TOOLCHAIN_VERSION
-	string "Version reported by the underlying GNU cross-compiler"
-	depends on TARGET_TOOLCHAIN_CLANG
-	default "4.9.1"
-
 config CLANG_CC_BINARY
 	string
 	default "clang"


### PR DESCRIPTION
GCC toolchains ship with their own C++ headers, which are used in
Clang builds in order to link with libstdc++.

Currently, we use a path relative to the output of `gcc
-print-sysroot`. However, because it contains '..', it becomes
invalid when the GCC toolchain is part of the system installation,
and therefore has '/' as its sysroot.

Furthermore, using the TARGET_SYSROOT to find these headers means we
can't use an _actual_ sysroot with Clang - it always has to refer to
a GCC installation.

Fortunately, this can be fixed: We can reliably determine the C++
header path of any pre-packaged GCC installation, because these
headers consistently live in the '{target}/include/c++/{version}' and
'{target}/include/c++/{version}/{target}' subdirectories.

When the compiler is not a cross-compiler, the first '{target}'
subdirectory is omitted.

This commit should not change the user-visible behaviour in any way,
except when using a Clang cross-compiler and system-installed GCC
toolchain, which was previously broken. Accordingly, TARGET_SYSROOT
is still filled-in in host_explore.py, even though it is no longer
needed. This will be changed in a later commit to enable using
arbitrary sysroots.

Change-Id: If4be308338c42fbbe9371192029a27d461e15373
Signed-off-by: Chris Diamand <chris.diamand@arm.com>