### PR TITLE
menuconfig: fix inputbox with integer configs

### DIFF
--- a/config_system/menuconfig.py
+++ b/config_system/menuconfig.py
@@ -578,9 +578,9 @@ def main(stdscr):
                 prompt(stdscr, window, selection.get_help())
             menu_bar.selection = 0
         elif c == ord('y'):
-            selection.set_bool('y')
+            selection.set()
         elif c == ord('n'):
-            selection.set_bool('n')
+            selection.clear()
         elif c == ord(' '):
             selection.toggle()
         elif  c == ord('r'):


### PR DESCRIPTION
An inputbox always wants to deal with strings, so make sure we
convert any integer config values for display.

When setting the value of the config make sure we convert back to an
int, and that we won't try to test the integer against a string.

Also split MenuItem.set_bool() into MenuItem.set() and
MenuItem.clear(), so the caller is isolated from how we encode the
boolean internally.