### PR TITLE
Fix append() usage with toolchain flags

### DIFF
--- a/core/linux.go
+++ b/core/linux.go
@@ -272,10 +272,10 @@ func (l *library) CompileObjs(ctx blueprint.ModuleContext) []string {
 	cc, cctargetflags := tc.getCCompiler()
 	cxx, cxxtargetflags := tc.getCXXCompiler()
 
-	ctx.Variable(pctx, "asflags", strings.Join(append(astargetflags, l.Properties.Asflags...), " "))
-	ctx.Variable(pctx, "cflags", strings.Join(cflagsList, " "))
-	ctx.Variable(pctx, "conlyflags", strings.Join(append(cctargetflags, l.Properties.Conlyflags...), " "))
-	ctx.Variable(pctx, "cxxflags", strings.Join(append(cxxtargetflags, l.Properties.Cxxflags...), " "))
+	ctx.Variable(pctx, "asflags", utils.Join(astargetflags, l.Properties.Asflags))
+	ctx.Variable(pctx, "cflags", utils.Join(cflagsList))
+	ctx.Variable(pctx, "conlyflags", utils.Join(cctargetflags, l.Properties.Conlyflags))
+	ctx.Variable(pctx, "cxxflags", utils.Join(cxxtargetflags, l.Properties.Cxxflags))
 
 	var objectFiles []string
 	for _, source := range srcs {
@@ -526,12 +526,12 @@ func (l *library) getCommonLibArgs(ctx blueprint.ModuleContext) map[string]strin
 	args := map[string]string{
 		"build_wrapper":     buildWrapper,
 		"compiler":          compiler,
-		"ldflags":           strings.Join(append(cctargetflags, ldflags...), " "),
+		"ldflags":           utils.Join(cctargetflags, ldflags),
 		"shared_libs_dir":   l.getSharedLibraryDir(),
-		"shared_libs_flags": strings.Join(sharedLibFlags, " "),
-		"static_libs":       strings.Join(l.GetStaticLibs(ctx), " "),
-		"ldlibs":            strings.Join(l.Properties.Ldlibs, " "),
-		"whole_static_libs": strings.Join(l.GetWholeStaticLibs(ctx), " "),
+		"shared_libs_flags": utils.Join(sharedLibFlags),
+		"static_libs":       utils.Join(l.GetStaticLibs(ctx)),
+		"ldlibs":            utils.Join(l.Properties.Ldlibs),
+		"whole_static_libs": utils.Join(l.GetWholeStaticLibs(ctx)),
 	}
 	return args
 }

--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -295,7 +295,7 @@ func newToolchainClangNative(config *bobConfig) (tc toolchainClangNative) {
 
 	// Combine cflags and cxxflags once here, to avoid appending during
 	// every call to getCXXCompiler().
-	tc.cxxflags = append(tc.cflags, tc.cxxflags...)
+	tc.cxxflags = append(tc.cxxflags, tc.cflags...)
 
 	return
 }
@@ -323,7 +323,7 @@ func newToolchainClangCross(config *bobConfig) (tc toolchainClangCross) {
 
 	// Combine cflags and cxxflags once here, to avoid appending during
 	// every call to getCXXCompiler().
-	tc.cxxflags = append(tc.cflags, tc.cxxflags...)
+	tc.cxxflags = append(tc.cxxflags, tc.cflags...)
 
 	return
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -190,3 +190,24 @@ func Trim(args []string) []string {
 	}
 	return out
 }
+
+// Join multiple lists of strings. This replaces appending multiple arrays
+// together before calling strings.Join().
+func Join(lists ...[]string) (joined string) {
+	const sep = " "
+	first := true
+
+	for _, list := range lists {
+		listJoined := strings.Join(list, sep)
+		if len(listJoined) > 0 {
+			if !first {
+				joined += sep
+			} else {
+				first = false
+			}
+			joined += listJoined
+		}
+	}
+
+	return
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -178,3 +178,20 @@ func Test_Trim(t *testing.T) {
 	assertArraysEqual(t, Trim([]string{"", " hello ", "world", "	"}),
 		[]string{"hello", "world"})
 }
+
+func Test_Join(t *testing.T) {
+	assertTrue(t,
+		Join() == "",
+		"Empty join should yield an empty string")
+	assertTrue(t,
+		Join([]string{"Hello", "world"}) == "Hello world",
+		"Didn't concatenate two words")
+
+	// Here, there's a 3rd space before "spaces", because strings.Join()
+	// adds one for the empty string, but utils.Join() doesn't.
+	assertTrue(t,
+		Join([]string{"this is", " surrounded by "},
+			[]string{"", "spaces"}, []string{}) ==
+			"this is  surrounded by   spaces",
+		"Surrounding space not handled")
+}


### PR DESCRIPTION
Toolchain flags are getting corrupted because of incorrect usage of
append(). The issue is as follows:

 (1) Toolchain initialisation generates cflags and cxxflags.
 (2) cxxflags is then merged with cflags:
         cxxflags = append(cflags, cxxflags)
 (3) In CompileObjs(), cflags is merged with conlyflags:
         ...append(cctargetflags, Properties.conlyflags)

The issue is that, because of (2), cxxflags ends up using the same
buffer as cflags. This means that the last two elements of that
buffer can be overwritten with conlyflags by (3), with the result
that conlyflags end up in cxxflags!

Fix this in two ways:
 * Swap the order of cflags and cxxflags in (2), so that the cflags
   are copied into cxxflags' buffer.
 * Instead of appending arrays then passing them to strings.Join(),
   add a new helper, utils.Join(), which can join multiple string
   arrays into a new destination string without appending any of the
   source arrays together. This prevents the overwriting in (3).

Change-Id: I652578bdda4cb7ec9cc33cccb97affa4dd44cc19
Signed-off-by: Chris Diamand <chris.diamand@arm.com>