### PR TITLE
Allow configurable link parallelism

### DIFF
--- a/bob.bash
+++ b/bob.bash
@@ -27,7 +27,10 @@ source "${BOOTSTRAP}"
 # Switch to the working directory
 cd "${WORKDIR}"
 
-# Generate config.go from Mconfig
+# Convert Mconfig into Go-readable JSON. Because this is run at every rebuild
+# (rather than every bootstrap or re-configuration), this also adds a hash of
+# the environment into the config, so that Bob is rerun and the Ninja is
+# updated if a relevant environment variable is changed.
 python "${BOB_DIR}/scripts/generate_config_json.py" --database "${SRCDIR}/Mconfig" --output "${BUILDDIR}/config.json" ${BOB_CONFIG_OPTS} "${BUILDDIR}/${CONFIGNAME}"
 
 # Source the pathtools script - we need bob_realpath for CCACHE_BASEDIR.


### PR DESCRIPTION
Permit modification of the link pool size using the
BOB_LINK_PARALLELISM environment variable, instead of hard-coding it
to num_cpus/5+1.

Because Bob now checks an environment variable, it needs to have a
mechanism to re-run Bob if the environment variable changes. This is
done by adding a hash of the current environment to the config in
generate_config_json.py, which is run at every build. If this
hash changes, config.json's will be updated with a new hash, causing
Bob to be re-run.

Change-Id: Ia93c6ca89a2379756ce0aeeedfff509d4887d62f
Signed-off-by: Chris Diamand <chris.diamand@arm.com>