### PR TITLE
Handle ccache symlinks in the toolchain path

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -18,6 +18,7 @@
 package utils
 
 import (
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -210,4 +211,12 @@ func Join(lists ...[]string) (joined string) {
 	}
 
 	return
+}
+
+// IsExecutable returns true if the given file exists and is executable
+func IsExecutable(fname string) bool {
+	if fi, err := os.Stat(fname); !os.IsNotExist(err) && (fi.Mode()&0111 != 0) {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
One way of using ccache is via a set of symlinks, usually in
/usr/lib/ccache, which point to the ccache executable ("masquerade"
mode). However, this causes toolchain.go to think that GCC is
installed in /usr/lib, rather than the actual location.

Fix this by checking if the C compiler is a symlink. If it is, and if
it points to a binary named "ccache", then try the PATH lookup again,
but ignoring the directory the symlinks were found in.

Change-Id: I58febe27a9f5c4172791f817a6b96d5324b75475
Signed-off-by: Chris Diamand <chris.diamand@arm.com>