### PR TITLE
Rename 'ARM' toolchain

### DIFF
--- a/example/Mconfig
+++ b/example/Mconfig
@@ -39,6 +39,9 @@ config TARGET_TOOLCHAIN_GNU
 config TARGET_TOOLCHAIN_CLANG
 	bool "Clang"
 
+config TARGET_TOOLCHAIN_ARMCLANG
+	bool "Arm Compiler 6"
+
 endchoice
 
 ## Toolchain prefix needed for Bob (for gcc)
@@ -81,6 +84,30 @@ config AR_BINARY
 config AS_BINARY
 	string
 	default "as"
+
+config ARMCLANG_CC_BINARY
+	string
+	default "armclang"
+
+config ARMCLANG_CXX_BINARY
+	string
+	default "armclang"
+
+config ARMCLANG_LD_BINARY
+	string
+	default "armlink"
+
+config ARMCLANG_AS_BINARY
+	string
+	default "armasm"
+
+config ARMCLANG_AR_BINARY
+	string
+	default "armar"
+
+config TARGET_ARMCLANG_FLAGS
+	string
+	default ""
 
 # Filled in by host_explore.py during the configuration step
 config EXTRA_HOST_LDFLAGS
@@ -135,6 +162,12 @@ config HOST_TOOLCHAIN_GNU
 	bool "GNU"
 	help
 		Build with GNU toolchain.
+
+config HOST_TOOLCHAIN_ARMCLANG
+	bool "Arm Compiler 6"
+	help
+		Build with the Arm Compiler.
+
 endchoice
 
 config HOST_CC_BINARY

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -39,8 +39,8 @@ config TARGET_TOOLCHAIN_GNU
 config TARGET_TOOLCHAIN_CLANG
 	bool "Clang"
 
-config TARGET_TOOLCHAIN_ARM
-	bool "ARM"
+config TARGET_TOOLCHAIN_ARMCLANG
+	bool "Arm Compiler 6"
 
 endchoice
 
@@ -73,30 +73,6 @@ config GNU_CXX_BINARY
 	string
 	default "g++"
 
-config ARM_CC_BINARY
-	string
-	default "armclang"
-
-config ARM_CXX_BINARY
-	string
-	default "armclang"
-
-config ARM_LD_BINARY
-	string
-	default "armlink"
-
-config ARM_AS_BINARY
-	string
-	default "armasm"
-
-config ARM_AR_BINARY
-	string
-	default "armar"
-
-config TARGET_ARM_FLAGS
-	string
-	default ""
-
 config TARGET_GNU_FLAGS
 	string
 	default ""
@@ -108,6 +84,30 @@ config AR_BINARY
 config AS_BINARY
 	string
 	default "as"
+
+config ARMCLANG_CC_BINARY
+	string
+	default "armclang"
+
+config ARMCLANG_CXX_BINARY
+	string
+	default "armclang"
+
+config ARMCLANG_LD_BINARY
+	string
+	default "armlink"
+
+config ARMCLANG_AS_BINARY
+	string
+	default "armasm"
+
+config ARMCLANG_AR_BINARY
+	string
+	default "armar"
+
+config TARGET_ARMCLANG_FLAGS
+	string
+	default ""
 
 # Filled in by host_explore.py during the configuration step
 config EXTRA_HOST_LDFLAGS
@@ -195,10 +195,10 @@ config HOST_TOOLCHAIN_GNU
 	help
 		Build with GNU toolchain.
 
-config HOST_TOOLCHAIN_ARM
-	bool "ARM"
+config HOST_TOOLCHAIN_ARMCLANG
+	bool "Arm Compiler 6"
 	help
-		Build with ARM toolchain.
+		Build with the Arm Compiler.
 
 endchoice
 
@@ -206,10 +206,10 @@ config HOST_CC_BINARY
 	string
 	default CLANG_CC_BINARY if HOST_TOOLCHAIN_CLANG
 	default GNU_CC_BINARY if HOST_TOOLCHAIN_GNU
-	default ARM_CC_BINARY if HOST_TOOLCHAIN_ARM
+	default ARMCLANG_CC_BINARY if HOST_TOOLCHAIN_ARMCLANG
 
 config HOST_CXX_BINARY
 	string
 	default CLANG_CXX_BINARY if HOST_TOOLCHAIN_CLANG
 	default GNU_CXX_BINARY if HOST_TOOLCHAIN_GNU
-	default ARM_CXX_BINARY if HOST_TOOLCHAIN_ARM
+	default ARMCLANG_CXX_BINARY if HOST_TOOLCHAIN_ARMCLANG


### PR DESCRIPTION
Rename the 'ARM' toolchain to 'ARMCLANG', and update the help text to
refer to it as "Arm Compiler 6", matching the product's name:

  https://developer.arm.com/products/software-development-tools/compilers/arm-compiler

'ARMCLANG' is chosen because:
 - it matches the name of the compiler binary
 - it is shorter than 'ARM_COMPILER_6' or similar
 - it differentiates it from Arm Compiler 5 and below, which use
   different options and have different binary names, e.g. 'armcc'.

This commit also moves some of the code around, since it is being
changed anyway, so as to keep each toolchain in its own section
within 'toolchain.go' and the Mconfig files. AC6 support is added to
'example/Mconfig'.

Change-Id: I6de3ea361af7a7494e87c3919bc83ea032cb1346
Signed-off-by: Chris Diamand <chris.diamand@arm.com>