### PR TITLE
Move config options into a shared Mconfig

### DIFF
--- a/docs/project_setup.md
+++ b/docs/project_setup.md
@@ -34,7 +34,9 @@ order to use Bob. It contains the following files:
 |Android.mk.blueprint     | Template Android makefile |
 |generate_android_inc.bash| Android script |
 
-If you want to make this build, just add a `hello_world.cpp`.
+If you want to make this build, just add a `hello_world.cpp`, and, if
+necessary, update the path in any `source` statements in `example/Mconfig` to
+reflect the location of Bob inside the example project.
 
 ## Bootstrap scripts
 

--- a/example/Mconfig
+++ b/example/Mconfig
@@ -49,75 +49,35 @@ config TARGET_GNU_TOOLCHAIN_PREFIX
 	string
 	default ""
 
-## Various tools need to be defined for Bob
-config PKG_CONFIG
-	bool "PKG_CONFIG"
-
-config CLANG_CC_BINARY
+config TARGET_GNU_FLAGS
 	string
-	default "clang"
-
-config CLANG_CXX_BINARY
-	string
-	default "clang++"
+	default ""
 
 config TARGET_CLANG_TRIPLE
 	string
 	default "x86_64-linux-gnu"
 
-config GNU_CC_BINARY
-	string
-	default "gcc"
+# Update this to reflect the path to Bob within the superproject
+source "bob-build/mconfig/toolchain.Mconfig"
 
-config GNU_CXX_BINARY
-	string
-	default "g++"
+config PKG_CONFIG
+	bool "Enable use of pkg-config"
+	help
+		When enabled, pkg-config is used to retrieve information
+		about the package(s) declared in PKG_CONFIG_PACKAGES.
+		PKG_CONFIG_PACKAGES contains a comma separated list of the packages.
+		For each package, pkg-config will be called to obtain
+		the cflags, linker paths and libraries. These will be assigned
+		to XXX_CFLAGS, XXX_LDFLAGS and XXX_LIBS respectively, where
+		XXX is the uppercase package name with any non alphanumeric letters
+		replaced by '_'.
 
-config TARGET_GNU_FLAGS
-	string
-	default ""
+		PKG_CONFIG_PATH and PKG_CONFIG_SYSROOT_DIR need to be setup
+		appropriately for pkg-config to use the information for the
+		target system.
 
-config AR_BINARY
-	string
-	default "ar"
-
-config AS_BINARY
-	string
-	default "as"
-
-config ARMCLANG_CC_BINARY
-	string
-	default "armclang"
-
-config ARMCLANG_CXX_BINARY
-	string
-	default "armclang"
-
-config ARMCLANG_LD_BINARY
-	string
-	default "armlink"
-
-config ARMCLANG_AS_BINARY
-	string
-	default "armasm"
-
-config ARMCLANG_AR_BINARY
-	string
-	default "armar"
-
-config TARGET_ARMCLANG_FLAGS
-	string
-	default ""
-
-# Filled in by host_explore.py during the configuration step
-config EXTRA_HOST_LDFLAGS
-	string "Extra Host Linker options"
-
-config EXTRA_TARGET_LDFLAGS
-	string "Extra Target Linker options"
-
-config EXTRA_LD_LIBRARY_PATH
-	string "Extra LD_LIBRARY_PATH Entries"
+		Where no package information exists the default configuration
+		value will be used.
 
 ## Bob needs sysroot for clang
 config TARGET_SYSROOT
@@ -128,16 +88,6 @@ config TARGET_SYSROOT
 config ALLOW_HOST_EXPLORE
 	bool
 	default y
-
-config TARGET_CC_BINARY
-	string
-	default CLANG_CC_BINARY if TARGET_TOOLCHAIN_CLANG
-	default GNU_CC_BINARY if TARGET_TOOLCHAIN_GNU
-
-config TARGET_CXX_BINARY
-	string
-	default CLANG_CXX_BINARY if TARGET_TOOLCHAIN_CLANG
-	default GNU_CXX_BINARY if TARGET_TOOLCHAIN_GNU
 
 choice
 	prompt "Host toolchain"
@@ -169,13 +119,3 @@ config HOST_TOOLCHAIN_ARMCLANG
 		Build with the Arm Compiler.
 
 endchoice
-
-config HOST_CC_BINARY
-	string
-	default CLANG_CC_BINARY if HOST_TOOLCHAIN_CLANG
-	default GNU_CC_BINARY if HOST_TOOLCHAIN_GNU
-
-config HOST_CXX_BINARY
-	string
-	default CLANG_CXX_BINARY if HOST_TOOLCHAIN_CLANG
-	default GNU_CXX_BINARY if HOST_TOOLCHAIN_GNU

--- a/mconfig/toolchain.Mconfig
+++ b/mconfig/toolchain.Mconfig
@@ -1,0 +1,146 @@
+# Copyright 2016-2019 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###################################
+
+menu "Toolchain binary names"
+
+config GNU_CC_BINARY
+	string "GNU C compiler binary"
+	default "gcc"
+	help
+		The name of the C compiler when the GNU toolchain is used.
+
+config GNU_CXX_BINARY
+	string "GNU C++ compiler binary"
+	default "g++"
+	help
+		The name of the C++ compiler when the GNU toolchain is used.
+
+config AR_BINARY
+	string "GNU and Clang Archiver binary"
+	default "ar"
+	help
+		The name of the archiver used to create static libraries.
+
+config AS_BINARY
+	string "GNU and Clang Assembler binary"
+	default "as"
+	help
+		The name of the assembly compiler used to compile
+		hand-written assembly code.
+
+###################################
+
+config CLANG_CC_BINARY
+	string "Clang C compiler binary"
+	default "clang"
+	help
+		The name of the C compiler when Clang toolchain is used.
+
+config CLANG_CXX_BINARY
+	string "Clang C++ compiler binary"
+	default "clang++"
+	help
+		The name of the C++ compiler when Clang toolchain is used.
+
+###################################
+
+config ARMCLANG_CC_BINARY
+	string "Armclang C compiler binary"
+	default "armclang"
+	help
+		The name of the C compiler when the Arm Compiler is used.
+
+config ARMCLANG_CXX_BINARY
+	string "Armclang C++ compiler binary"
+	default "armclang"
+	help
+		The name of the C++ compiler when the Arm Compiler is used.
+
+config ARMCLANG_LD_BINARY
+	string
+	default "armlink"
+	help
+		The name of the linker when the Arm Compiler is used.
+
+config ARMCLANG_AS_BINARY
+	string "Armclang assembler binary"
+	default "armasm"
+	help
+		The name of the assembly compiler used to compile
+		hand-written assembly code when the Arm Compiler is used.
+
+config ARMCLANG_AR_BINARY
+	string "Armclang archiver"
+	default "armar"
+	help
+		The name of the archiver used to create static libraries when
+		the Arm Compiler is used.
+
+config TARGET_ARMCLANG_FLAGS
+	string
+	default ""
+	help
+		Extra flags passed to the compiler when building for the
+		potentially cross-compiled target with the Arm Compiler.
+
+endmenu
+
+menu "Host explore options"
+	help
+		Options set by the host exploration script during
+		configuration. In most cases, do not set the values here; if
+		ALLOW_HOST_EXPLORE is enabled, they will be overwritten.
+
+config EXTRA_HOST_LDFLAGS
+	string "Extra host linker options"
+	help
+		Specific linker options required by the host linker.
+
+		This value is determined automatically when ALLOW_HOST_EXPLORE
+		is enabled (any value set manually will be overwritten).
+
+config EXTRA_TARGET_LDFLAGS
+	string "Extra target linker options"
+	help
+		Specific linker options required by the target linker.
+
+		This value is determined automatically when ALLOW_HOST_EXPLORE
+		is enabled (any value set manually will be overwritten).
+
+config EXTRA_LD_LIBRARY_PATH
+	string "Extra LD_LIBRARY_PATH entries"
+	help
+		Library path that needs to be used to execute a binary
+		compiled by the host linker.
+
+		This value is determined automatically when ALLOW_HOST_EXPLORE
+		is enabled (any value set manually will be overwritten).
+
+endmenu
+
+# Some options, despite being primarily used by Bob, must be defined by the
+# superproject so that it can add any desired defaults, etc:
+
+# config TARGET_GNU_TOOLCHAIN_PREFIX
+#	string "Cross-compiler prefix"
+
+# config TARGET_GNU_FLAGS
+#	string
+#	default "-m32" if ...
+
+# config TARGET_CLANG_TRIPLE
+#	string "Clang target"

--- a/scripts/host_explore.py
+++ b/scripts/host_explore.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,7 +72,13 @@ def compiler_config():
     '''
     extra_target_ldflags = ''
     extra_host_ldflags = ''
-    host_cxx = get_config_string('HOST_CXX_BINARY')
+    if get_config_bool('HOST_TOOLCHAIN_GNU'):
+        host_cxx = get_config_string('GNU_CXX_BINARY')
+    elif get_config_bool('HOST_TOOLCHAIN_CLANG'):
+        host_cxx = get_config_string('CLANG_CXX_BINARY')
+    elif get_config_bool('HOST_TOOLCHAIN_ARMCLANG'):
+        host_cxx = get_config_string('ARMCLANG_CXX_BINARY')
+
     host_libstdcxx_path = check_output([host_cxx, '-print-file-name=libstdc++.so'])
     target_libstdcxx_path = ""
 

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 Arm Limited.
+# Copyright 2016-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,75 +49,34 @@ config TARGET_GNU_TOOLCHAIN_PREFIX
 	string
 	default ""
 
-## Various tools need to be defined for Bob
-config PKG_CONFIG
-	bool "PKG_CONFIG"
-
-config CLANG_CC_BINARY
+config TARGET_GNU_FLAGS
 	string
-	default "clang"
-
-config CLANG_CXX_BINARY
-	string
-	default "clang++"
+	default ""
 
 config TARGET_CLANG_TRIPLE
 	string
 	default "x86_64-linux-gnu"
 
-config GNU_CC_BINARY
-	string
-	default "gcc"
+source "bob/mconfig/toolchain.Mconfig"
 
-config GNU_CXX_BINARY
-	string
-	default "g++"
+config PKG_CONFIG
+	bool "Enable use of pkg-config"
+	help
+		When enabled, pkg-config is used to retrieve information
+		about the package(s) declared in PKG_CONFIG_PACKAGES.
+		PKG_CONFIG_PACKAGES contains a comma separated list of the packages.
+		For each package, pkg-config will be called to obtain
+		the cflags, linker paths and libraries. These will be assigned
+		to XXX_CFLAGS, XXX_LDFLAGS and XXX_LIBS respectively, where
+		XXX is the uppercase package name with any non alphanumeric letters
+		replaced by '_'.
 
-config TARGET_GNU_FLAGS
-	string
-	default ""
+		PKG_CONFIG_PATH and PKG_CONFIG_SYSROOT_DIR need to be setup
+		appropriately for pkg-config to use the information for the
+		target system.
 
-config AR_BINARY
-	string
-	default "ar"
-
-config AS_BINARY
-	string
-	default "as"
-
-config ARMCLANG_CC_BINARY
-	string
-	default "armclang"
-
-config ARMCLANG_CXX_BINARY
-	string
-	default "armclang"
-
-config ARMCLANG_LD_BINARY
-	string
-	default "armlink"
-
-config ARMCLANG_AS_BINARY
-	string
-	default "armasm"
-
-config ARMCLANG_AR_BINARY
-	string
-	default "armar"
-
-config TARGET_ARMCLANG_FLAGS
-	string
-	default ""
-
-# Filled in by host_explore.py during the configuration step
-config EXTRA_HOST_LDFLAGS
-	string "Extra Host Linker options"
-
-config EXTRA_TARGET_LDFLAGS
-	string "Extra Target Linker options"
-
-config EXTRA_LD_LIBRARY_PATH
-	string "Extra LD_LIBRARY_PATH Entries"
+		Where no package information exists the default configuration
+		value will be used.
 
 ## Bob needs sysroot for clang
 config TARGET_SYSROOT
@@ -161,16 +120,6 @@ config ALWAYS_ENABLED_FEATURE
 	bool
 	default y
 
-config TARGET_CC_BINARY
-	string
-	default CLANG_CC_BINARY if TARGET_TOOLCHAIN_CLANG
-	default GNU_CC_BINARY if TARGET_TOOLCHAIN_GNU
-
-config TARGET_CXX_BINARY
-	string
-	default CLANG_CXX_BINARY if TARGET_TOOLCHAIN_CLANG
-	default GNU_CXX_BINARY if TARGET_TOOLCHAIN_GNU
-
 choice
 	prompt "Host toolchain"
 	default HOST_TOOLCHAIN_CLANG if TARGET_TOOLCHAIN_CLANG
@@ -201,15 +150,3 @@ config HOST_TOOLCHAIN_ARMCLANG
 		Build with the Arm Compiler.
 
 endchoice
-
-config HOST_CC_BINARY
-	string
-	default CLANG_CC_BINARY if HOST_TOOLCHAIN_CLANG
-	default GNU_CC_BINARY if HOST_TOOLCHAIN_GNU
-	default ARMCLANG_CC_BINARY if HOST_TOOLCHAIN_ARMCLANG
-
-config HOST_CXX_BINARY
-	string
-	default CLANG_CXX_BINARY if HOST_TOOLCHAIN_CLANG
-	default GNU_CXX_BINARY if HOST_TOOLCHAIN_GNU
-	default ARMCLANG_CXX_BINARY if HOST_TOOLCHAIN_ARMCLANG


### PR DESCRIPTION
Avoid duplicated config options by moving some of the tests and
example Mconfig into a shared 'toolchain.Mconfig', which can be
source'd from the superproject Mconfig.

Not all options are moved yet - some options might have different
defaults depending on the superproject, so they are left where they
are now, as there is no way to, for example, 'select' a string value.

Remove the [HOST|TARGET]_[CC|CXX]_BINARY options, because they are
not actually used by toolchain.go.

Change-Id: I2f686954f250f05d9fee2d43d7486b10df51ae94
Signed-off-by: Chris Diamand <chris.diamand@arm.com>