### PR TITLE
Fix potential issues with misuse of append function

### DIFF
--- a/core/generated.go
+++ b/core/generated.go
@@ -363,7 +363,7 @@ func (m *generateSource) Inouts(ctx blueprint.ModuleContext) []inout {
 	var io inout
 	g := getBackend(ctx)
 	io.srcIn = m.generateCommon.Properties.GetSrcs(ctx)
-	io.genIn = append(m.generateCommon.Properties.SourceProps.Specials, getGeneratedFiles(ctx)...)
+	io.genIn = utils.NewStringSlice(m.generateCommon.Properties.SourceProps.Specials, getGeneratedFiles(ctx))
 	io.out = m.outputs(g)
 	if m.Properties.Depfile != "" {
 		io.depfile = filepath.Join(g.sourceOutputDir(&m.generateCommon), m.Properties.Depfile)
@@ -449,7 +449,7 @@ func (m *transformSource) Inouts(ctx blueprint.ModuleContext) []inout {
 
 		inouts = append(inouts, inout{ins, empty, outs, depfile, implicitSrcs})
 	}
-	for _, src := range append(m.generateCommon.Properties.Specials, getGeneratedFiles(ctx)...) {
+	for _, src := range utils.NewStringSlice(m.generateCommon.Properties.Specials, getGeneratedFiles(ctx)) {
 		ins := []string{src}
 		outs := []string{}
 		depfile := ""

--- a/core/library.go
+++ b/core/library.go
@@ -200,7 +200,7 @@ func (l *Build) getBuildWrapperAndDeps(ctx blueprint.ModuleContext) (string, []s
 			buildWrapper = strings.Replace(buildWrapper, "${"+k+"}", v, -1)
 		}
 
-		return buildWrapper, append(l.Build_wrapper_deps, files...)
+		return buildWrapper, utils.NewStringSlice(l.Build_wrapper_deps, files)
 	}
 
 	return "", []string{}
@@ -832,7 +832,7 @@ func (handler *graphMutatorHandler) ResolveDependencySortMutator(mctx blueprint.
 		mainBuild.ResolvedStaticLibs = sortedStaticLibs
 	}
 
-	alreadyAddedStaticLibsDependencies := append(mainBuild.Static_libs, mainBuild.Export_static_libs...)
+	alreadyAddedStaticLibsDependencies := utils.NewStringSlice(mainBuild.Static_libs, mainBuild.Export_static_libs)
 	extraStaticLibsDependencies := utils.Difference(mainBuild.ResolvedStaticLibs, alreadyAddedStaticLibsDependencies)
 
 	mctx.AddVariationDependencies(nil, staticDepTag, extraStaticLibsDependencies...)

--- a/core/linux.go
+++ b/core/linux.go
@@ -54,7 +54,7 @@ func pathToLibFlag(path string) string {
 func addPhony(p phonyInterface, ctx blueprint.ModuleContext,
 	installDeps []string, optional bool) {
 
-	deps := append(p.outputs(getBackend(ctx)), installDeps...)
+	deps := utils.NewStringSlice(p.outputs(getBackend(ctx)), installDeps)
 
 	ctx.Build(pctx,
 		blueprint.BuildParams{
@@ -151,7 +151,7 @@ func (g *linuxGenerator) generateCommonActions(m *generateCommon, ctx blueprint.
 		ctx.Build(pctx,
 			blueprint.BuildParams{
 				Rule:      rule,
-				Inputs:    append(inout.srcIn, inout.genIn...),
+				Inputs:    utils.NewStringSlice(inout.srcIn, inout.genIn),
 				Outputs:   inout.out,
 				Implicits: implicits,
 				Args:      args,
@@ -263,7 +263,7 @@ func (l *library) CompileObjs(ctx blueprint.ModuleContext) []string {
 	gendirs, orderOnly := l.GetGeneratedHeaders(ctx)
 	includeDirs = append(includeDirs, gendirs...)
 	includeFlags := utils.PrefixAll(includeDirs, "-I")
-	cflagsList := append(l.Properties.Cflags, includeFlags...)
+	cflagsList := utils.NewStringSlice(l.Properties.Cflags, includeFlags)
 	cflagsList = append(cflagsList, l.Properties.Export_cflags...)
 	cflagsList = append(cflagsList, exportedCflags...)
 
@@ -320,7 +320,7 @@ func (l *library) CompileObjs(ctx blueprint.ModuleContext) []string {
 				Outputs:   []string{output},
 				Inputs:    []string{source},
 				Args:      args,
-				OrderOnly: append(orderOnly, buildWrapperDeps...),
+				OrderOnly: utils.NewStringSlice(orderOnly, buildWrapperDeps),
 				Optional:  true,
 			})
 		objectFiles = append(objectFiles, output)
@@ -556,7 +556,7 @@ func (b *binary) getLibArgs(ctx blueprint.ModuleContext) map[string]string {
 
 // Returns the implicit dependencies for a library
 func (l *library) Implicits(ctx blueprint.ModuleContext) []string {
-	implicits := append(l.GetWholeStaticLibs(ctx), l.GetStaticLibs(ctx)...)
+	implicits := utils.NewStringSlice(l.GetWholeStaticLibs(ctx), l.GetStaticLibs(ctx))
 	implicits = append(implicits, l.getSharedLibLinkPaths(ctx)...)
 
 	return implicits
@@ -824,8 +824,8 @@ func (g *linuxGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.Modu
 		blueprint.BuildParams{
 			Rule:      kbuildRule,
 			Outputs:   []string{builtModule},
-			Inputs:    append(m.Properties.GetSrcs(ctx), m.Properties.Build.SourceProps.Specials...),
-			Implicits: append(m.extraSymbolsFiles(ctx), args["copy_with_deps"]),
+			Inputs:    utils.NewStringSlice(m.Properties.GetSrcs(ctx), m.Properties.Build.SourceProps.Specials),
+			Implicits: utils.NewStringSlice(m.extraSymbolsFiles(ctx), []string{args["copy_with_deps"]}),
 			Optional:  false,
 			Args:      args,
 		})

--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -131,7 +131,7 @@ func (tc toolchainGnuCommon) getBinDirs() []string {
 // `-print-multiarch` and `-dumpmachine` options.
 func (tc toolchainGnuCommon) getTargetTripleHeaderSubdir() string {
 	ccBinary, flags := tc.getCCompiler()
-	cmd := exec.Command(ccBinary, append(flags, "-print-multiarch")...)
+	cmd := exec.Command(ccBinary, utils.NewStringSlice(flags, []string{"-print-multiarch"})...)
 	bytes, err := cmd.Output()
 	if err == nil {
 		target := strings.TrimSpace(string(bytes))
@@ -143,7 +143,7 @@ func (tc toolchainGnuCommon) getTargetTripleHeaderSubdir() string {
 	// Some toolchains will output nothing for -print-multiarch, so try
 	// -dumpmachine if it didn't work (-dumpmachine works for most
 	// toolchains, but will ignore options like '-m32').
-	cmd = exec.Command(ccBinary, append(flags, "-dumpmachine")...)
+	cmd = exec.Command(ccBinary, utils.NewStringSlice(flags, []string{"-dumpmachine"})...)
 	bytes, err = cmd.Output()
 	if err != nil {
 		panic(fmt.Errorf("Couldn't get arch directory for compiler %s: %v", ccBinary, err))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -129,7 +129,8 @@ func AppendUnique(destination []string, source []string) []string {
 		return destination
 	}
 
-	output := destination
+	output := make([]string, len(destination))
+	copy(output, destination)
 
 	for _, value := range source {
 		output = AppendIfUnique(output, value)
@@ -219,4 +220,21 @@ func IsExecutable(fname string) bool {
 		return true
 	}
 	return false
+}
+
+// NewStringSlice initialises a new slice from the input lists, which are concatenated.
+// The in-built append function modifies the slice buffer of the existing slice.
+// This means that using append has side-effect on the first list.
+// The purpose of this function is to avoid those side-effects.
+func NewStringSlice(lists ...[]string) []string {
+	// Checkout utils test for exmaple why this is different to append()
+	sumSize := 0
+	for _, list := range lists {
+		sumSize += len(list)
+	}
+	allLists := make([]string, 0, sumSize)
+	for _, list := range lists {
+		allLists = append(allLists, list...)
+	}
+	return allLists
 }


### PR DESCRIPTION
No issue usage.
x = append(x, a)

Problematic one.
y = append(x, a)

If the backing array of x is too small to fit all the given values a
bigger array will be allocated. The returned slice will point to the
newly allocated array.

So when append allocates new slice there is no problem in case #2.
When no new array is allocated then x is appended so y is an alias to
x..

Change-Id: I32b1c3976d0710e5c4d92c4bbe82a72e93af2b73
Signed-off-by: Dawid Drozd <dawid.drozd@arm.com>