### PR TITLE
Fix Python 3 issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: go
 
-go:
-  - "1.8"
-  - "1.9"
-  - "1.10"
+matrix:
+  include:
+  - go: "1.8"
+    env: PYTHON_SUFFIX=2.7
+  - go: "1.9"
+    env: PYTHON_SUFFIX=3
+  - go: "1.10"
+    env: PYTHON_SUFFIX=2.7
 
 cache:
   directories:
@@ -15,7 +19,7 @@ before_install:
   - export -f travis_time_start
   - export -f travis_time_finish
   - sudo apt-get update
-  - sudo apt-get install -y rsync python-ply
+  - sudo apt-get install -y rsync python-ply python3 python3-ply
 
 install:
   - bash .travis/install-ninja.sh

--- a/.travis/run_all_tests.sh
+++ b/.travis/run_all_tests.sh
@@ -3,6 +3,12 @@ source .travis/utils.sh
 STATUS_CODE=0 # reset
 
 ####################
+fold_start 'setup_python'
+    source ${BOB_ROOT}/.travis/set_python_version.sh
+    check_result $? "Check setup_python"
+fold_end 'setup_python'
+
+####################
 fold_start 'run_build_tests.sh'
     bash ${BOB_ROOT}/.travis/run_build_tests.sh
     check_result $? "Check run_build_tests: "

--- a/.travis/set_python_version.sh
+++ b/.travis/set_python_version.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Travis doesn't support multiple languages. So to support multiple Python
+# versions, use an environment variable to select the version to be used, then
+# create a wrapper script in a new PATH directory which invokes the correct
+# version.
+if [[ -n $PYTHON_SUFFIX ]]; then
+    PYTHON_WRAPPER=~/pythonbin/python
+    rm -f "$PYTHON_WRAPPER"
+    mkdir -p $(dirname "$PYTHON_WRAPPER" ~/pythonbin)
+
+    echo "#!/usr/bin/env bash" > "$PYTHON_WRAPPER"
+    echo "python$PYTHON_SUFFIX" '"$@"' >> "$PYTHON_WRAPPER"
+    chmod +x $PYTHON_WRAPPER
+
+    export PATH=~/pythonbin:$PATH
+    PYVER=$(python -c 'import sys; print("%d.%d." % (sys.version_info.major, sys.version_info.minor))') || STATUS_CODE=1
+    echo "Check python version"
+    if [[ $PYVER != "$PYTHON_SUFFIX."* ]]; then
+        echo "Error: Python binary suffix is $PYTHON_SUFFIX, but version reported is $PYVER"
+        echo "Set up Python version: FAIL"
+        return 1
+    fi
+else
+    echo "Error: No Python version selected"
+    return 1
+fi
+
+return 0

--- a/scripts/generate_config_json.py
+++ b/scripts/generate_config_json.py
@@ -76,7 +76,7 @@ def write_if_different(fname, text):
 def hash_env():
     m = hashlib.sha256()
     for k in sorted(os.environ.keys()):
-        m.update(k + "=" + os.environ[k] + "\n")
+        m.update((k + "=" + os.environ[k] + "\n").encode())
     return m.hexdigest()
 
 def main():

--- a/tests/static_libs/check_link_order.py
+++ b/tests/static_libs/check_link_order.py
@@ -26,6 +26,8 @@
 #      /       /
 #     g       e
 
+from __future__ import print_function
+
 import os
 import argparse
 import subprocess
@@ -72,13 +74,13 @@ if not compile_obj:
         if lib in deps:
             for dep in deps[lib]:
                 if dep not in libs[idx+1:]:
-                    print "Error: " + dep + " not after " + lib
+                    print("Error:", dep, "not after", lib)
                     error = True
 
     # Check every library is listed
     for lib in deps:
         if lib not in libs:
-            print "Error: " + lib + " missing"
+            print("Error:", lib, "missing")
             error = True
 
 cmd = [args.cmd] + args.args


### PR DESCRIPTION
Fix two issues preventing Python 3 from being usable:
 - Hash functions need to be fed bytes, not strings
 - Use the `print()` function

Update Travis to test with Python 3 as well as 2.7. Unfortunately,
Travis cannot support multiple languages with the `language`
directive, so instead use an environment variable set from a matrix
to choose the version.

Change-Id: Ica35e4a0e22c8c4cb14efa20ede264fe0f19d5cd
Signed-off-by: Chris Diamand <chris.diamand@arm.com>