### PR TITLE
Fix off-by-one error when calculating the config exit status

### DIFF
--- a/config_system/menuconfig.py
+++ b/config_system/menuconfig.py
@@ -665,7 +665,7 @@ if __name__ == "__main__":
 
     issues = counter.errors() + counter.criticals()
     warnings = counter.warnings()
-    if issues > 1:
+    if issues > 0:
         sys.exit(2)
     elif warnings > 0:
         sys.exit(1)

--- a/config_system/update_config.py
+++ b/config_system/update_config.py
@@ -104,7 +104,7 @@ write_config(args.output)
 
 issues = counter.errors() + counter.criticals()
 warnings = counter.warnings()
-if issues > 1:
+if issues > 0:
     sys.exit(2)
 elif warnings > 0:
     sys.exit(1)


### PR DESCRIPTION
Change `issues > 1` to `issues > 0`, because the exit status should
be non-zero whenever there is even a single error or critical
message.

Change-Id: Id929ec4e2605512f902b32f9dc26d6ada50056ca
Signed-off-by: Chris Diamand <chris.diamand@arm.com>