### PR TITLE
Fix bob_alias to work with host and target specific targets

### DIFF
--- a/core/linux.go
+++ b/core/linux.go
@@ -679,7 +679,12 @@ func (*linuxGenerator) aliasActions(m *alias, ctx blueprint.ModuleContext) {
 					return
 				}
 			}
-			srcs = append(srcs, ctx.OtherModuleName(p))
+			name := ctx.OtherModuleName(p)
+			if lib, ok := p.(phonyInterface); ok {
+				name = lib.shortName()
+			}
+
+			srcs = append(srcs, name)
 		})
 
 	ctx.Build(pctx,

--- a/tests/aliases/build.bp
+++ b/tests/aliases/build.bp
@@ -24,6 +24,12 @@ bob_binary {
     add_to_alias: ["bob_test_aliases"],
 }
 
+bob_static_library {
+    name: "libwidgetb",
+    srcs: ["widgetb.c"],
+    host_supported: true,
+}
+
 bob_binary {
     name: "widgetb",
     srcs: ["widgetb.c"],
@@ -33,6 +39,16 @@ bob_alias {
     name: "bob_test_aliases",
 
     srcs: [
+        "libwidgetb:host",
         "widgetb",
+    ],
+}
+
+bob_alias {
+    name: "bob_test_aliases_all_variants",
+
+    srcs: [
+        "libwidgetb:host",
+        "libwidgetb:target",
     ],
 }

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -21,6 +21,7 @@ bob_alias {
     name: "bob_tests",
     srcs: [
         "bob_test_aliases",
+        "bob_test_aliases_all_variants",
         "bob_test_cflags",
         "bob_test_export_include_dirs",
         "bob_test_flag_defaults",


### PR DESCRIPTION
`bob_alias` was using direct module name instead using `shortName()` which contain `"__host"` or
`"__target"` suffix.

So when we check build.ninja we find:
`build libwidgetb__host: phony ${g.bob.BuildDir}/host/static/libwidgetb.a`

but `bob_alias` has:
`build bob_test_aliases: phony libwidgetb widgetb widgeta`
so we don't know such target. After fix we will get:
`build bob_test_aliases: phony libwidgetb__host widgetb widgeta`

Change-Id: I3b5f85a3649d9ab0ee090d8ddc0caccb9f56d9f1
Signed-off-by: Dawid Drozd <dawid.drozd@arm.com>