### PR TITLE
Provide `as` variable in generated modules

### DIFF
--- a/core/generated.go
+++ b/core/generated.go
@@ -301,14 +301,17 @@ func (m *generateCommon) getArgs(ctx blueprint.ModuleContext) (string, map[strin
 	g := getBackend(ctx)
 
 	tc := g.getToolchain(m.Properties.Target)
+	arBinary, _ := tc.getArchiver()
+	asBinary, astargetflags := tc.getAssembler()
 	cc, cctargetflags := tc.getCCompiler()
 	cxx, cxxtargetflags := tc.getCXXCompiler()
-	arBinary, _ := tc.getArchiver()
 
 	props := &m.Properties.flagArgsBuild
 
 	args := map[string]string{
 		"ar":                arBinary,
+		"as":                asBinary,
+		"asflags":           strings.Join(astargetflags, " "),
 		"bob_config":        filepath.Join(g.buildDir(), configName),
 		"bob_config_opts":   configOpts,
 		"cc":                cc,


### PR DESCRIPTION
Allow generated modules to access the toolchain's assembler via the
`as` and `asflags` variables.

Change-Id: Ibd49d67b1875dad1dd8dd5dff23428bab27fd4c9
Signed-off-by: Chris Diamand <chris.diamand@arm.com>