### PR TITLE
Remove FileNotFoundError workaround

### DIFF
--- a/scripts/host_explore.py
+++ b/scripts/host_explore.py
@@ -38,17 +38,11 @@ def check_output(command, dir=None):
     The 'command' needs to be an array of arguments.
     '''
 
-    # FileNotFoundError does not exist on Python 2
-    try:
-        fileNotFoundError = FileNotFoundError
-    except NameError:
-        fileNotFoundError = None
-
     output = ''
     try:
         output = subprocess.check_output(command, cwd=dir).strip()
         output = output.decode(sys.getdefaultencoding())
-    except (OSError, fileNotFoundError) as e:
+    except OSError as e:
         logger.error(str(e))
     except subprocess.CalledProcessError as e:
         logger.warning("Problem executing command: %s" % str(e))


### PR DESCRIPTION
FileNotFoundError does not exist on Python 2, but on Python 3 it is
still a subclass of OSError. So it is safe to just catch OSError,
which works on both versions.

Change-Id: I37237597521a68f33f1f778cb7e54972a911fbf2
Signed-off-by: Chris Diamand <chris.diamand@arm.com>