### PR TITLE
Fix travis link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Bob Build System
 ================
-[![Build status for Travis](https://travis-ci.com/ARM-software/bob-build.svg?branch=master)](https://travis-ci.org/ARM-software/bob-build)
+[![Build status for Travis](https://travis-ci.com/ARM-software/bob-build.svg?branch=master)](https://travis-ci.com/ARM-software/bob-build)
 
 ## Introduction
 


### PR DESCRIPTION
We're currently referencing travis.org in the link, where we should be referencing travis.com (which is where we are getting the status icon). Checked by following the link in github