### PR TITLE
Handle different STL implementations

### DIFF
--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -259,6 +259,7 @@ type toolchainClangCommon struct {
 	clangBinary   string
 	clangxxBinary string
 	useGnuLibs    bool
+	useGnuStl     bool
 
 	// Use the GNU toolchain's 'ar' and 'as', as well as its libstdc++
 	// headers if required
@@ -304,6 +305,7 @@ func newToolchainClangCommon(config *bobConfig, gnu toolchainGnu, tgtType string
 	tc.clangBinary = props.GetString("clang_cc_binary")
 	tc.clangxxBinary = props.GetString("clang_cxx_binary")
 	tc.useGnuLibs = props.GetBool(tgtType + "_clang_use_gnu_libs")
+	tc.useGnuStl = props.GetBool(tgtType + "_clang_use_gnu_stl")
 	tc.gnu = gnu
 
 	// Tell Clang where the GNU toolchain is installed, so it can use its
@@ -343,9 +345,6 @@ func newToolchainClangCross(config *bobConfig) (tc toolchainClangCross) {
 	props := config.Properties
 	tc.target = props.GetString("target_clang_triple")
 
-	tc.cxxflags = append(tc.cxxflags,
-		utils.PrefixAll(tc.gnu.getStdCxxHeaderDirs(), "-isystem ")...)
-
 	if tc.target != "" {
 		tc.cflags = append(tc.cflags, "-target", tc.target)
 		tc.ldflags = append(tc.ldflags, "-target", tc.target)
@@ -355,6 +354,11 @@ func newToolchainClangCross(config *bobConfig) (tc toolchainClangCross) {
 		dirs := append(getFileNameDir(tc.gnu, "libgcc.a"),
 			getFileNameDir(tc.gnu, "libgcc_s.so")...)
 		tc.ldflags = append(tc.ldflags, utils.PrefixAll(dirs, "-L")...)
+	}
+
+	if tc.useGnuStl {
+		tc.cxxflags = append(tc.cxxflags,
+			utils.PrefixAll(tc.gnu.getStdCxxHeaderDirs(), "-isystem ")...)
 	}
 
 	// Combine cflags and cxxflags once here, to avoid appending during

--- a/example/Mconfig
+++ b/example/Mconfig
@@ -114,3 +114,23 @@ config HOST_TOOLCHAIN_ARMCLANG
 		Build with the Arm Compiler.
 
 endchoice
+
+config HOST_STL_LIBRARY
+	string "Host STL implementation"
+	default ""
+	help
+		This is the C++ Standard Template Library being linked against,
+		without the `lib` prefix, e.g. `stdc++` for `libstdc++`, or
+		`c++` for `libc++`. Specifying it here allows it to be added to
+		the library's run-time lookup path, in case the toolchain is
+		installed in a non-standard location.
+
+config TARGET_STL_LIBRARY
+	string "Target STL implementation"
+	default ""
+	help
+		This is the C++ Standard Template Library being linked against,
+		without the `lib` prefix, e.g. `stdc++` for `libstdc++`, or
+		`c++` for `libc++`. Specifying it here allows it to be added to
+		the library's run-time lookup path, in case the toolchain is
+		installed in a non-standard location.

--- a/mconfig/toolchain.Mconfig
+++ b/mconfig/toolchain.Mconfig
@@ -164,6 +164,17 @@ config HOST_CLANG_TRIPLE
 # config TARGET_CLANG_TRIPLE
 #	string "Clang target"
 
+# Bob also cannot know the superproject's desired STL implementation, so the
+# superproject must also define the following:
+
+# config HOST_STL_LIBRARY
+# 	string "Host STL implementation"
+# 	default "stdc++"
+#
+# config TARGET_STL_LIBRARY
+# 	string "Target STL implementation"
+# 	default "stdc++"
+
 ### Toolchain configuration options ###
 
 config HOST_CLANG_USE_GNU_LIBS
@@ -182,3 +193,30 @@ config TARGET_CLANG_USE_GNU_LIBS
 	help
 		Detect the location of the configured GNU toolchain's `crt1.o`,
 		`libgcc.a` and `libgcc_s.so`, and pass these to Clang.
+
+# This is a workaround for `depends on` not supporting the comparison operator.
+config HOST_STL_LIBSTDCXX
+	bool
+	default y if HOST_STL_LIBRARY="stdc++"
+	default n
+
+config TARGET_STL_LIBSTDCXX
+	bool
+	default y if TARGET_STL_LIBRARY="stdc++"
+	default n
+
+config HOST_CLANG_USE_GNU_STL
+	bool "Detect the GNU toolchain's libstdc++ implementation for Clang"
+	depends on HOST_TOOLCHAIN_CLANG && HOST_STL_LIBSTDCXX
+	default n
+	help
+		Detect the location of the configured GNU toolchain's
+		STL implementation, and pass this to Clang.
+
+config TARGET_CLANG_USE_GNU_STL
+	bool "Detect the GNU toolchain's libstdc++ implementation for Clang"
+	depends on TARGET_TOOLCHAIN_CLANG && TARGET_STL_LIBSTDCXX
+	default y if TARGET_CLANG_TRIPLE != ""
+	help
+		Detect the location of the configured GNU toolchain's
+		STL implementation, and pass this to Clang.

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -145,3 +145,23 @@ config HOST_TOOLCHAIN_ARMCLANG
 		Build with the Arm Compiler.
 
 endchoice
+
+config HOST_STL_LIBRARY
+	string "Host STL implementation"
+	default ""
+	help
+		This is the C++ Standard Template Library being linked against,
+		without the `lib` prefix, e.g. `stdc++` for `libstdc++`, or
+		`c++` for `libc++`. Specifying it here allows it to be added to
+		the library's run-time lookup path, in case the toolchain is
+		installed in a non-standard location.
+
+config TARGET_STL_LIBRARY
+	string "Target STL implementation"
+	default ""
+	help
+		This is the C++ Standard Template Library being linked against,
+		without the `lib` prefix, e.g. `stdc++` for `libstdc++`, or
+		`c++` for `libc++`. Specifying it here allows it to be added to
+		the library's run-time lookup path, in case the toolchain is
+		installed in a non-standard location.


### PR DESCRIPTION
 - Make the adding of libstdc++ headers in `toolchain.go` optional
   under a new config option, [HOST|TARGET]_CLANG_USE_GNU_STL.
 - Modify `host_explore.py` to cope with different STL
   implementations.
 - Fix the missing use of [HOST|TARGET]_GNU_FLAGS when querying the
   C++ STL path in `host_explore.py` (from `3784038`). Without this,
   the wrong path will be used in case *_GNU_FLAGS contained
   something like `-m32`.
 - Don't use *_CLANG_TRIPLE to decide whether Clang is
   cross-compiling, because this is always set. Instead, use the
   method the GNU toolchain uses (examining the prefix).

Change-Id: I97eb092c32fb71c693a0c8a0d9ffa644a0e2e2b1
Signed-off-by: Chris Diamand <chris.diamand@arm.com>