### PR TITLE
Fix warn_on argument parsing

### DIFF
--- a/config_system/warn_on.py
+++ b/config_system/warn_on.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,8 @@ logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 parser = argparse.ArgumentParser()
 parser.add_argument("config", help="Path to the configuration file (*.config)")
 parser.add_argument("-d", "--database", help="Path to the configuration database (Mconfig)", required=True)
-parser.add_argument("-w", "--warning", action="store", help="Config options to warn about if selected", nargs="+", required=True)
+parser.add_argument("-w", "--warning", action="append", default=[], required=True,
+                    help="Config options to warn about if selected")
 parser.add_argument("--ignore-missing", dest="ignore_missing", action="store_true", default=False,
                     help="Ignore missing database files included with 'source'")
 args = parser.parse_args()


### PR DESCRIPTION
The `warn_on` script was using `action="store"` for its `-w` option,
which is used to specify options to warn about. However, the action
meant that using multiple `-w` flags would not work, as the last one
would overwrite the previous ones.

Fix this by changing the action to "append".

Change-Id: I3313f6e5b1a56623dfcbe1152172ea02948baef5
Signed-off-by: Chris Diamand <chris.diamand@arm.com>