### PR TITLE
Mconfig formatter implementation

### DIFF
--- a/.travis/run_all_tests.sh
+++ b/.travis/run_all_tests.sh
@@ -22,4 +22,18 @@ fold_start 'run_go_tests.sh'
 fold_end
 ####################
 
+####################
+fold_start 'run_tests.sh'
+    bash ${BOB_ROOT}/.travis/run_tests.sh
+    check_result $? "Check run_tests: "
+fold_end
+####################
+
+####################
+fold_start 'run_formatter_tests.sh'
+    bash ${BOB_ROOT}/.travis/run_formatter_tests.sh
+    check_result $? "Check run_formatter_tests: "
+fold_end
+####################
+
 exit $STATUS_CODE

--- a/.travis/run_formatter_tests.sh
+++ b/.travis/run_formatter_tests.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eE
+trap "echo '<------------- run_formatter_tests.sh failed'" ERR
+
+cd ${BOB_ROOT}/config_system/tests
+which python
+
+# Execute run_test_formatter
+python run_tests_formatter.py

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eE
+trap "echo '<------------- run_tests.sh failed'" ERR
+
+cd ${BOB_ROOT}/config_system/tests
+which python
+
+# Execute run_test
+python run_tests.py

--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -104,10 +104,12 @@ if [ ${SRCDIR:0:1} != '/' ]; then
     ln -sf "${WORKDIR}/${BOB_DIR}/menuconfig.bash" "${BUILDDIR}/menuconfig"
     ln -sf "${WORKDIR}/${BOB_DIR}/bob.bash" "${BUILDDIR}/bob"
     ln -sf "${WORKDIR}/${BOB_DIR}/bob_graph.bash" "${BUILDDIR}/bob_graph"
+    ln -sf "${WORKDIR}/${BOB_DIR}/config_system/mconfigfmt.py" "${BUILDDIR}/mconfigfmt"
 else
     # Use absolute symlinks
     ln -sf "${BOB_DIR_ABS}/config.bash" "${BUILDDIR}/config"
     ln -sf "${BOB_DIR_ABS}/menuconfig.bash" "${BUILDDIR}/menuconfig"
     ln -sf "${BOB_DIR_ABS}/bob.bash" "${BUILDDIR}/bob"
     ln -sf "${BOB_DIR_ABS}/bob_graph.bash" "${BUILDDIR}/bob_graph"
+    ln -sf "${BOB_DIR_ABS}/config_system/mconfigfmt.py" "${BUILDDIR}/mconfigfmt"
 fi

--- a/config_system/lex_wrapper.py
+++ b/config_system/lex_wrapper.py
@@ -19,10 +19,11 @@ from . import lex
 
 
 class LexWrapper:
-    def __init__(self, ignore_missing):
+    def __init__(self, ignore_missing, verbose=False):
         self.lexers = []
         self.root_dir = None
         self.ignore_missing = ignore_missing
+        self.verbose = verbose
 
     def source(self, fname):
         if self.root_dir is None:
@@ -37,7 +38,7 @@ class LexWrapper:
         with open(fname, "rt") as fp:
             file_contents = fp.read()
 
-        lexer = lex.create_mconfig_lexer(fname)
+        lexer = lex.create_mconfig_lexer(fname, verbose=self.verbose)
 
         self.push_lexer(lexer)
         self.input(file_contents)
@@ -67,3 +68,8 @@ class LexWrapper:
             t = self.token()
 
         return t
+
+    def iterate_tokens(self):
+        """Generator method to yield tokens"""
+        while True:
+            yield self.current_lexer().token()

--- a/config_system/mconfigfmt.py
+++ b/config_system/mconfigfmt.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import re
+import sys
+import argparse
+
+# Get file directory path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+
+from config_system.lex_wrapper import LexWrapper
+
+
+def perform_formatting(file_list_path, output=None):
+    """Call LexWrapper class to call PLY lexer facade, then get back outcome with formatting principles
+    :param file_list_path: Input file path list
+    :param output (optional) output file path
+    """
+    for file_path in file_list_path:
+        wrapper = LexWrapper(ignore_missing=False, verbose=True)
+        wrapper.source(file_path)
+        dump(output or file_path, wrapper)
+
+
+def dump(file_path, wrapper):
+    """General method for dumping the output into file from given path"""
+    line, lines = [], []
+    for token in wrapper.iterate_tokens():
+        if not token:
+            break
+        if token.type == "HELPTEXT" and len(token.value) > 1:
+            line.append(handle_help_format(token))
+            continue
+        if "\n" not in str(token.value):
+            line.append(handle_formatting(token))
+            continue
+        line.append(token.value)
+        str_line = "".join(line)
+        lines.append(str_line[:-1].rstrip(' ') + str_line[-1])
+        line = []
+    with open(file_path, "w") as f:
+        f.writelines(lines)
+
+
+def handle_formatting(token):
+    """Handle formatting for various types of tokens"""
+    if isinstance(token.value, int):
+        return str(token.value)
+    elif token.type == "QUOTED_STRING":
+        return '"{}"'.format(token.value)
+    return "{}".format(token.value)
+
+
+def handle_help_format(token):
+    """Workaround for indentation requirement"""
+    help_ind = "  "
+    indent, text = re.search(r"(\s+)(.+\n)", token.value).groups()
+    # replace unfolded spaces to tabs
+    indent = indent.replace("    ", "\t")
+    if not indent.endswith(help_ind) or indent.count(' ') != len(help_ind):
+        # replace last tab as 2 spaces and invalid amount of spaces
+        indent = indent[:-1].rstrip(" ") + help_ind
+    return "".join([indent, text])
+
+
+def main():
+    """Main function of formatter. Adds parser facade with two params input and output file
+    Also checks via CheckPath action if file is present under given path.
+    Input file need to be present and output file should not be present
+    """
+    parser = argparse.ArgumentParser(formatter_class=argparse.HelpFormatter)
+    parser.add_argument('input', nargs='+',
+                        help="Input file with configuration database (Mconfig) to fix.")
+    args = parser.parse_args()
+    perform_formatting(args.input)
+
+
+if __name__ == "__main__":
+    main()

--- a/config_system/syntax.py
+++ b/config_system/syntax.py
@@ -208,7 +208,9 @@ def p_mainmenu_stmt_first(p):
 def p_dummy(p):
     """dummy :
              | DUMMY
-             """
+             | TAB
+             | SPACE
+             | COMMENT"""
     p[0] = {}
 
 
@@ -393,7 +395,7 @@ def p_helptext(p):
 
 
 def p_error(p):
-    report_error("Parse error", p, ParseError)
+    report_error("Parse error on token: {}".format(str(p)), p, ParseError)
 
 
 parser = yacc.yacc(debug=False, write_tables=False)

--- a/config_system/tests/formatter/expected.out
+++ b/config_system/tests/formatter/expected.out
@@ -1,0 +1,69 @@
+# Some comment that need to be parsed!
+
+source "foo"
+
+config MODE
+	bool "Mode"
+	default n
+
+
+choice
+	prompt "Choose"
+	default OPTION_A
+
+config OPTION_A
+	bool "A"
+
+config OPTION_B
+	bool "B"
+	depends on MODE
+
+config OPTION_C
+	bool "C"
+	depends on MODE
+
+endchoice
+choice
+    int 365 if HOW_MUCH_DAYS_IN_YEAR || !WEEKS && DAYS
+    default BUILDER_BUILD if DROID
+	prompt "Choice 1" if ALA_MA_KOTA
+	default DEFAULT_OPTION
+
+config FIRST_OPTION
+	default y if SOME_VALUE >= 9 if SOME_VALUE
+	bool "First option"
+
+config DEFAULT_OPTION
+	default y if SOME_PARAM && SUN_IS_SHINING
+	bool "Default option"
+
+config THIRD_OPTION
+    default y if (XYZ || ABC) && !ALA_MA_KOTA
+	bool "Third option"
+
+endchoice
+
+choice
+	prompt "Choice 2"
+	default BAZ
+
+config FOO
+	bool "Foo"
+	select FIRST_OPTION
+	depends on FOOBAR
+	help
+	  text written in multiple paragraphs
+
+	  is still displayed as multiple paragraphs
+
+config BAR
+	bool "Bar"
+
+config BAZ
+	bool "Baz"
+
+endchoice
+
+config FOOBAR
+	bool "Foobar"
+	default y

--- a/config_system/tests/formatter/formatter.test
+++ b/config_system/tests/formatter/formatter.test
@@ -1,0 +1,69 @@
+# Some comment that need to be parsed!
+
+source "foo"
+
+config MODE
+	bool "Mode"
+	default n
+
+
+choice
+	prompt "Choose"
+	default OPTION_A
+
+config OPTION_A
+	bool "A"
+
+config OPTION_B
+	bool "B"
+	depends on MODE
+
+config OPTION_C
+	bool "C"
+	depends on MODE
+
+endchoice
+choice
+    int 365 if HOW_MUCH_DAYS_IN_YEAR || !WEEKS && DAYS
+    default BUILDER_BUILD if DROID
+	prompt "Choice 1" if ALA_MA_KOTA
+	default DEFAULT_OPTION
+
+config FIRST_OPTION
+	default y if SOME_VALUE >= 9 if SOME_VALUE
+	bool "First option"
+
+config DEFAULT_OPTION
+	default y if SOME_PARAM && SUN_IS_SHINING
+	bool "Default option"
+
+config THIRD_OPTION
+    default y if (XYZ || ABC) && !ALA_MA_KOTA
+	bool "Third option"
+
+endchoice
+
+choice
+	prompt "Choice 2"
+	default BAZ
+
+config FOO
+	bool "Foo"
+	select FIRST_OPTION
+	depends on FOOBAR
+	help
+	    text written in multiple paragraphs
+
+	    is still displayed as multiple paragraphs
+
+config BAR
+	bool "Bar"
+
+config BAZ
+	bool "Baz"
+
+endchoice
+
+config FOOBAR
+	bool "Foobar"
+	default y

--- a/config_system/tests/run_tests.py
+++ b/config_system/tests/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright 2018 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
@@ -152,8 +152,8 @@ def main():
 
     print("")
     print("%d tests run, %d failed" % (tests_run, tests_failed))
-    if tests_failed == 0:
-        print("All tests passed!")
+    if tests_failed > 0:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/config_system/tests/run_tests_formatter.py
+++ b/config_system/tests/run_tests_formatter.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import tempfile
+
+# Get file directory path
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+BOB_DIR = os.path.dirname(os.path.dirname(TEST_DIR))
+sys.path.append(BOB_DIR)
+
+
+def run_fix_test(name, expected_output):
+    """ Test function to verify difference between two file contents"""
+    from config_system import mconfigfmt
+    print("Running %s" % name)
+    tmp_file = tempfile.NamedTemporaryFile(delete=False)
+    tests_run = 0
+    tests_failed = 0
+    mconfigfmt.perform_formatting([name], output=tmp_file.name)
+    with open(tmp_file.name) as test_out, open(expected_output) as exp_out:
+        out_lines, exp_lines = exp_out.readlines(), test_out.readlines()
+    if any(out_lines[i] != exp_lines[i] for i in range(len(exp_lines))):
+        tests_failed += 1
+    tests_run += 1
+    os.remove(tmp_file.name)
+    return tests_run, tests_failed
+
+
+def main():
+    formatter_tests = os.path.join(TEST_DIR, "formatter")
+    os.chdir(formatter_tests)
+    test_run, failed = run_fix_test("formatter.test", "expected.out")
+
+    print("")
+    print("{} tests run, {} failed".format(test_run, failed))
+    if failed > 0:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Across the whole change here's what's changed:
- Handling for KConfig help msg format (tabs + 2 spaces indent)
- Introduce mconfigfmt formatter script
- Travis script expanded to handle tests for config_menu module

Run_tests.py changes:
- Exit code 1 when any test failed (error checks for travis)

Run_tests_formatter.py changes:
- Compare expected result of formatting for both input files: wrongly
  formatted and properly formatted one
- Exit code 1 when any test failed (error checks for travis)

Change-Id: I2825bbc69bd29c219534855cc8b621f8bd81af89
Signed-off-by: Michal Widera <michal.widera@arm.com>