### PR TITLE
Add external static library module type

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -39,6 +39,7 @@ bootstrap_go_package {
         "core/build_structs.go",
         "core/config_props.go",
         "core/defaults.go",
+        "core/external_library.go",
         "core/feature.go",
         "core/gen_binary.go",
         "core/gen_library.go",

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -512,6 +512,7 @@ func Main() {
 	ctx.RegisterModuleType("bob_static_library", passConfig(staticLibraryFactory, config))
 	ctx.RegisterModuleType("bob_shared_library", passConfig(sharedLibraryFactory, config))
 	ctx.RegisterModuleType("bob_defaults", passConfig(defaultsFactory, config))
+	ctx.RegisterModuleType("bob_external_static_library", passConfig(externalLibFactory, config))
 	ctx.RegisterModuleType("bob_generate_source", passConfig(generateSourceFactory, config))
 	ctx.RegisterModuleType("bob_transform_source", passConfig(transformSourceFactory, config))
 	ctx.RegisterModuleType("bob_generate_static_library", passConfig(genStaticLibFactory, config))

--- a/core/external_library.go
+++ b/core/external_library.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"github.com/google/blueprint"
+)
+
+type externalLib struct {
+	blueprint.SimpleName
+}
+
+func (l *externalLib) topLevelProperties() []interface{} { return []interface{}{} }
+
+func (m *externalLib) outputName() string   { return m.Name() }
+func (m *externalLib) altName() string      { return m.outputName() }
+func (m *externalLib) altShortName() string { return m.altName() }
+func (m *externalLib) shortName() string    { return m.Name() }
+
+// External libraries have no outputs - they are already built.
+func (m *externalLib) outputs(g generatorBackend) []string { return []string{} }
+
+// Implement the splittable interface so "normal" libraries can depend on external ones.
+func (m *externalLib) supportedVariants() []string          { return []string{tgtTypeHost, tgtTypeTarget} }
+func (m *externalLib) disable()                             {}
+func (m *externalLib) setVariant(string)                    {}
+func (m *externalLib) getSplittableProps() *SplittableProps { return &SplittableProps{} }
+
+// External libraries have no actions - they are already built.
+func (m *externalLib) GenerateBuildActions(ctx blueprint.ModuleContext) {}
+
+func externalLibFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+	module := &externalLib{}
+
+	return module, []interface{}{&module.SimpleName.Properties}
+}

--- a/core/library.go
+++ b/core/library.go
@@ -691,6 +691,8 @@ func exportLibFlagsMutator(mctx blueprint.TopDownMutatorContext) {
 			// The GeneratedStaticLibrary is expected to be self
 			// contained, so no pulling in of other static or shared
 			// libraries.
+		} else if _, ok := dep.(*externalLib); ok {
+			// External libary dependencies are not handled.
 		} else {
 			panic(fmt.Sprintf("%s is not a staticLibrary", dep.Name()))
 		}

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,6 +1,6 @@
 # Ignore default build directory
 build/
-Android.mk
+/Android.mk
 
 # Bob symlink created for Bob tests
 bob

--- a/tests/Android.mk.blueprint
+++ b/tests/Android.mk.blueprint
@@ -52,3 +52,10 @@ ifneq ($(BOB_GEN_RET_VAL),Success)
 endif
 
 include $(BOB_ANDROIDMK_DIR)/Android.inc
+
+# These should really be in their own Android.mk file - however, to simplify
+# running the tests, include them from here instead. This means that the tests
+# and their dependencies can always be built with a single `mm` command.
+#
+# This script will overwrite $(LOCAL_PATH), so it must be included last!
+include $(LOCAL_PATH)/external_libs/external_libs.mk

--- a/tests/bplist
+++ b/tests/bplist
@@ -7,6 +7,7 @@
 ./export_cflags/libb/build.bp
 ./export_include_dirs/liba/build.bp
 ./export_include_dirs/libb/build.bp
+./external_libs/build.bp
 ./flag_defaults/build.bp
 ./forwarding_libs/forwarding/build.bp
 ./forwarding_libs/forwarding_impl/build.bp

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -25,6 +25,7 @@ bob_alias {
         "bob_test_cxx11simple",
         "bob_test_export_cflags",
         "bob_test_export_include_dirs",
+        "bob_test_external_libs",
         "bob_test_flag_defaults",
         "bob_test_forwarding_libs",
         "bob_test_generate_libs",

--- a/tests/external_libs/build.bp
+++ b/tests/external_libs/build.bp
@@ -1,0 +1,18 @@
+bob_external_static_library {
+    name: "libbob_test_external_static",
+}
+
+bob_binary {
+    name: "use_external_libs",
+    srcs: ["use_external_libs.c"],
+    static_libs: ["libbob_test_external_static"],
+    enabled: false,
+    android: {
+        enabled: true,
+    },
+}
+
+bob_alias {
+    name: "bob_test_external_libs",
+    srcs: ["use_external_libs"],
+}

--- a/tests/external_libs/external_libs.mk
+++ b/tests/external_libs/external_libs.mk
@@ -1,0 +1,10 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libbob_test_external_static
+LOCAL_MODULE_CLASS := STATIC_LIBRARIES
+
+LOCAL_SRC_FILES := external_static.c
+
+include $(BUILD_STATIC_LIBRARY)

--- a/tests/external_libs/external_static.c
+++ b/tests/external_libs/external_static.c
@@ -1,0 +1,3 @@
+int external_static(void) {
+    return 23456;
+}

--- a/tests/external_libs/use_external_libs.c
+++ b/tests/external_libs/use_external_libs.c
@@ -1,0 +1,5 @@
+int external_static(void);
+
+int main(void) {
+    return external_static();
+}


### PR DESCRIPTION
Use this to replace the hard-coded list, `androidStaticLibs`, by letting
the superproject define their own `bob_external_static_library` modules.

External shared and header libraries will be added in future commits.

Change-Id: I7eae70bb42c2d8a693e2880a30520812069976db
Signed-off-by: Chris Diamand <chris.diamand@arm.com>