### PR TITLE
Fix uninstalled shared libraries on Android

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -464,9 +464,14 @@ func (m *library) GenerateBuildAction(binType int, ctx blueprint.ModuleContext) 
 			text += "LOCAL_REQUIRED_MODULES:=" + newlineSeparatedList(requiredModuleNames)
 		}
 	} else {
-		if m.Properties.TargetType == tgtTypeTarget {
-			// Only disable installation of target libraries.
-			// Host libraries need to be installed to be used by the build.
+		// Only disable installation on the target, because host
+		// libraries need to be installed to be used by the build.
+		//
+		// Target shared libraries do not need an explicit installation
+		// location, but cannot be uninstallable, or the multilib paths
+		// will conflict, resulting in the same location being used for
+		// both 32 and 64-bit versions.
+		if m.Properties.TargetType == tgtTypeTarget && binType != binTypeShared {
 			text += "LOCAL_UNINSTALLABLE_MODULE:=true\n"
 		}
 	}

--- a/tests/bplist
+++ b/tests/bplist
@@ -18,6 +18,7 @@
 ./properties/build.bp
 ./reexport_libs/build.bp
 ./resources/build.bp
+./shared_libs/build.bp
 ./static_libs/build.bp
 ./templates/build.bp
 ./transform_source/build.bp

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -34,6 +34,7 @@ bob_alias {
         "bob_test_properties",
         "bob_test_reexport_libs",
         "bob_test_resources",
+        "bob_test_shared_libs",
         "bob_test_static_libs",
         "bob_test_templates",
         "bob_test_transform_source",

--- a/tests/shared_libs/build.bp
+++ b/tests/shared_libs/build.bp
@@ -1,0 +1,77 @@
+bob_shared_library {
+    name: "libsharedtest_installed",
+    srcs: ["lib.c"],
+    cflags: ["-DFUNC_NAME=sharedtest_installed"],
+    host: {
+        install_group: "IG_host_libs",
+    },
+    target: {
+        install_group: "IG_libs",
+    },
+    host_supported: true,
+    target_supported: true,
+}
+
+bob_shared_library {
+    name: "libsharedtest_not_installed",
+    srcs: ["lib.c"],
+    cflags: ["-DFUNC_NAME=sharedtest_not_installed"],
+    host_supported: true,
+    target_supported: true,
+}
+
+// Test that we can link to a shared library, whether it has an install group
+// or not.
+bob_binary {
+    name: "sharedtest",
+    srcs: ["main.c"],
+    shared_libs: [
+        "libsharedtest_installed",
+        "libsharedtest_not_installed",
+    ],
+    host_supported: true,
+    target_supported: true,
+}
+
+// Ensure that the host version of `sharedtest` is actually built, and that it
+// can be run successfully, which checks there are no library path issues.
+bob_generate_source {
+    name: "use_sharedtest_host",
+    host_bin: "sharedtest:host",
+    cmd: "${host_bin} ${out}",
+    out: ["use_sharedtest_host_main.c"],
+}
+
+bob_binary {
+    name: "use_sharedtest_host_gen_source",
+    generated_sources: ["use_sharedtest_host"],
+}
+
+bob_alias {
+    name: "bob_test_shared_libs",
+    srcs: [
+        "sharedtest:host",
+        "sharedtest:target",
+        "use_sharedtest_host_gen_source",
+    ],
+}
+
+bob_install_group {
+    name: "IG_host_libs",
+    android: {
+        install_path: "$(HOST_OUT_SHARED_LIBRARIES)",
+    },
+    linux: {
+        install_path: "install/hostlib",
+    },
+}
+
+bob_install_group {
+    name: "IG_libs",
+    android: {
+        install_path: "$(TARGET_OUT_VENDOR)/lib",
+    },
+    linux: {
+        install_path: "install/lib",
+    },
+}

--- a/tests/shared_libs/lib.c
+++ b/tests/shared_libs/lib.c
@@ -1,0 +1,3 @@
+int FUNC_NAME(void) {
+    return 12345;
+}

--- a/tests/shared_libs/main.c
+++ b/tests/shared_libs/main.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <string.h>
+
+int sharedtest_installed(void);
+int sharedtest_not_installed(void);
+
+int main(int argc, char **argv) {
+    /* To verify that this works for host libraries too, and that the test is
+     * run on Android, use the host version of this to generate a source file
+     * for another target binary. */
+    if (argc > 1) {
+        FILE *fp = fopen(argv[1], "wt");
+        fprintf(fp, "int main(void) { return 0; }\n");
+        fclose(fp);
+    }
+
+    if (sharedtest_installed() == 12345 && sharedtest_not_installed() == 12345) {
+        return 0;
+    } else {
+        fprintf(stderr, "%s: Library functions did not return correct values\n", argv[0]);
+        return 1;
+    }
+}


### PR DESCRIPTION
The `out:` field tests added in `01f6e0f` revealed an issue on Android,
where multilib shared libraries cannot be linked:

    prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/aarch64-linux-android/bin/ld.gold:
        error: out/target/product/hikey960/obj/lib/libshared_output.so: incompatible target
    external/bob-build/tests/output/out.c:5: error: undefined reference to 'libshared'

This is occurring because setting `LOCAL_UNINSTALLABLE_MODULE := true`
on target shared library causes the multilib paths to conflict,
resulting in the 32-bit library overwriting the 64-bit one.

Fix this by not disabling installation of target shared libraries. This
will let Android use a default location, and the above issue does not
occur.

Add a test to ensure that shared libraries work both with and without
install groups, on both host and target.

Change-Id: Id10801fd9e14027d64c4ea9a9bf6db319f320e95
Signed-off-by: Chris Diamand <chris.diamand@arm.com>