### PR TITLE
Add external shared library module type

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -512,6 +512,7 @@ func Main() {
 	ctx.RegisterModuleType("bob_static_library", passConfig(staticLibraryFactory, config))
 	ctx.RegisterModuleType("bob_shared_library", passConfig(sharedLibraryFactory, config))
 	ctx.RegisterModuleType("bob_defaults", passConfig(defaultsFactory, config))
+	ctx.RegisterModuleType("bob_external_shared_library", passConfig(externalLibFactory, config))
 	ctx.RegisterModuleType("bob_external_static_library", passConfig(externalLibFactory, config))
 	ctx.RegisterModuleType("bob_generate_source", passConfig(generateSourceFactory, config))
 	ctx.RegisterModuleType("bob_transform_source", passConfig(transformSourceFactory, config))

--- a/tests/external_libs/build.bp
+++ b/tests/external_libs/build.bp
@@ -2,10 +2,15 @@ bob_external_static_library {
     name: "libbob_test_external_static",
 }
 
+bob_external_shared_library {
+    name: "libbob_test_external_shared",
+}
+
 bob_binary {
     name: "use_external_libs",
     srcs: ["use_external_libs.c"],
     static_libs: ["libbob_test_external_static"],
+    shared_libs: ["libbob_test_external_shared"],
     enabled: false,
     android: {
         enabled: true,

--- a/tests/external_libs/external_lib.c
+++ b/tests/external_libs/external_lib.c
@@ -1,0 +1,5 @@
+#define FUNCNAME external_##TYPE
+
+int FUNCNAME(void) {
+    return 23456;
+}

--- a/tests/external_libs/external_libs.mk
+++ b/tests/external_libs/external_libs.mk
@@ -5,6 +5,19 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := libbob_test_external_static
 LOCAL_MODULE_CLASS := STATIC_LIBRARIES
 
-LOCAL_SRC_FILES := external_static.c
+LOCAL_SRC_FILES := external_lib.c
+LOCAL_CFLAGS := -DTYPE=static
+LOCAL_EXPORT_C_INCLUDE_DIRS := static
 
 include $(BUILD_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libbob_test_external_shared
+LOCAL_MODULE_CLASS := STATIC_LIBRARIES
+
+LOCAL_SRC_FILES := external_lib.c
+LOCAL_CFLAGS := -DTYPE=shared
+LOCAL_EXPORT_C_INCLUDE_DIRS := shared
+
+include $(BUILD_SHARED_LIBRARY)

--- a/tests/external_libs/external_static.c
+++ b/tests/external_libs/external_static.c
@@ -1,3 +1,0 @@
-int external_static(void) {
-    return 23456;
-}

--- a/tests/external_libs/shared/external_shared.h
+++ b/tests/external_libs/shared/external_shared.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int external_shared(void);

--- a/tests/external_libs/static/external_static.h
+++ b/tests/external_libs/static/external_static.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int external_static(void);

--- a/tests/external_libs/use_external_libs.c
+++ b/tests/external_libs/use_external_libs.c
@@ -1,5 +1,6 @@
-int external_static(void);
+#include "external_static.h"
+#include "external_shared.h"
 
 int main(void) {
-    return external_static();
+    return external_static() + external_shared();
 }


### PR DESCRIPTION
This new module type can be used to replace the hard-coded list of
Android libraries in `androidSharedLibs`.

One non-obvious part of this change is that we have to output the
contents of `export_shared_libs` into `LOCAL_SHARED_LIBRARIES` for
static libraries. This is because unlike the `ldlibs` field which
contained this information previously, static libraries cannot have a
non-empty `shared_libs` property.

Extend the external static library tests to cover shared libraries, too.

Change-Id: I3212c19a3411492ed8f138944192fafcd7b4f045
Signed-off-by: Chris Diamand <chris.diamand@arm.com>