### PR TITLE
Accept comparison operators in depends on

### DIFF
--- a/config_system/general.py
+++ b/config_system/general.py
@@ -28,6 +28,12 @@ def config_options_in_menu(data, menu):
     return output
 
 def check_depends(depends, value):
+    """Check if the config identified in value is a simple dependency listed in the depends expression.
+    A simple expression consists of just && and || boolean operators.
+    If the expression uses any other operator, return False.
+
+    This is used by the menu_parse below to indent dependent configs.
+    """
     if depends == None:
         return False
     if type(depends) == tuple:
@@ -37,11 +43,8 @@ def check_depends(depends, value):
         elif depends[0] == 'or':
             return (check_depends(depends[1], value) and
                     check_depends(depends[2], value))
-        elif depends[0] == 'not':
-            # We only consider positive dependencies
+        else:
             return False
-        raise Exception("Unexpected depend list: %s" % depends)
-
     return depends == value
 
 def value_of(depends):

--- a/config_system/tests/depends_on_compare.test
+++ b/config_system/tests/depends_on_compare.test
@@ -1,0 +1,38 @@
+# This test checks 'depends on' statements using operators other than '&&' and '||'
+# Description of dependencies checks verification:
+# - Configuration which depends on some configurations and string
+# - Configuration which depends on integer value
+
+config STRING_OPTION
+    string "String to compare in a depends clause"
+    default "no"
+
+config INT_OPTION
+    int
+    default 21
+
+config OPTION
+    bool "An option in the menu"
+    default y
+
+config OPTION2
+    bool "An option in the menu"
+    default y
+
+config DEPEND_ON_STR
+    bool "User-settable option depending on a string"
+    depends on OPTION && OPTION2 && STRING_OPTION="yes"
+    default y
+
+config DEPEND_ON_INT
+    bool
+    depends on INT_OPTION = 42 && INT_OPTION >= 41 && INT_OPTION <= 44
+    default y
+
+# ASSERT: STRING_OPTION=no
+# ASSERT: DEPEND_ON_STR=n
+# ASSERT: DEPEND_ON_INT=n
+# SET: STRING_OPTION=yes
+# SET: INT_OPTION=42
+# ASSERT: DEPEND_ON_STR=y
+# ASSERT: DEPEND_ON_INT=y


### PR DESCRIPTION
The existing code handling 'depends on' supports comparison operators,
but the menu indentation logic for dependent configs throws an exception
during init_config on encountering this construct.

Fix the menu indentation logic to ignore any 'depends on' with more
complicated expressions.

Add new test to check functionality.

Change-Id: I41d293b9620cd121d27bf37da4c966a4e3cc1d56
Signed-off-by: Michal Widera <michal.widera@arm.com>