### PR TITLE
Remove toolchain Mconfig workaround

### DIFF
--- a/mconfig/toolchain.Mconfig
+++ b/mconfig/toolchain.Mconfig
@@ -194,20 +194,9 @@ config TARGET_CLANG_USE_GNU_LIBS
 		Detect the location of the configured GNU toolchain's `crt1.o`,
 		`libgcc.a` and `libgcc_s.so`, and pass these to Clang.
 
-# This is a workaround for `depends on` not supporting the comparison operator.
-config HOST_STL_LIBSTDCXX
-	bool
-	default y if HOST_STL_LIBRARY="stdc++"
-	default n
-
-config TARGET_STL_LIBSTDCXX
-	bool
-	default y if TARGET_STL_LIBRARY="stdc++"
-	default n
-
 config HOST_CLANG_USE_GNU_STL
 	bool "Detect the GNU toolchain's libstdc++ implementation for Clang"
-	depends on HOST_TOOLCHAIN_CLANG && HOST_STL_LIBSTDCXX
+	depends on HOST_TOOLCHAIN_CLANG && HOST_STL_LIBRARY="stdc++"
 	default n
 	help
 		Detect the location of the configured GNU toolchain's
@@ -215,7 +204,7 @@ config HOST_CLANG_USE_GNU_STL
 
 config TARGET_CLANG_USE_GNU_STL
 	bool "Detect the GNU toolchain's libstdc++ implementation for Clang"
-	depends on TARGET_TOOLCHAIN_CLANG && TARGET_STL_LIBSTDCXX
+	depends on TARGET_TOOLCHAIN_CLANG && TARGET_STL_LIBRARY="stdc++"
 	default y if TARGET_CLANG_TRIPLE != ""
 	help
 		Detect the location of the configured GNU toolchain's


### PR DESCRIPTION
As the implementation for depends on has been changed there's no further
need to use workaround for dependency checks

Change-Id: I8730592ce9cf709d51a1ab8e5937b07ce9215b16
Signed-off-by: Michal Widera <michal.widera@arm.com>