### PR TITLE
Revert assembler build flags setting

### DIFF
--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -117,7 +117,6 @@ type toolchainGnuCommon struct {
 	gxxBinary string
 	cflags    []string // Flags for both C and C++
 	ldflags   []string // Linker flags, including anything required for C++
-	asflags   []string // Flags for ASM
 	binDir    string
 }
 
@@ -135,7 +134,7 @@ func (tc toolchainGnuCommon) getArchiver() (string, []string) {
 }
 
 func (tc toolchainGnuCommon) getAssembler() (string, []string) {
-	return tc.asBinary, tc.asflags
+	return tc.asBinary, []string{}
 }
 
 func (tc toolchainGnuCommon) getCCompiler() (string, []string) {
@@ -249,7 +248,6 @@ func newToolchainGnuCross(config *bobConfig) (tc toolchainGnuCross) {
 	tc.asBinary = tc.prefix + props.GetString("as_binary")
 	tc.gccBinary = tc.prefix + props.GetString("gnu_cc_binary")
 	tc.gxxBinary = tc.prefix + props.GetString("gnu_cxx_binary")
-	tc.asflags = strings.Split(props.GetString("target_gnu_flags"), " ")
 	tc.cflags = strings.Split(props.GetString("target_gnu_flags"), " ")
 	tc.ldflags = utils.NewStringSlice(tc.cflags)
 	tc.binDir = filepath.Dir(getToolPath(tc.gccBinary))


### PR DESCRIPTION
This change reverts previous change for setting up assembler flags

Change-Id: Ied74bc2b7afe5661aea3a6a7e9984388b25bfd1c
Signed-off-by: Michal Widera <michal.widera@arm.com>