### PR TITLE
Use Android's prebuilt Ninja

### DIFF
--- a/bob.bash
+++ b/bob.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,4 +48,4 @@ export CCACHE_SLOPPINESS=file_macro,time_macros
 BUILDDIR="${BUILDDIR}" SKIP_NINJA=true ${BOB_DIR}/blueprint/blueprint.bash
 
 # Do the actual build
-ninja -f "${BUILDDIR}/build.ninja" -w dupbuild=err "$@"
+"${NINJA}" -f "${BUILDDIR}/build.ninja" -w dupbuild=err "$@"

--- a/bob.bootstrap.in
+++ b/bob.bootstrap.in
@@ -1,4 +1,4 @@
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# If the NINJA variable is set, use it as the Ninja binary. Otherwise, default
+# to `ninja`. Do this in the bootstrap template so that it can be easily
+# accessed from multiple places - most scripts will already need to source this
+# file.
+[[ -z $NINJA ]] && export NINJA=ninja
 
 export WORKDIR="@@WorkDir@@"
 export SRCDIR="@@SrcDir@@"

--- a/example/Android.mk.blueprint
+++ b/example/Android.mk.blueprint
@@ -1,4 +1,4 @@
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,13 +34,16 @@ BOB_$(PROJ)_DIR:=$(LOCAL_PATH)
 # Soong clears the GOROOT environment, so store the root we want to use
 BOB_$(PROJ)_GOROOT:=@@BOB_GOROOT@@
 
+# Get the location of the Ninja binary.
+include $(BUILD_SYSTEM)/ninja_config.mk
+
 # It is important to have the ./ before the output directory, due to kati ignoring
 # any shell command that begins with "out/"
 BOB_GEN_CMD:="$(BOB_$(PROJ)_DIR)/generate_android_inc.bash" "$(LOCAL_PATH)" "./$(BOB_ANDROIDMK_DIR)" "$(BOB_$(PROJ)_GOROOT)"
 
 $(info Running '$(BOB_GEN_CMD)')
 
-BOB_GEN_RESULT:=$(shell $(BOB_GEN_CMD))
+BOB_GEN_RESULT:=$(shell NINJA=$(NINJA) $(BOB_GEN_CMD))
 BOB_GEN_RET_VAL:=$(lastword $(BOB_GEN_RESULT))
 
 # The preferred solution here would be to do:

--- a/example/generate_android_inc.bash
+++ b/example/generate_android_inc.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,7 +32,13 @@ PATH_TO_PROJ="$1"
 BUILDDIR=$(readlink -f "$2")
 GOROOT="$3"
 
+source "${PATH_TO_PROJ}/bob/pathtools.bash"
+
 if [ -x "${BUILDDIR}/buildme" -a -f "${BUILDDIR}/bob.config" ] ; then
+    # The Ninja path is relative to the root of the Android tree, but Bob is
+    # run from the project directory.
+    NINJA=`relative_path "${PATH_TO_PROJ}" "${NINJA}"`
+
     cd "${PATH_TO_PROJ}"
 
     # The following would setup to use Androids prebuilt go. We don't

--- a/tests/Android.mk.blueprint
+++ b/tests/Android.mk.blueprint
@@ -1,4 +1,4 @@
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,13 +34,16 @@ BOB_$(PROJ)_DIR:=$(LOCAL_PATH)
 # Soong clears the GOROOT environment, so store the root we want to use
 BOB_$(PROJ)_GOROOT:=@@BOB_GOROOT@@
 
+# Get the location of the Ninja binary.
+include $(BUILD_SYSTEM)/ninja_config.mk
+
 # It is important to have the ./ before the output directory, due to kati ignoring
 # any shell command that begins with "out/"
 BOB_GEN_CMD:="$(BOB_$(PROJ)_DIR)/generate_android_inc.bash" "$(LOCAL_PATH)" "./$(BOB_ANDROIDMK_DIR)" "$(BOB_$(PROJ)_GOROOT)"
 
 $(info Running '$(BOB_GEN_CMD)')
 
-BOB_GEN_RESULT:=$(shell $(BOB_GEN_CMD))
+BOB_GEN_RESULT:=$(shell NINJA=$(NINJA) $(BOB_GEN_CMD))
 BOB_GEN_RET_VAL:=$(lastword $(BOB_GEN_RESULT))
 
 # The preferred solution here would be to do:

--- a/tests/generate_android_inc.bash
+++ b/tests/generate_android_inc.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,7 +32,13 @@ PATH_TO_PROJ="$1"
 BUILDDIR=$(readlink -f "$2")
 GOROOT="$3"
 
+source "${PATH_TO_PROJ}/bob/pathtools.bash"
+
 if [ -x "${BUILDDIR}/buildme" -a -f "${BUILDDIR}/bob.config" ] ; then
+    # The Ninja path is relative to the root of the Android tree, but Bob is
+    # run from the project directory.
+    NINJA=`relative_path "${PATH_TO_PROJ}" "${NINJA}"`
+
     cd "${PATH_TO_PROJ}"
 
     # The following would setup to use Androids prebuilt go. We don't


### PR DESCRIPTION
Include `ninja_config.mk`, which sets up the NINJA environment variable,
which contains the location of Ninja within Android's prebuilts.
Propagate this through the bootstrap process so that it is used when
building.

When NINJA is not set, default to using `ninja`, which will be found
using PATH as usual.

Change-Id: Ie9ccff0e08375ba91b5a6a70ae394fa3e886bf68
Signed-off-by: Chris Diamand <chris.diamand@arm.com>