### PR TITLE
Use Android's prebuilt Go

### DIFF
--- a/example/Android.mk.blueprint
+++ b/example/Android.mk.blueprint
@@ -31,15 +31,12 @@ BOB_ANDROIDMK_DIR:=$(local-generated-sources-dir)
 
 BOB_$(PROJ)_DIR:=$(LOCAL_PATH)
 
-# Soong clears the GOROOT environment, so store the root we want to use
-BOB_$(PROJ)_GOROOT:=@@BOB_GOROOT@@
-
 # Get the location of the Ninja binary.
 include $(BUILD_SYSTEM)/ninja_config.mk
 
 # It is important to have the ./ before the output directory, due to kati ignoring
 # any shell command that begins with "out/"
-BOB_GEN_CMD:="$(BOB_$(PROJ)_DIR)/@@BOB_DIR@@/scripts/generate_android_inc.bash" "$(LOCAL_PATH)" "./$(BOB_ANDROIDMK_DIR)" "$(BOB_$(PROJ)_GOROOT)" "@@CONFIGNAME@@"
+BOB_GEN_CMD:="$(BOB_$(PROJ)_DIR)/@@BOB_DIR@@/scripts/generate_android_inc.bash" "$(LOCAL_PATH)" "./$(BOB_ANDROIDMK_DIR)" "@@CONFIGNAME@@"
 
 $(info Running '$(BOB_GEN_CMD)')
 

--- a/example/bootstrap_android.bash
+++ b/example/bootstrap_android.bash
@@ -92,8 +92,7 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 
 # Write the Android.mk
 TMP_ANDROID_MK="$(mktemp)"
-sed -e "s#@@BOB_GOROOT@@#$GOROOT#" \
-    -e "s#@@BOB_PROJ_NAME@@#$PROJ_NAME#" \
+sed -e "s#@@BOB_PROJ_NAME@@#$PROJ_NAME#" \
     -e "s#@@BOB_DIR@@#$BOB_DIR#" \
     -e "s#@@CONFIGNAME@@#$CONFIGNAME#" \
     "${PROJ_DIR}/Android.mk.blueprint" > "$TMP_ANDROID_MK"

--- a/scripts/generate_android_inc.bash
+++ b/scripts/generate_android_inc.bash
@@ -27,12 +27,12 @@
 exec 3>&2 2>&1 1>&3-
 
 set -e
+trap 'echo "*** Unexpected error in $0 ***"' ERR
 
 BOB_DIR=$(dirname $(dirname "${BASH_SOURCE[0]}"))
 PATH_TO_PROJ="$1"
 BUILDDIR=$(readlink -f "$2")
-GOROOT="$3"
-CONFIGNAME="$4"
+CONFIGNAME="$3"
 
 source "${BOB_DIR}/pathtools.bash"
 
@@ -43,15 +43,8 @@ if [ -x "${BUILDDIR}/buildme" -a -f "${BUILDDIR}/${CONFIGNAME}" ] ; then
 
     cd "${PATH_TO_PROJ}"
 
-    # The following would setup to use Androids prebuilt go. We don't
-    # do this because we depend on Go 1.8 but still run on Android N
-    # (which has an older version).
-    #export GOPATH="${ANDROID_BUILD_TOP}"
-    #export GOROOT="${GOPATH}/prebuilts/go/linux-x86"
-    #export PATH="${GOROOT}/bin:${PATH}"
-
-    # Use GOROOT recorded during setup_android call
-    export GOROOT
+    # Use the Go shipped with Android:
+    export GOROOT="${TOP}/prebuilts/go/linux-x86/"
 
     "$BUILDDIR/buildme"
 

--- a/tests/Android.mk.blueprint
+++ b/tests/Android.mk.blueprint
@@ -31,15 +31,12 @@ BOB_ANDROIDMK_DIR:=$(local-generated-sources-dir)
 
 BOB_$(PROJ)_DIR:=$(LOCAL_PATH)
 
-# Soong clears the GOROOT environment, so store the root we want to use
-BOB_$(PROJ)_GOROOT:=@@BOB_GOROOT@@
-
 # Get the location of the Ninja binary.
 include $(BUILD_SYSTEM)/ninja_config.mk
 
 # It is important to have the ./ before the output directory, due to kati ignoring
 # any shell command that begins with "out/"
-BOB_GEN_CMD:="$(BOB_$(PROJ)_DIR)/@@BOB_DIR@@/scripts/generate_android_inc.bash" "$(LOCAL_PATH)" "./$(BOB_ANDROIDMK_DIR)" "$(BOB_$(PROJ)_GOROOT)" "@@CONFIGNAME@@"
+BOB_GEN_CMD:="$(BOB_$(PROJ)_DIR)/@@BOB_DIR@@/scripts/generate_android_inc.bash" "$(LOCAL_PATH)" "./$(BOB_ANDROIDMK_DIR)" "@@CONFIGNAME@@"
 
 $(info Running '$(BOB_GEN_CMD)')
 

--- a/tests/bootstrap_android
+++ b/tests/bootstrap_android
@@ -98,8 +98,7 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 
 # Write the Android.mk
 TMP_ANDROID_MK="$(mktemp)"
-sed -e "s#@@BOB_GOROOT@@#$GOROOT#" \
-    -e "s#@@BOB_PROJ_NAME@@#$PROJ_NAME#" \
+sed -e "s#@@BOB_PROJ_NAME@@#$PROJ_NAME#" \
     -e "s#@@BOB_DIR@@#$BOB_DIR#" \
     -e "s#@@CONFIGNAME@@#$CONFIGNAME#" \
     "${PROJ_DIR}/Android.mk.blueprint" > "$TMP_ANDROID_MK"


### PR DESCRIPTION
Use the version of Go shipped with Android by setting GOROOT in
`generate_android_inc.bash`. No other variables need to be set (e.g.
GOPATH or PATH), because Blueprint always chooses its Go binary location
based on GOROOT; see e.g. line 55 of `microfactory/microfactory.bash`.

While modifying `generate_android_inc.bash`, add an error handler so
that it doesn't exit silently on error.

Change-Id: Ia08382ab6c4c62298d24dd6d42e5e53c5ece5d3e
Signed-off-by: Chris Diamand <chris.diamand@arm.com>