### PR TITLE
 Only use BFD linker for libraries using forwarding libs

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2019 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -270,7 +270,7 @@ func (m *library) GenerateBuildAction(binType int, ctx blueprint.ModuleContext) 
 			}
 		})
 	if hasForwardingLib {
-		copydtneeded = "-Wl,--copy-dt-needed-entries"
+		copydtneeded = "-fuse-ld=bfd -Wl,--copy-dt-needed-entries"
 	}
 
 	// Handle installation

--- a/core/library.go
+++ b/core/library.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2019 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -138,11 +138,17 @@ type BuildProps struct {
 	// Files in the source directory that the wrapper depends on.
 	Build_wrapper_deps []string
 
-	// This is a shared library that pulls in another shared library which will resolve symbols that
-	// the binary needs. Only valid on bob_shared_library.
+	// This is a shared library that pulls in one or more shared
+	// libraries to resolve symbols that the binary needs. This is
+	// useful where a named library is the standard library to link
+	// against, but the implementation may exist in another
+	// library.
 	//
-	// Currently we need to link this with -Wl,--copy-dt-needed-entries,
-	// but this makes the binary depend on the forwarded library too
+	// Only valid on bob_shared_library.
+	//
+	// Currently we need to link with -Wl,--copy-dt-needed-entries.
+	// This makes the binary depend on the implementation library, and
+	// requires the BFD linker.
 	Forwarding_shlib *bool
 
 	InstallableProps

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -230,15 +230,18 @@ Files that the wrapper depends on.
 
 ----
 ### **bob_module.forwarding_shlib** (optional)
-This is a shared library that pulls in another shared
-library which will resolve symbols that the binary needs.
+This is a shared library that pulls in one or more shared libraries to
+resolve symbols that the binary needs. This is useful where a named
+library is the standard library to link against, but the
+implementation may exist in another library.
+
 Only valid on `bob_shared_library`.
 
-Currently we need to link this with
-`-Wl,--copy-dt-needed-entries`, but this makes the
-binary depend on the forwarded library too.
+Currently we need to link with `-Wl,--copy-dt-needed-entries`. This
+makes the binary depend on the implementation library, and requires
+the BFD linker.
 
-This is not supported on Android.
+This isn't guaranteed to work on Android.
 
 ----
 ### **bob_module.install_group** (optional)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -105,4 +105,3 @@ Note that not all Bob features are supported on Android. This includes:
 
 * Aliases
 * Versioned libraries
-* Forwarding libraries

--- a/mconfig/toolchain.Mconfig
+++ b/mconfig/toolchain.Mconfig
@@ -105,22 +105,6 @@ menu "Host explore options"
 		configuration. In most cases, do not set the values here; if
 		ALLOW_HOST_EXPLORE is enabled, they will be overwritten.
 
-config EXTRA_HOST_LDFLAGS
-	string "Extra host linker options"
-	help
-		Specific linker options required by the host linker.
-
-		This value is determined automatically when ALLOW_HOST_EXPLORE
-		is enabled (any value set manually will be overwritten).
-
-config EXTRA_TARGET_LDFLAGS
-	string "Extra target linker options"
-	help
-		Specific linker options required by the target linker.
-
-		This value is determined automatically when ALLOW_HOST_EXPLORE
-		is enabled (any value set manually will be overwritten).
-
 config EXTRA_LD_LIBRARY_PATH
 	string "Extra LD_LIBRARY_PATH entries"
 	help

--- a/scripts/host_explore.py
+++ b/scripts/host_explore.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import distutils.spawn
 import os
 import sys
 import logging
@@ -23,12 +22,6 @@ import re
 from config_system import get_config_bool, get_config_string, set_config
 
 logger = logging.getLogger(__name__)
-
-def which_binary(executable):
-    full_path = distutils.spawn.find_executable(executable)
-    if not full_path:
-        logger.error("Executable (%s) not found", executable)
-    return full_path
 
 
 def check_output(command, dir=None):
@@ -48,26 +41,6 @@ def check_output(command, dir=None):
         logger.warning("Problem executing command: %s" % str(e))
 
     return output
-
-
-def force_bfd_ldflags(tgtType):
-    if get_config_bool("BUILDER_ANDROID"):
-        return []
-
-    ld = which_binary(get_config_string(tgtType + "_GNU_TOOLCHAIN_PREFIX") + "ld")
-    if ld:
-        ld_version = check_output([ld, "-version"])
-        if ld_version.count("gold") == 1:
-            return ["-fuse-ld=bfd"]
-    return []
-
-
-def compiler_config():
-    host_ldflags = force_bfd_ldflags("HOST")
-    target_ldflags = force_bfd_ldflags("TARGET")
-
-    set_config("EXTRA_HOST_LDFLAGS", " ".join(host_ldflags))
-    set_config("EXTRA_TARGET_LDFLAGS", " ".join(target_ldflags))
 
 
 def pkg_config():
@@ -117,5 +90,4 @@ def pkg_config():
 
 def plugin_exec():
     if get_config_bool('ALLOW_HOST_EXPLORE'):
-        compiler_config()
         pkg_config()

--- a/tests/cxx11_simple/build.bp
+++ b/tests/cxx11_simple/build.bp
@@ -18,8 +18,4 @@
 bob_binary {
     name: "bob_test_cxx11simple",
     srcs: ["simple.cpp"],
-    linux: {
-        // Android should figure out required target LDFLAGS
-        ldflags: ["{{.extra_target_ldflags}}"],
-    },
 }


### PR DESCRIPTION
 Only use BFD linker for libraries using forwarding libs

Currently we must use the BFD linker when libraries link against
forwarding libraries. This is because newer linkers do not support
--copy-dt-needed-entries.

Rather than force the BFD linker to be used for all libraries, only
use it for these libraries.

Then clean up the shared Mconfig to remove unused entries