### PR TITLE
Update blueprint SHA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: go
 
 matrix:
   include:
-  - go: "1.8"
-    env: PYTHON_SUFFIX=2.7
   - go: "1.9"
-    env: PYTHON_SUFFIX=3
+    env: PYTHON_SUFFIX=2.7
   - go: "1.10"
+    env: PYTHON_SUFFIX=3
+  - go: "1.12"
     env: PYTHON_SUFFIX=2.7
 
 cache:

--- a/scripts/generate_android_inc.bash
+++ b/scripts/generate_android_inc.bash
@@ -43,8 +43,8 @@ if [ -x "${BUILDDIR}/buildme" -a -f "${BUILDDIR}/${CONFIGNAME}" ] ; then
 
     cd "${PATH_TO_PROJ}"
 
-    # Use the Go shipped with Android:
-    export GOROOT="${TOP}/prebuilts/go/linux-x86/"
+    # Use the Go shipped with Android on P and later, where it's recent enough (> 1.9).
+    [[ $PLATFORM_SDK_VERSION -ge 28 ]] && export GOROOT="${TOP}/prebuilts/go/linux-x86/"
 
     "$BUILDDIR/buildme"
 

--- a/tests/Android.mk.blueprint
+++ b/tests/Android.mk.blueprint
@@ -40,7 +40,7 @@ BOB_GEN_CMD:="$(BOB_$(PROJ)_DIR)/@@BOB_DIR@@/scripts/generate_android_inc.bash" 
 
 $(info Running '$(BOB_GEN_CMD)')
 
-BOB_GEN_RESULT:=$(shell NINJA=$(NINJA) $(BOB_GEN_CMD))
+BOB_GEN_RESULT:=$(shell NINJA=$(NINJA) PLATFORM_SDK_VERSION=$(PLATFORM_SDK_VERSION) $(BOB_GEN_CMD))
 BOB_GEN_RET_VAL:=$(lastword $(BOB_GEN_RESULT))
 
 # The preferred solution here would be to do:


### PR DESCRIPTION
This includes a fix which allows using Go 1.12. However, Blueprint also
now uses `sync.Map`, which doesn't work in Go 1.8. Remove testing of Go
1.8 from Travis, and add a workaround to `generate_android_inc.bash` so
that on Android O and earlier we do not use the prebuilt Go, because
that is not recent enough.

Change-Id: Ib048baf5a9f7d53b093d706afd6aa37589fae184
Signed-off-by: Chris Diamand <chris.diamand@arm.com>