### PR TITLE
Fix broken comment regex

### DIFF
--- a/config_system/lex.py
+++ b/config_system/lex.py
@@ -91,11 +91,13 @@ def t_newline(t):
 
 
 def t_ANY_comment(t):
-    r"[ \t]*\#.*[\n|\Z]"
+    r"[ \t]*\#.*\n"
     t.lexer.lineno += 1
+
+    # Backtrack on newlines so that an EOL token is generated.
     t.lexer.lexpos -= 1
+
     t.type = "COMMENT"
-    t.value = t.value[:-1]
     return t if verbose_flag else None
 
 

--- a/config_system/mconfigfmt.py
+++ b/config_system/mconfigfmt.py
@@ -67,6 +67,7 @@ def handle_formatting(prev_type, token):
     dec_map = {
         "HELPTEXT": format_helptext,
         "QUOTED_STRING": '"{}"'.format,
+        "COMMENT": lambda value: value.rstrip(),
     }
     handler = dec_map.get(token.type, str)
 

--- a/config_system/tests/formatter/comment_whitespace.expected
+++ b/config_system/tests/formatter/comment_whitespace.expected
@@ -1,0 +1,9 @@
+# This is a normal comment
+
+config TEST # Comment following some code
+	bool    # This aligns with the previous line
+	default y
+
+# More trailing whitespace
+    # This comment is indented, but currently should not be moved.
+    # It also finishes right before the end of file.

--- a/config_system/tests/formatter/comment_whitespace.test
+++ b/config_system/tests/formatter/comment_whitespace.test
@@ -1,0 +1,9 @@
+# This is a normal comment
+
+config TEST # Comment following some code   
+	bool    # This aligns with the previous line
+    default y
+
+# More trailing whitespace	
+    # This comment is indented, but currently should not be moved. 
+    # It also finishes right before the end of file.

--- a/config_system/tests/run_tests_formatter.py
+++ b/config_system/tests/run_tests_formatter.py
@@ -14,6 +14,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import print_function
+
 import os
 import sys
 import tempfile
@@ -37,8 +40,14 @@ def run_test(name, expected_output):
 
     with open(tmp_file.name) as test_out, open(expected_output) as exp_out:
         out_lines, exp_lines = test_out.readlines(), exp_out.readlines()
-    if any(out_lines[i] != exp_lines[i] for i in range(len(exp_lines))):
-        passed = False
+
+    for i in range(len(exp_lines)):
+        if out_lines[i] != exp_lines[i]:
+            print("Error: Line {} differs! Expected:".format(i + 1))
+            print("   ", repr(exp_lines[i]))
+            print("...but got:")
+            print("   ", repr(out_lines[i]))
+            passed = False
 
     os.remove(tmp_file.name)
 


### PR DESCRIPTION
Python 3.6 and later changes the behaviour of regular expressions, so
that unknown escape sequences result in errors. This highlights the
regular expression in `t_ANY_comment()`, which contains `\Z` in a
character class. `\Z` *does* correctly match the end of string
(i.e. EOF in Ply), but when used in a character class it loses its
special meaning and just becomes a normal, broken escape sequence.

Fix this by removing it. It is only required to handle the case where
the last line is a comment, but has no newline before the end-of-file.
This isn't supported in the other token types anyway, so for now there
is no need to support it in comments.

Test this by adding a formatter test, which lets us check that arbitrary
input can be scanned without issue. Since the code is being changed anyway,
with a test being added, make the formatter strip trailing whitespace
from comments.

Improve the tests' error message by printing the expected and actual
lines when a failure occurs.

Change-Id: I4dffd64ba775199c3a5c41be0adfd7a37bf399ae
Signed-off-by: Chris Diamand <chris.diamand@arm.com>