### PR TITLE
Use getopts in generate_android_inc.bash

### DIFF
--- a/example/Android.mk.blueprint
+++ b/example/Android.mk.blueprint
@@ -36,7 +36,11 @@ include $(BUILD_SYSTEM)/ninja_config.mk
 
 # It is important to have the ./ before the output directory, due to kati ignoring
 # any shell command that begins with "out/"
-BOB_GEN_CMD:="$(BOB_$(PROJ)_DIR)/@@BOB_DIR@@/scripts/generate_android_inc.bash" "$(LOCAL_PATH)" "./$(BOB_ANDROIDMK_DIR)" "@@CONFIGNAME@@"
+BOB_GEN_CMD:="$(BOB_$(PROJ)_DIR)/@@BOB_DIR@@/scripts/generate_android_inc.bash" \
+    -c "@@CONFIGNAME@@" \
+    -o "./$(BOB_ANDROIDMK_DIR)" \
+    -s "$(LOCAL_PATH)" \
+    -v "$(PLATFORM_SDK_VERSION)"
 
 $(info Running '$(BOB_GEN_CMD)')
 

--- a/scripts/generate_android_inc.bash
+++ b/scripts/generate_android_inc.bash
@@ -18,9 +18,6 @@
 # This script sets up the environment to be able to build the project
 # using Android paths only.
 
-# This script should be called like:
-# $PATH_TO_PROJ/generate_android_inc.bash $PATH_TO_PROJ $BUILDDIR $GOROOT $CONFIGNAME
-
 # This script is invoked by Android.mk in a $(shell) expression, so its
 # standard output is buffered. Swap stdout and stderr so that the output of
 # this is visible.
@@ -30,9 +27,21 @@ set -e
 trap 'echo "*** Unexpected error in $0 ***"' ERR
 
 BOB_DIR=$(dirname $(dirname "${BASH_SOURCE[0]}"))
-PATH_TO_PROJ="$1"
-BUILDDIR=$(readlink -f "$2")
-CONFIGNAME="$3"
+
+while getopts "c:o:s:v:" opt; do
+    case $opt in
+        c) CONFIGNAME="$OPTARG";;
+        o) BUILDDIR=`readlink -f "$OPTARG"`;;
+        s) PATH_TO_PROJ="$OPTARG";;
+        v) PLATFORM_SDK_VERSION="$OPTARG";;
+    esac
+done
+
+if [[ -z $BUILDDIR || -z $CONFIGNAME || -z $PATH_TO_PROJ || -z $PLATFORM_SDK_VERSION ]]; then
+    echo "Error: Missing argument to $0"
+    echo "Usage: $0 -c CONFIGNAME -o BUILDDIR -s PATH_TO_PROJ -v PLATFORM_SDK_VERSION"
+    exit 1
+fi
 
 source "${BOB_DIR}/pathtools.bash"
 

--- a/tests/Android.mk.blueprint
+++ b/tests/Android.mk.blueprint
@@ -36,11 +36,15 @@ include $(BUILD_SYSTEM)/ninja_config.mk
 
 # It is important to have the ./ before the output directory, due to kati ignoring
 # any shell command that begins with "out/"
-BOB_GEN_CMD:="$(BOB_$(PROJ)_DIR)/@@BOB_DIR@@/scripts/generate_android_inc.bash" "$(LOCAL_PATH)" "./$(BOB_ANDROIDMK_DIR)" "@@CONFIGNAME@@"
+BOB_GEN_CMD:="$(BOB_$(PROJ)_DIR)/@@BOB_DIR@@/scripts/generate_android_inc.bash" \
+    -c "@@CONFIGNAME@@" \
+    -o "./$(BOB_ANDROIDMK_DIR)" \
+    -s "$(LOCAL_PATH)" \
+    -v "$(PLATFORM_SDK_VERSION)"
 
 $(info Running '$(BOB_GEN_CMD)')
 
-BOB_GEN_RESULT:=$(shell NINJA=$(NINJA) PLATFORM_SDK_VERSION=$(PLATFORM_SDK_VERSION) $(BOB_GEN_CMD))
+BOB_GEN_RESULT:=$(shell NINJA=$(NINJA) $(BOB_GEN_CMD))
 BOB_GEN_RET_VAL:=$(lastword $(BOB_GEN_RESULT))
 
 # The preferred solution here would be to do:


### PR DESCRIPTION
Modify generate_android_inc.bash to use arguments with `getopts`. This
is a lot clearer than relying on specific argument ordering.

`PLATFORM_SDK_VERSION` is now passed a parameter, rather than via the
environment - only `NINJA` is expected to always be an environment
variable.

Change-Id: Ie6eeddd62c9847d5437f2e40398b89a9e318c486
Signed-off-by: Chris Diamand <chris.diamand@arm.com>