### PR TITLE
Drop support for Go < 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: go
 
 matrix:
   include:
-  - go: "1.9"
-    env: PYTHON_SUFFIX=2.7
   - go: "1.10"
+    env: PYTHON_SUFFIX=2.7
+  - go: "1.11"
     env: PYTHON_SUFFIX=3
   - go: "1.12"
     env: PYTHON_SUFFIX=2.7

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ do the heavy lifting. As such it has similarities with
 ## Requirements
 
 To use Bob you will need:
--  golang (>=1.8)
+-  golang (>=1.10)
 -  ninja-build (>=1.8)
 -  python
 -  python-ply

--- a/scripts/generate_android_inc.bash
+++ b/scripts/generate_android_inc.bash
@@ -52,7 +52,7 @@ if [ -x "${BUILDDIR}/buildme" -a -f "${BUILDDIR}/${CONFIGNAME}" ] ; then
 
     cd "${PATH_TO_PROJ}"
 
-    # Use the Go shipped with Android on P and later, where it's recent enough (> 1.9).
+    # Use the Go shipped with Android on P and later, where it's recent enough (>= 1.10).
     [[ $PLATFORM_SDK_VERSION -ge 28 ]] && export GOROOT="${TOP}/prebuilts/go/linux-x86/"
 
     "$BUILDDIR/buildme"


### PR DESCRIPTION
Update Travis to no longer test Go versions below 1.10.

Change-Id: I4865c17bd8dff8693df4bff5fed965e25cf89bc7
Signed-off-by: Chris Diamand <chris.diamand@arm.com>