### PR TITLE
Add prefixes to different toolchains

### DIFF
--- a/example/Mconfig
+++ b/example/Mconfig
@@ -44,9 +44,9 @@ config TARGET_TOOLCHAIN_ARMCLANG
 
 endchoice
 
-## Toolchain prefix needed for Bob (for gcc)
-config TARGET_GNU_TOOLCHAIN_PREFIX
-	string
+## Toolchain prefixes needed for Bob
+config TARGET_GNU_PREFIX
+	string "GNU cross-compiler prefix"
 	default ""
 
 config TARGET_GNU_FLAGS

--- a/mconfig/toolchain.Mconfig
+++ b/mconfig/toolchain.Mconfig
@@ -119,12 +119,28 @@ endmenu
 ### Toolchain target options ###
 # The host options are not yet read by `toolchain.go`, so are empty, and
 # exist so that `host_explore.py` can be agnostic to the target type when
-# doing e.g. `get_config_string(tgtType + "_GNU_TOOLCHAIN_PREFIX")`. They are
+# doing e.g. `get_config_string(tgtType + "_GNU_PREFIX")`. They are
 # defined here, rather than in the superproject, because even when they are
 # fully supported, they will be empty most of the time.
 
-config HOST_GNU_TOOLCHAIN_PREFIX
-	string
+config HOST_GNU_PREFIX
+	string "GNU compiler prefix"
+	default ""
+
+config HOST_CLANG_PREFIX
+	string "Clang compiler prefix"
+	default ""
+
+config HOST_ARMCLANG_PREFIX
+	string "Arm Compiler 6 prefix"
+	default ""
+
+config TARGET_CLANG_PREFIX
+	string "Clang cross-compiler prefix"
+	default ""
+
+config TARGET_ARMCLANG_PREFIX
+	string "Arm Compiler 6 cross-compiler prefix"
 	default ""
 
 config HOST_GNU_FLAGS
@@ -138,8 +154,9 @@ config HOST_CLANG_TRIPLE
 # The target equivalents, despite being only used by Bob, must be defined by
 # the superproject so that it can add any desired defaults, etc:
 
-# config TARGET_GNU_TOOLCHAIN_PREFIX
+# config TARGET_GNU_PREFIX
 #	string "Cross-compiler prefix"
+#	default ""
 
 # config TARGET_GNU_FLAGS
 #	string

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -44,8 +44,8 @@ config TARGET_TOOLCHAIN_ARMCLANG
 
 endchoice
 
-## Toolchain prefix needed for Bob (for gcc)
-config TARGET_GNU_TOOLCHAIN_PREFIX
+## Toolchain prefixes needed for Bob
+config TARGET_GNU_PREFIX
 	string
 	default ""
 


### PR DESCRIPTION
This change adds prefixes to handle non-default path for tools such as gcc/clang
Prefixes are required to work with custom path provided for tools that
maybe used only for the build process but are not default for the system
environment

Change-Id: I188b244897a6a29d0e40a37394c99adafdbe42a3
Signed-off-by: Michal Widera <michal.widera@arm.com>