### PR TITLE
Replace string concatenation with string builder

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -43,14 +43,15 @@ type androidMkGenerator struct {
 
 var androidLock sync.Mutex
 
-func writeIfChanged(filename string, text string) {
+func writeIfChanged(filename string, sb *strings.Builder) {
 	mustWrite := true
+	text := sb.String()
 
 	// If any errors occur trying to determine the state of the existing file,
 	// just write the new file
 	fileinfo, err := os.Stat(filename)
 	if err == nil {
-		if fileinfo.Size() == int64(len(text)) {
+		if fileinfo.Size() == int64(sb.Len()) {
 			current, err := ioutil.ReadFile(filename)
 			if err == nil {
 				if string(current) == text {
@@ -72,9 +73,9 @@ func writeIfChanged(filename string, text string) {
 	}
 }
 
-func androidMkWriteString(ctx blueprint.ModuleContext, name string, text string) {
+func androidMkWriteString(sb *strings.Builder, ctx blueprint.ModuleContext, name string) {
 	filename := filepath.Join(builddir, name+".inc")
-	writeIfChanged(filename, text)
+	writeIfChanged(filename, sb)
 }
 
 func newlineSeparatedList(list []string) string {
@@ -140,14 +141,14 @@ func specifyCompilerStandard(varname string, flags []string) string {
 	return line
 }
 
-func (m *library) GenerateBuildAction(binType int, ctx blueprint.ModuleContext) {
+func (m *library) GenerateBuildAction(sb *strings.Builder, binType int, ctx blueprint.ModuleContext) {
 	if m.Properties.Build_wrapper != nil {
 		panic(errors.New("build_wrapper not supported on Android"))
 	}
 
-	text := "##########################\ninclude $(CLEAR_VARS)\n\n"
-	text += "LOCAL_MODULE:=" + m.altName() + "\n"
-	text += "LOCAL_MODULE_CLASS:=" + classes[binType] + "\n\n"
+	sb.WriteString("##########################\ninclude $(CLEAR_VARS)\n\n")
+	sb.WriteString("LOCAL_MODULE:=" + m.altName() + "\n")
+	sb.WriteString("LOCAL_MODULE_CLASS:=" + classes[binType] + "\n\n")
 
 	// The order we want is  local_include_dirs, export_local_include_dirs,
 	//                       include_dirs, export_include_dirs
@@ -165,7 +166,7 @@ func (m *library) GenerateBuildAction(binType int, ctx blueprint.ModuleContext) 
 		includes = append(includes, headerDirs...)
 		headers := strings.Join(headerOutputs, " ")
 
-		text += "LOCAL_ADDITIONAL_DEPENDENCIES := " + headers + "\n\n"
+		sb.WriteString("LOCAL_ADDITIONAL_DEPENDENCIES := " + headers + "\n\n")
 	}
 
 	// Handle generated sources
@@ -193,33 +194,33 @@ func (m *library) GenerateBuildAction(binType int, ctx blueprint.ModuleContext) 
 		localSourceExpr := "$(subst " + sourcesDir + ", $(local-generated-sources-dir), " + sources + ")"
 		localSources := "$(" + m.altName() + "_" + module + "_SRCS)"
 
-		text += m.altName() + "_" + module + "_SRCS:=" + localSourceExpr + "\n"
-		text += "LOCAL_GENERATED_SOURCES+=" + localSources + "\n"
+		sb.WriteString(m.altName() + "_" + module + "_SRCS:=" + localSourceExpr + "\n")
+		sb.WriteString("LOCAL_GENERATED_SOURCES+=" + localSources + "\n")
 
 		// Copy rule. Use a static pattern to avoid running the command for each file
-		text += localSources + ": $(local-generated-sources-dir)" + "/%: " + sourcesDir + "/%\n"
-		text += "\tcp $< $@\n\n"
+		sb.WriteString(localSources + ": $(local-generated-sources-dir)" + "/%: " + sourcesDir + "/%\n")
+		sb.WriteString("\tcp $< $@\n\n")
 	}
 
 	if getConfig(ctx).Properties.GetBool("target_toolchain_clang") {
-		text += "LOCAL_CLANG := true\n"
+		sb.WriteString("LOCAL_CLANG := true\n")
 	} else {
-		text += "LOCAL_CLANG := false\n"
+		sb.WriteString("LOCAL_CLANG := false\n")
 	}
 	srcs := utils.NewStringSlice(m.Properties.GetSrcs(ctx), m.Properties.Build.SourceProps.Specials)
-	text += "LOCAL_SRC_FILES := " + strings.Join(srcs, " ") + "\n"
+	sb.WriteString("LOCAL_SRC_FILES := " + strings.Join(srcs, " ") + "\n")
 
-	text += "LOCAL_C_INCLUDES := " + strings.Join(includes, " ") + "\n"
+	sb.WriteString("LOCAL_C_INCLUDES := " + strings.Join(includes, " ") + "\n")
 	cflagsList := utils.NewStringSlice(m.Properties.Cflags, m.Properties.Export_cflags)
 	_, exportedCflags := m.GetExportedVariables(ctx)
 	cflagsList = append(cflagsList, exportedCflags...)
-	text += "LOCAL_CFLAGS := " + strings.Join(utils.Filter(cflagsList, moduleCompileFlags), " ") + "\n"
-	text += "LOCAL_CPPFLAGS := " + strings.Join(utils.Filter(m.Properties.Cxxflags, moduleCompileFlags), " ") + "\n"
-	text += "LOCAL_CONLYFLAGS := " + strings.Join(utils.Filter(m.Properties.Conlyflags, moduleCompileFlags), " ") + "\n"
+	sb.WriteString("LOCAL_CFLAGS := " + strings.Join(utils.Filter(cflagsList, moduleCompileFlags), " ") + "\n")
+	sb.WriteString("LOCAL_CPPFLAGS := " + strings.Join(utils.Filter(m.Properties.Cxxflags, moduleCompileFlags), " ") + "\n")
+	sb.WriteString("LOCAL_CONLYFLAGS := " + strings.Join(utils.Filter(m.Properties.Conlyflags, moduleCompileFlags), " ") + "\n")
 
 	// Setup module C/C++ standard if requested. Note that this only affects Android O and later.
-	text += specifyCompilerStandard("LOCAL_C_STD", utils.NewStringSlice(cflagsList, m.Properties.Conlyflags))
-	text += specifyCompilerStandard("LOCAL_CPP_STD", utils.NewStringSlice(cflagsList, m.Properties.Cxxflags))
+	sb.WriteString(specifyCompilerStandard("LOCAL_C_STD", utils.NewStringSlice(cflagsList, m.Properties.Conlyflags)))
+	sb.WriteString(specifyCompilerStandard("LOCAL_CPP_STD", utils.NewStringSlice(cflagsList, m.Properties.Cxxflags)))
 
 	// convert Shared_libs, Export_shared_libs, Resolved_static_libs, and
 	// Whole_static_libs to Android module names rather than Bob module
@@ -231,22 +232,22 @@ func (m *library) GenerateBuildAction(binType int, ctx blueprint.ModuleContext) 
 	exportHeaderLibs := androidModuleNames(m.Properties.Export_header_libs)
 	headerLibs := append(androidModuleNames(m.Properties.Header_libs), exportHeaderLibs...)
 
-	text += "LOCAL_SHARED_LIBRARIES := " + strings.Join(append(sharedLibs, "liblog"), " ") + "\n"
-	text += "LOCAL_STATIC_LIBRARIES := " + strings.Join(staticLibs, " ") + "\n"
-	text += "LOCAL_WHOLE_STATIC_LIBRARIES := " + strings.Join(wholeStaticLibs, " ") + "\n"
+	sb.WriteString("LOCAL_SHARED_LIBRARIES := " + strings.Join(append(sharedLibs, "liblog"), " ") + "\n")
+	sb.WriteString("LOCAL_STATIC_LIBRARIES := " + strings.Join(staticLibs, " ") + "\n")
+	sb.WriteString("LOCAL_WHOLE_STATIC_LIBRARIES := " + strings.Join(wholeStaticLibs, " ") + "\n")
 
-	text += "LOCAL_MODULE_TAGS := " + strings.Join(m.Properties.Tags, " ") + "\n"
-	text += "LOCAL_EXPORT_C_INCLUDE_DIRS := " + strings.Join(exportIncludeDirs, " ") + "\n"
+	sb.WriteString("LOCAL_MODULE_TAGS := " + strings.Join(m.Properties.Tags, " ") + "\n")
+	sb.WriteString("LOCAL_EXPORT_C_INCLUDE_DIRS := " + strings.Join(exportIncludeDirs, " ") + "\n")
 	if m.Properties.Owner != "" {
-		text += "LOCAL_MODULE_OWNER := " + m.Properties.Owner + "\n"
-		text += "LOCAL_PROPRIETARY_MODULE := true\n"
+		sb.WriteString("LOCAL_MODULE_OWNER := " + m.Properties.Owner + "\n")
+		sb.WriteString("LOCAL_PROPRIETARY_MODULE := true\n")
 	}
 
 	if len(headerLibs) > 0 {
-		text += "LOCAL_HEADER_LIBRARIES := " + strings.Join(headerLibs, " ") + "\n"
+		sb.WriteString("LOCAL_HEADER_LIBRARIES := " + strings.Join(headerLibs, " ") + "\n")
 	}
 	if len(exportHeaderLibs) > 0 {
-		text += "LOCAL_EXPORT_HEADER_LIBRARY_HEADERS := " + strings.Join(headerLibs, " ") + "\n"
+		sb.WriteString("LOCAL_EXPORT_HEADER_LIBRARY_HEADERS := " + strings.Join(headerLibs, " ") + "\n")
 	}
 
 	// Can't see a way to wrap a particular library in -Wl in link flags on android, so specify
@@ -285,7 +286,7 @@ func (m *library) GenerateBuildAction(binType int, ctx blueprint.ModuleContext) 
 		((binType == binTypeShared) || (binType == binTypeStatic) || ok)
 
 	if ok {
-		text += "LOCAL_MODULE_RELATIVE_PATH:=" + m.Properties.Relative_install_path + "\n"
+		sb.WriteString("LOCAL_MODULE_RELATIVE_PATH:=" + m.Properties.Relative_install_path + "\n")
 		if m.Properties.Post_install_cmd != "" {
 			// Setup args like we do for bob_generated_*
 			args := map[string]string{}
@@ -304,7 +305,7 @@ func (m *library) GenerateBuildAction(binType int, ctx blueprint.ModuleContext) 
 			// Intentionally using a recursively expanded variable. We
 			// don't want LOCAL_INSTALLED_MODULE expanded now, but
 			// when it is used in base_rules.mk
-			text += "LOCAL_POST_INSTALL_CMD=" + cmd + "\n"
+			sb.WriteString("LOCAL_POST_INSTALL_CMD=" + cmd + "\n")
 		}
 
 		if binType == binTypeExecutable {
@@ -313,16 +314,16 @@ func (m *library) GenerateBuildAction(binType int, ctx blueprint.ModuleContext) 
 				// install both 32 and 64 bit versions of the
 				// binaries.
 				// LOCAL_UNSTRIPPED_PATH does not need to be set
-				text += "LOCAL_MODULE_PATH_32:=" + installGroupPath + "\n"
-				text += "LOCAL_MODULE_PATH_64:=" + installGroupPath + "64\n"
+				sb.WriteString("LOCAL_MODULE_PATH_32:=" + installGroupPath + "\n")
+				sb.WriteString("LOCAL_MODULE_PATH_64:=" + installGroupPath + "64\n")
 			} else {
 				// When LOCAL_MODULE_PATH is specified, you need to
 				// specify LOCAL_UNSTRIPPED_PATH too
-				text += "LOCAL_MODULE_PATH:=" + installGroupPath + "\n"
+				sb.WriteString("LOCAL_MODULE_PATH:=" + installGroupPath + "\n")
 
 				if m.Properties.TargetType == tgtTypeTarget {
 					// Unstripped executables only generated for target
-					text += "LOCAL_UNSTRIPPED_PATH:=$(TARGET_OUT_EXECUTABLES_UNSTRIPPED)\n"
+					sb.WriteString("LOCAL_UNSTRIPPED_PATH:=$(TARGET_OUT_EXECUTABLES_UNSTRIPPED)\n")
 				}
 			}
 		} else {
@@ -336,7 +337,7 @@ func (m *library) GenerateBuildAction(binType int, ctx blueprint.ModuleContext) 
 			for i, v := range requiredModuleNames {
 				requiredModuleNames[i] = androidModuleName(v)
 			}
-			text += "LOCAL_REQUIRED_MODULES:=" + newlineSeparatedList(requiredModuleNames)
+			sb.WriteString("LOCAL_REQUIRED_MODULES:=" + newlineSeparatedList(requiredModuleNames))
 		}
 	} else {
 		// Only disable installation on the target, because host
@@ -347,61 +348,63 @@ func (m *library) GenerateBuildAction(binType int, ctx blueprint.ModuleContext) 
 		// will conflict, resulting in the same location being used for
 		// both 32 and 64-bit versions.
 		if m.Properties.TargetType == tgtTypeTarget && binType != binTypeShared {
-			text += "LOCAL_UNINSTALLABLE_MODULE:=true\n"
+			sb.WriteString("LOCAL_UNINSTALLABLE_MODULE:=true\n")
 		}
 	}
 
 	if isMultiLib {
-		text += "LOCAL_MULTILIB:=both\n"
-		text += "LOCAL_LDFLAGS_32:=" + strings.Join(utils.Filter(m.Properties.Ldflags, moduleLinkFlags), " ") + copydtneeded + "\n"
+		sb.WriteString("LOCAL_MULTILIB:=both\n")
+		sb.WriteString("LOCAL_LDFLAGS_32:=" + strings.Join(utils.Filter(m.Properties.Ldflags, moduleLinkFlags), " ") + copydtneeded + "\n")
 	}
-	text += "LOCAL_LDFLAGS:=" + strings.Join(utils.Filter(m.Properties.Ldflags, moduleLinkFlags), " ") + copydtneeded + "\n"
+	sb.WriteString("LOCAL_LDFLAGS:=" + strings.Join(utils.Filter(m.Properties.Ldflags, moduleLinkFlags), " ") + copydtneeded + "\n")
 
 	if m.Properties.TargetType == tgtTypeTarget {
-		text += "LOCAL_LDLIBS := " + strings.Join(m.Properties.Ldlibs, " ") + "\n"
+		sb.WriteString("LOCAL_LDLIBS := " + strings.Join(m.Properties.Ldlibs, " ") + "\n")
 	} else {
-		text += "LOCAL_LDLIBS_$(HOST_OS) := " + strings.Join(m.Properties.Ldlibs, " ") + "\n"
+		sb.WriteString("LOCAL_LDLIBS_$(HOST_OS) := " + strings.Join(m.Properties.Ldlibs, " ") + "\n")
 	}
-	text += "\ninclude $(" + rulePrefix[m.Properties.TargetType] + ruleSuffix[binType] + ")\n"
+	sb.WriteString("\ninclude $(" + rulePrefix[m.Properties.TargetType] + ruleSuffix[binType] + ")\n")
 
-	androidMkWriteString(ctx, m.altShortName(), text)
+	androidMkWriteString(sb, ctx, m.altShortName())
 }
 
 func (g *androidMkGenerator) staticActions(m *staticLibrary, ctx blueprint.ModuleContext) {
 	if enabledAndRequired(m) {
-		m.GenerateBuildAction(binTypeStatic, ctx)
+		var sb strings.Builder
+		m.GenerateBuildAction(&sb, binTypeStatic, ctx)
 	}
 }
 
 func (g *androidMkGenerator) sharedActions(m *sharedLibrary, ctx blueprint.ModuleContext) {
 	if enabledAndRequired(m) {
-		m.GenerateBuildAction(binTypeShared, ctx)
+		var sb strings.Builder
+		m.GenerateBuildAction(&sb, binTypeShared, ctx)
 	}
 }
 
 func (g *androidMkGenerator) binaryActions(m *binary, ctx blueprint.ModuleContext) {
 	if enabledAndRequired(m) {
-		m.GenerateBuildAction(binTypeExecutable, ctx)
+		var sb strings.Builder
+		m.GenerateBuildAction(&sb, binTypeExecutable, ctx)
 	}
 }
 
-func (*androidMkGenerator) declareAlias(name string, srcs []string) string {
-	text := "\ninclude $(CLEAR_VARS)\n\n"
-	text += "LOCAL_MODULE := " + name + "\n"
+func (*androidMkGenerator) declareAlias(sb *strings.Builder, name string, srcs []string) {
+	sb.WriteString("\ninclude $(CLEAR_VARS)\n\n")
+	sb.WriteString("LOCAL_MODULE := " + name + "\n")
 
-	text += "LOCAL_REQUIRED_MODULES :=" + newlineSeparatedList(srcs)
+	sb.WriteString("LOCAL_REQUIRED_MODULES :=" + newlineSeparatedList(srcs))
 
-	text += "\n.PHONY: " + name + "\n"
-	text += name + ": $(LOCAL_REQUIRED_MODULES)\n\n"
+	sb.WriteString("\n.PHONY: " + name + "\n")
+	sb.WriteString(name + ": $(LOCAL_REQUIRED_MODULES)\n\n")
 
-	text += "include $(base_rules.mk)\n"
-
-	return text
+	sb.WriteString("include $(base_rules.mk)\n")
 }
 
 func (g *androidMkGenerator) aliasActions(m *alias, ctx blueprint.ModuleContext) {
-	text := g.declareAlias(m.Name(), m.Properties.Srcs)
-	androidMkWriteString(ctx, m.Name(), text)
+	var sb strings.Builder
+	g.declareAlias(&sb, m.Name(), m.Properties.Srcs)
+	androidMkWriteString(&sb, ctx, m.Name())
 }
 
 func pathToModuleName(path string) string {
@@ -417,36 +420,35 @@ func (g *androidMkGenerator) resourceActions(m *resource, ctx blueprint.ModuleCo
 	if !enabledAndRequired(m) {
 		return
 	}
+	var sb strings.Builder
 
 	installGroupPath, ok := getInstallGroupPath(ctx)
 	if !ok {
-		androidMkWriteString(ctx, m.altShortName(), "")
+		androidMkWriteString(&sb, ctx, m.altShortName())
 		return
 	}
 
 	filesToInstall := m.filesToInstall(ctx)
 	requiredModuleNames := m.getInstallDepPhonyNames(ctx)
 
-	text := ""
-
 	for _, file := range filesToInstall {
 		moduleName := pathToModuleName(file)
 		requiredModuleNames = append(requiredModuleNames, moduleName)
 
-		text += "\ninclude $(CLEAR_VARS)\n\n"
-		text += "LOCAL_MODULE := " + moduleName + "\n"
-		text += "LOCAL_INSTALLED_MODULE_STEM := " + filepath.Base(file) + "\n"
-		text += "LOCAL_MODULE_CLASS := ETC\n"
-		text += "LOCAL_MODULE_PATH := " + installGroupPath + "\n"
-		text += "LOCAL_MODULE_RELATIVE_PATH := " + m.Properties.Relative_install_path + "\n"
-		text += "LOCAL_MODULE_TAGS := " + strings.Join(m.Properties.Tags, " ") + "\n"
-		text += "LOCAL_SRC_FILES := " + file + "\n"
-		text += "\ninclude $(BUILD_PREBUILT)\n"
+		sb.WriteString("\ninclude $(CLEAR_VARS)\n\n")
+		sb.WriteString("LOCAL_MODULE := " + moduleName + "\n")
+		sb.WriteString("LOCAL_INSTALLED_MODULE_STEM := " + filepath.Base(file) + "\n")
+		sb.WriteString("LOCAL_MODULE_CLASS := ETC\n")
+		sb.WriteString("LOCAL_MODULE_PATH := " + installGroupPath + "\n")
+		sb.WriteString("LOCAL_MODULE_RELATIVE_PATH := " + m.Properties.Relative_install_path + "\n")
+		sb.WriteString("LOCAL_MODULE_TAGS := " + strings.Join(m.Properties.Tags, " ") + "\n")
+		sb.WriteString("LOCAL_SRC_FILES := " + file + "\n")
+		sb.WriteString("\ninclude $(BUILD_PREBUILT)\n")
 	}
 
-	text += g.declareAlias(m.Name(), requiredModuleNames)
+	g.declareAlias(&sb, m.Name(), requiredModuleNames)
 
-	androidMkWriteString(ctx, m.altShortName(), text)
+	androidMkWriteString(&sb, ctx, m.altShortName())
 }
 
 func (g *androidMkGenerator) sourcePrefix() string {
@@ -526,46 +528,45 @@ const cmnLibraryMkText string = "include $(BUILD_SYSTEM)/base_rules.mk\n\n" +
 	"  include $(BUILD_SYSTEM)/link_type.mk\n" +
 	"endif\n"
 
-func declarePrebuiltStaticLib(moduleName, path, includePaths string, target bool) string {
-	text := "\ninclude $(CLEAR_VARS)\n"
-	text += "LOCAL_MODULE:=" + moduleName + "\n"
-	text += "LOCAL_SRC_FILES:=" + path + "\n"
+func declarePrebuiltStaticLib(sb *strings.Builder, moduleName, path, includePaths string, target bool) {
+	sb.WriteString("\ninclude $(CLEAR_VARS)\n")
+	sb.WriteString("LOCAL_MODULE:=" + moduleName + "\n")
+	sb.WriteString("LOCAL_SRC_FILES:=" + path + "\n")
 	if !target {
-		text += "LOCAL_IS_HOST_MODULE:=true\n"
+		sb.WriteString("LOCAL_IS_HOST_MODULE:=true\n")
 	}
 
 	// We would like to just have the following line, but it looks like it is NDK only
 	// Therefore all the following is needed.
-	//text += "include $(PREBUILT_STATIC_LIBRARY)\n"
+	//sb.WriteString("include $(PREBUILT_STATIC_LIBRARY)\n")
 
-	text += "LOCAL_MODULE_CLASS:=STATIC_LIBRARIES\n"
-	text += "LOCAL_UNINSTALLABLE_MODULE:=true\n"
-	text += "LOCAL_MODULE_SUFFIX:=.a\n"
+	sb.WriteString("LOCAL_MODULE_CLASS:=STATIC_LIBRARIES\n")
+	sb.WriteString("LOCAL_UNINSTALLABLE_MODULE:=true\n")
+	sb.WriteString("LOCAL_MODULE_SUFFIX:=.a\n")
 
 	if includePaths != "" {
-		text += "LOCAL_EXPORT_C_INCLUDE_DIRS:=" + includePaths + "\n"
+		sb.WriteString("LOCAL_EXPORT_C_INCLUDE_DIRS:=" + includePaths + "\n")
 	}
 
-	text += cmnLibraryMkText
-	return text
+	sb.WriteString(cmnLibraryMkText)
 }
 
-func declarePrebuiltSharedLib(moduleName, path, includePaths string, target bool) string {
-	text := "\ninclude $(CLEAR_VARS)\n"
-	text += "LOCAL_MODULE:=" + moduleName + "\n"
-	text += "LOCAL_SRC_FILES:=" + path + "\n"
+func declarePrebuiltSharedLib(sb *strings.Builder, moduleName, path, includePaths string, target bool) {
+	sb.WriteString("\ninclude $(CLEAR_VARS)\n")
+	sb.WriteString("LOCAL_MODULE:=" + moduleName + "\n")
+	sb.WriteString("LOCAL_SRC_FILES:=" + path + "\n")
 	if !target {
-		text += "LOCAL_IS_HOST_MODULE:=true\n"
+		sb.WriteString("LOCAL_IS_HOST_MODULE:=true\n")
 	}
 	// We would like to just have the following line, but it looks like it is NDK only
 	// Therefore all the following is needed.
-	//text += "include $(PREBUILT_SHARED_LIBRARY)\n"
+	//sb.WriteString("include $(PREBUILT_SHARED_LIBRARY)\n")
 
-	text += "LOCAL_MODULE_CLASS:=SHARED_LIBRARIES\n"
-	text += "LOCAL_MODULE_SUFFIX:=.so\n"
+	sb.WriteString("LOCAL_MODULE_CLASS:=SHARED_LIBRARIES\n")
+	sb.WriteString("LOCAL_MODULE_SUFFIX:=.so\n")
 
 	if includePaths != "" {
-		text += "LOCAL_EXPORT_C_INCLUDE_DIRS:=" + includePaths + "\n"
+		sb.WriteString("LOCAL_EXPORT_C_INCLUDE_DIRS:=" + includePaths + "\n")
 	}
 
 	//  Put shared libraries in common path to simplify link line.
@@ -573,76 +574,70 @@ func declarePrebuiltSharedLib(moduleName, path, includePaths string, target bool
 	if target {
 		// Only supporting the primary target architecture.
 		// Others are TARGET_2ND_x
-		text += "OVERRIDE_BUILT_MODULE_PATH:=$(TARGET_OUT_INTERMEDIATE_LIBRARIES)\n\n"
+		sb.WriteString("OVERRIDE_BUILT_MODULE_PATH:=$(TARGET_OUT_INTERMEDIATE_LIBRARIES)\n\n")
 	} else {
 		// Only supporting the primary host architecture.
 		// Others are HOST_2ND_x, HOST_CROSS_x, HOST_CROSS_2ND_x
-		text += "OVERRIDE_BUILT_MODULE_PATH:=$(HOST_OUT_INTERMEDIATE_LIBRARIES)\n\n"
+		sb.WriteString("OVERRIDE_BUILT_MODULE_PATH:=$(HOST_OUT_INTERMEDIATE_LIBRARIES)\n\n")
 	}
 
-	text += cmnLibraryMkText
-	return text
+	sb.WriteString(cmnLibraryMkText)
 }
 
-func declarePrebuiltBinary(moduleName, path string, target bool) string {
-	text := "\ninclude $(CLEAR_VARS)\n"
-	text += "LOCAL_MODULE:=" + moduleName + "\n"
-	text += "LOCAL_SRC_FILES:=" + path + "\n"
+func declarePrebuiltBinary(sb *strings.Builder, moduleName, path string, target bool) {
+	sb.WriteString("\ninclude $(CLEAR_VARS)\n")
+	sb.WriteString("LOCAL_MODULE:=" + moduleName + "\n")
+	sb.WriteString("LOCAL_SRC_FILES:=" + path + "\n")
 	if !target {
-		text += "LOCAL_IS_HOST_MODULE:=true\n"
+		sb.WriteString("LOCAL_IS_HOST_MODULE:=true\n")
 	}
 
-	text += "LOCAL_MODULE_CLASS:=EXECUTABLES\n"
-	text += "LOCAL_MODULE_SUFFIX:=\n\n"
+	sb.WriteString("LOCAL_MODULE_CLASS:=EXECUTABLES\n")
+	sb.WriteString("LOCAL_MODULE_SUFFIX:=\n\n")
 
-	text += "include $(BUILD_SYSTEM)/base_rules.mk\n\n"
+	sb.WriteString("include $(BUILD_SYSTEM)/base_rules.mk\n\n")
 
-	text += "$(LOCAL_BUILT_MODULE): $(LOCAL_SRC_FILES)\n"
-	text += "\tmkdir -p $(dir $@)\n"
-	text += "\tcp $< $@\n"
-
-	return text
+	sb.WriteString("$(LOCAL_BUILT_MODULE): $(LOCAL_SRC_FILES)\n")
+	sb.WriteString("\tmkdir -p $(dir $@)\n")
+	sb.WriteString("\tcp $< $@\n")
 }
 
-func installGeneratedFiles(m installable, ctx blueprint.ModuleContext, tags []string) string {
+func installGeneratedFiles(sb *strings.Builder, m installable, ctx blueprint.ModuleContext, tags []string) {
 	/* Install generated files one by one, if required */
 	installGroupPath, ok := getInstallGroupPath(ctx)
 
 	if !ok {
-		return ""
+		return
 	}
-
-	text := "\n"
+	sb.WriteString("\n")
 	filesToInstall := m.filesToInstall(ctx)
 
 	for _, file := range filesToInstall {
 		moduleName := pathToModuleName(file)
 
-		text += "include $(CLEAR_VARS)\n\n"
+		sb.WriteString("include $(CLEAR_VARS)\n\n")
 
-		text += "LOCAL_MODULE := " + moduleName + "\n"
-		text += "LOCAL_INSTALLED_MODULE_STEM := " + filepath.Base(file) + "\n"
-		text += "LOCAL_MODULE_CLASS := ETC\n"
-		text += "LOCAL_MODULE_PATH := " + installGroupPath + "\n"
-		text += "LOCAL_MODULE_RELATIVE_PATH := " + m.getInstallableProps().Relative_install_path + "\n"
-		text += "LOCAL_MODULE_TAGS := " + strings.Join(tags, " ") + "\n"
-		text += "LOCAL_PREBUILT_MODULE_FILE := " + file + "\n\n"
+		sb.WriteString("LOCAL_MODULE := " + moduleName + "\n")
+		sb.WriteString("LOCAL_INSTALLED_MODULE_STEM := " + filepath.Base(file) + "\n")
+		sb.WriteString("LOCAL_MODULE_CLASS := ETC\n")
+		sb.WriteString("LOCAL_MODULE_PATH := " + installGroupPath + "\n")
+		sb.WriteString("LOCAL_MODULE_RELATIVE_PATH := " + m.getInstallableProps().Relative_install_path + "\n")
+		sb.WriteString("LOCAL_MODULE_TAGS := " + strings.Join(tags, " ") + "\n")
+		sb.WriteString("LOCAL_PREBUILT_MODULE_FILE := " + file + "\n\n")
 
-		text += "include $(BUILD_PREBUILT)\n"
+		sb.WriteString("include $(BUILD_PREBUILT)\n")
 	}
-
-	return text
 }
 
-func (g *androidMkGenerator) generateCommonActions(m *generateCommon, ctx blueprint.ModuleContext, inouts []inout) string {
-	text := "##########################\ninclude $(CLEAR_VARS)\n\n"
+func (g *androidMkGenerator) generateCommonActions(sb *strings.Builder, m *generateCommon, ctx blueprint.ModuleContext, inouts []inout) {
+	sb.WriteString("##########################\ninclude $(CLEAR_VARS)\n\n")
 
 	// This is required to have $(local-generated-sources-dir) work as expected
-	text += "LOCAL_MODULE := " + m.Name() + "\n"
-	text += "LOCAL_MODULE_CLASS := STATIC_LIBRARIES\n"
-	text += outputsVarName(m) + " := \n"
-	text += outputDirVarName(m) + " := " + g.sourceOutputDir(m) + "\n"
-	text += "\n"
+	sb.WriteString("LOCAL_MODULE := " + m.Name() + "\n")
+	sb.WriteString("LOCAL_MODULE_CLASS := STATIC_LIBRARIES\n")
+	sb.WriteString(outputsVarName(m) + " := \n")
+	sb.WriteString(outputDirVarName(m) + " := " + g.sourceOutputDir(m) + "\n")
+	sb.WriteString("\n")
 
 	cmd, args, implicits, _ := m.getArgs(ctx)
 	utils.StripUnusedArgs(args, cmd)
@@ -667,89 +662,92 @@ func (g *androidMkGenerator) generateCommonActions(m *generateCommon, ctx bluepr
 		// directory should not be common.
 		outs := inout.out[0]
 		for _, key := range utils.SortedKeys(args) {
-			text += outs + ": " + key + ":= " + args[key] + "\n"
+			sb.WriteString(outs + ": " + key + ":= " + args[key] + "\n")
 		}
 
-		text += outs + ": in := " + ins + "\n"
-		text += outs + ": out := " + strings.Join(inout.out, " ") + "\n"
-		text += outs + ": depfile := " + inout.depfile + "\n"
-		text += outs + ": " + ins + " " + strings.Join(inout.implicitSrcs, " ") + "\n"
-		text += "\t" + cmd + "\n"
+		sb.WriteString(outs + ": in := " + ins + "\n")
+		sb.WriteString(outs + ": out := " + strings.Join(inout.out, " ") + "\n")
+		sb.WriteString(outs + ": depfile := " + inout.depfile + "\n")
+		sb.WriteString(outs + ": " + ins + " " + strings.Join(inout.implicitSrcs, " ") + "\n")
+		sb.WriteString("\t" + cmd + "\n")
 		if inout.depfile != "" {
 			// Convert the depfile file format as part of this rule.
-			text += g.transformDepFile("$(depfile)")
+			sb.WriteString(g.transformDepFile("$(depfile)"))
 			// ...and include it outside the rule.
-			text += g.includeDepFile(outs, inout.depfile)
+			sb.WriteString(g.includeDepFile(outs, inout.depfile))
 		}
-		text += outputsVarName(m) + " += " + outs + "\n"
+		sb.WriteString(outputsVarName(m) + " += " + outs + "\n")
 
 		for _, out := range inout.out[1:] {
-			text += out + ": " + outs + "\n"
-			text += outputsVarName(m) + " += " + out + "\n"
+			sb.WriteString(out + ": " + outs + "\n")
+			sb.WriteString(outputsVarName(m) + " += " + out + "\n")
 		}
-		text += "\n"
+		sb.WriteString("\n")
 	}
-	text += g.outputs(m) + ": " + strings.Join(implicits, " ") + "\n"
+	sb.WriteString(g.outputs(m) + ": " + strings.Join(implicits, " ") + "\n")
 
 	/* This will ensure that any dependencies will not be rebuilt in the case of no change */
-	text += ".KATI_RESTAT: " + g.outputs(m) + "\n"
-
-	return text
+	sb.WriteString(".KATI_RESTAT: " + g.outputs(m) + "\n")
 }
 
 func (g *androidMkGenerator) generateSourceActions(m *generateSource, ctx blueprint.ModuleContext, inouts []inout) {
 	if enabledAndRequired(m) {
-		text := g.generateCommonActions(&m.generateCommon, ctx, inouts)
-		text += installGeneratedFiles(m, ctx, m.generateCommon.Properties.Tags)
-		androidMkWriteString(ctx, m.altShortName(), text)
+		var sb strings.Builder
+		g.generateCommonActions(&sb, &m.generateCommon, ctx, inouts)
+		installGeneratedFiles(&sb, m, ctx, m.generateCommon.Properties.Tags)
+		androidMkWriteString(&sb, ctx, m.altShortName())
 	}
 }
 
 func (g *androidMkGenerator) transformSourceActions(m *transformSource, ctx blueprint.ModuleContext, inouts []inout) {
 	if enabledAndRequired(m) {
-		text := g.generateCommonActions(&m.generateCommon, ctx, inouts)
-		text += installGeneratedFiles(m, ctx, m.generateCommon.Properties.Tags)
-		androidMkWriteString(ctx, m.altShortName(), text)
+		var sb strings.Builder
+		g.generateCommonActions(&sb, &m.generateCommon, ctx, inouts)
+		installGeneratedFiles(&sb, m, ctx, m.generateCommon.Properties.Tags)
+		androidMkWriteString(&sb, ctx, m.altShortName())
 	}
 }
 
 func (g *androidMkGenerator) genStaticActions(m *generateStaticLibrary, ctx blueprint.ModuleContext, inouts []inout) {
 	if enabledAndRequired(m) {
-		text := g.generateCommonActions(&m.generateCommon, ctx, inouts)
+		var sb strings.Builder
+		g.generateCommonActions(&sb, &m.generateCommon, ctx, inouts)
 
 		// Add prebuilt outputs
 		includeDirs := utils.PrefixDirs(m.generateCommon.Properties.Export_gen_include_dirs, g.sourceOutputDir(&m.generateCommon))
-		text += declarePrebuiltStaticLib(m.altShortName(), getLibraryGeneratedPath(m, g),
+		declarePrebuiltStaticLib(&sb, m.altShortName(), getLibraryGeneratedPath(m, g),
 			strings.Join(includeDirs, " "),
 			m.generateCommon.Properties.Target != tgtTypeHost)
 
-		androidMkWriteString(ctx, m.altShortName(), text)
+		androidMkWriteString(&sb, ctx, m.altShortName())
 	}
 }
 
 func (g *androidMkGenerator) genSharedActions(m *generateSharedLibrary, ctx blueprint.ModuleContext, inouts []inout) {
 	if enabledAndRequired(m) {
-		text := g.generateCommonActions(&m.generateCommon, ctx, inouts)
+		var sb strings.Builder
+		g.generateCommonActions(&sb, &m.generateCommon, ctx, inouts)
 
 		// Add prebuilt outputs
 		includeDirs := utils.PrefixDirs(m.generateCommon.Properties.Export_gen_include_dirs, g.sourceOutputDir(&m.generateCommon))
-		text += declarePrebuiltSharedLib(m.altShortName(), getLibraryGeneratedPath(m, g),
+		declarePrebuiltSharedLib(&sb, m.altShortName(), getLibraryGeneratedPath(m, g),
 			strings.Join(includeDirs, " "),
 			m.generateCommon.Properties.Target != tgtTypeHost)
 
-		androidMkWriteString(ctx, m.altShortName(), text)
+		androidMkWriteString(&sb, ctx, m.altShortName())
 	}
 }
 
 func (g *androidMkGenerator) genBinaryActions(m *generateBinary, ctx blueprint.ModuleContext, inouts []inout) {
 	if enabledAndRequired(m) {
-		text := g.generateCommonActions(&m.generateCommon, ctx, inouts)
+		var sb strings.Builder
+		g.generateCommonActions(&sb, &m.generateCommon, ctx, inouts)
 
 		// Add prebuilt outputs
-		text += declarePrebuiltBinary(m.altShortName(), getLibraryGeneratedPath(m, g),
+		declarePrebuiltBinary(&sb, m.altShortName(), getLibraryGeneratedPath(m, g),
 			m.generateCommon.Properties.Target != tgtTypeHost)
 
-		androidMkWriteString(ctx, m.altShortName(), text)
+		androidMkWriteString(&sb, ctx, m.altShortName())
 	}
 }
 
@@ -794,7 +792,7 @@ func generatesAndroidIncFile(m blueprint.Module) bool {
 }
 
 func (s *androidMkOrderer) GenerateBuildActions(ctx blueprint.SingletonContext) {
-
+	var sb strings.Builder
 	var order androidMkFileSlice
 	ctx.VisitAllModules(func(m blueprint.Module) {
 		di, ok := m.(androidNaming)
@@ -812,7 +810,6 @@ func (s *androidMkOrderer) GenerateBuildActions(ctx blueprint.SingletonContext) 
 		}
 	})
 
-	text := ""
 	// Quick and dirty alphabetical topological sort
 	for len(order) > 0 {
 		lowindex := -1
@@ -835,7 +832,7 @@ func (s *androidMkOrderer) GenerateBuildActions(ctx blueprint.SingletonContext) 
 			panic(fmt.Errorf("unmet or circular dependency. %d remaining.\n%s", len(order), deps))
 		}
 
-		text += "include $(BOB_ANDROIDMK_DIR)/" + order[lowindex].Name + ".inc\n"
+		sb.WriteString("include $(BOB_ANDROIDMK_DIR)/" + order[lowindex].Name + ".inc\n")
 
 		for i := range order {
 			newdeps := []string{}
@@ -848,7 +845,7 @@ func (s *androidMkOrderer) GenerateBuildActions(ctx blueprint.SingletonContext) 
 		}
 		order = append(order[:lowindex], order[lowindex+1:]...)
 	}
-	writeIfChanged(filepath.Join(builddir, "Android.inc"), text)
+	writeIfChanged(filepath.Join(builddir, "Android.inc"), &sb)
 }
 
 func (g *androidMkGenerator) moduleOutputDir(moduleName string) string {
@@ -894,33 +891,33 @@ func (g *androidMkGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.
 	if !enabledAndRequired(m) {
 		return
 	}
-
-	text := "##########################\ninclude $(CLEAR_VARS)\n\n"
-	text += "LOCAL_MODULE := " + m.altShortName() + "\n"
-	text += "LOCAL_MODULE_CLASS := KERNEL_MODULES\n"
-	text += "LOCAL_CLANG := false\n"
-	text += "LOCAL_MODULE_TAGS := " + strings.Join(m.Properties.Tags, " ") + "\n\n"
+	var sb strings.Builder
+	sb.WriteString("##########################\ninclude $(CLEAR_VARS)\n\n")
+	sb.WriteString("LOCAL_MODULE := " + m.altShortName() + "\n")
+	sb.WriteString("LOCAL_MODULE_CLASS := KERNEL_MODULES\n")
+	sb.WriteString("LOCAL_CLANG := false\n")
+	sb.WriteString("LOCAL_MODULE_TAGS := " + strings.Join(m.Properties.Tags, " ") + "\n\n")
 
 	sources := m.Properties.GetSrcs(ctx)
 
-	text += "LOCAL_SRC_FILES :=" + newlineSeparatedList(sources)
+	sb.WriteString("LOCAL_SRC_FILES :=" + newlineSeparatedList(sources))
 
 	// Now the build rules (i.e. what would be done by an 'include
 	// $(BUILD_KERNEL_MODULE)', if there was one).
-	text += "TARGET_OUT_$(LOCAL_MODULE_CLASS) := $(TARGET_OUT)/lib/modules\n"
+	sb.WriteString("TARGET_OUT_$(LOCAL_MODULE_CLASS) := $(TARGET_OUT)/lib/modules\n")
 	installGroupPath, ok := getInstallGroupPath(ctx)
 	if ok {
-		text += "LOCAL_MODULE_PATH := " + installGroupPath + "\n"
-		text += "LOCAL_MODULE_RELATIVE_PATH := " + m.Properties.Relative_install_path + "\n"
+		sb.WriteString("LOCAL_MODULE_PATH := " + installGroupPath + "\n")
+		sb.WriteString("LOCAL_MODULE_RELATIVE_PATH := " + m.Properties.Relative_install_path + "\n")
 	} else {
-		text += "LOCAL_UNINSTALLABLE_MODULE := true\n"
+		sb.WriteString("LOCAL_UNINSTALLABLE_MODULE := true\n")
 	}
-	text += "LOCAL_MODULE_SUFFIX := .ko\n"
+	sb.WriteString("LOCAL_MODULE_SUFFIX := .ko\n")
 	if m.Properties.Owner != "" {
-		text += "LOCAL_MODULE_OWNER := " + m.Properties.Owner + "\n"
-		text += "LOCAL_PROPRIETARY_MODULE := true\n"
+		sb.WriteString("LOCAL_MODULE_OWNER := " + m.Properties.Owner + "\n")
+		sb.WriteString("LOCAL_PROPRIETARY_MODULE := true\n")
 	}
-	text += "include $(BUILD_SYSTEM)/base_rules.mk\n\n"
+	sb.WriteString("include $(BUILD_SYSTEM)/base_rules.mk\n\n")
 
 	args := m.generateKbuildArgs(ctx)
 	args["sources"] = "$(addprefix $(LOCAL_PATH)/,$(LOCAL_SRC_FILES))"
@@ -929,14 +926,14 @@ func (g *androidMkGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.
 
 	// Create a target-specific variable declaration for each required parameter.
 	for _, key := range utils.SortedKeys(args) {
-		text += fmt.Sprintf("$(LOCAL_BUILT_MODULE): %s := %s\n", key, args[key])
+		sb.WriteString(fmt.Sprintf("$(LOCAL_BUILT_MODULE): %s := %s\n", key, args[key]))
 	}
 
-	text += "\n$(LOCAL_BUILT_MODULE): $(LOCAL_MODULE_MAKEFILE_DEP) " +
+	sb.WriteString("\n$(LOCAL_BUILT_MODULE): $(LOCAL_MODULE_MAKEFILE_DEP) " +
 		args["sources"] + " " +
 		args["kmod_build"] + " " +
-		strings.Join(m.extraSymbolsFiles(ctx), " ") + "\n"
-	text += "\tmkdir -p \"$(@D)\"\n"
+		strings.Join(m.extraSymbolsFiles(ctx), " ") + "\n")
+	sb.WriteString("\tmkdir -p \"$(@D)\"\n")
 	cmd := "python $(kmod_build) --output $@ --depfile $@.d " +
 		"--common-root $(local_path) " +
 		"--module-dir \"$(output_module_dir)\" $(extra_includes) " +
@@ -944,18 +941,18 @@ func (g *androidMkGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.
 		"--kernel \"$(kernel_dir)\" --cross-compile \"$(kernel_compiler)\" " +
 		"$(kbuild_options) --extra-cflags \"$(extra_cflags)\" $(make_args)"
 
-	text += "\techo " + cmd + "\n"
-	text += "\t" + cmd + "\n"
-	text += g.transformDepFile("$@.d") + "\n"
+	sb.WriteString("\techo " + cmd + "\n")
+	sb.WriteString("\t" + cmd + "\n")
+	sb.WriteString(g.transformDepFile("$@.d") + "\n")
 
-	text += g.includeDepFile("$(LOCAL_BUILT_MODULE)", "$(LOCAL_BUILT_MODULE).d")
+	sb.WriteString(g.includeDepFile("$(LOCAL_BUILT_MODULE)", "$(LOCAL_BUILT_MODULE).d"))
 
 	// The Module.symvers file is generated during Kbuild, but make doesn't
 	// support multiple output files in a rule, so add it as a dependency
 	// of the module.
-	text += fmt.Sprintf("\n$(dir $(LOCAL_BUILT_MODULE))/Module.symvers: $(LOCAL_BUILT_MODULE)\n")
+	sb.WriteString(fmt.Sprintf("\n$(dir $(LOCAL_BUILT_MODULE))/Module.symvers: $(LOCAL_BUILT_MODULE)\n"))
 
-	androidMkWriteString(ctx, m.altShortName(), text)
+	androidMkWriteString(&sb, ctx, m.altShortName())
 }
 
 func androidMkOrdererFactory() blueprint.Singleton {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2019 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -195,7 +195,8 @@ func Trim(args []string) []string {
 
 // Join multiple lists of strings. This replaces appending multiple arrays
 // together before calling strings.Join().
-func Join(lists ...[]string) (joined string) {
+func Join(lists ...[]string) string {
+	var sb strings.Builder
 	const sep = " "
 	first := true
 
@@ -203,15 +204,15 @@ func Join(lists ...[]string) (joined string) {
 		listJoined := strings.Join(list, sep)
 		if len(listJoined) > 0 {
 			if !first {
-				joined += sep
+				sb.WriteString(sep)
 			} else {
 				first = false
 			}
-			joined += listJoined
+			sb.WriteString(listJoined)
 		}
 	}
 
-	return
+	return sb.String()
 }
 
 // IsExecutable returns true if the given file exists and is executable


### PR DESCRIPTION
Profiling of the Bob project shows that the utilization of the
string builder which has been introduced in Go 1.10 improves builder
execution time on Android

Change-Id: I023bb9bcfa94b902d9ec48089606bfceec0b7f67
Signed-off-by: Michal Widera <michal.widera@arm.com>