### PR TITLE
Add source dir prefix to the ninja

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -652,7 +652,7 @@ func (g *androidMkGenerator) generateCommonActions(sb *strings.Builder, m *gener
 			args["srcs_generated"] = strings.Join(sources, " ")
 		}
 
-		ins := utils.Join(utils.PrefixDirs(inout.srcIn, g.sourcePrefix()), inout.genIn)
+		ins := utils.Join(inout.srcIn, inout.genIn)
 
 		// Make does not cleanly support multiple out-files
 		// To handle that, we output the rule only on the first file, and let every other output

--- a/core/gen_library.go
+++ b/core/gen_library.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2019 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 
 	"github.com/google/blueprint"
+
+	"github.com/ARM-software/bob-build/utils"
 )
 
 // Support generation of static and shared libraries
@@ -62,7 +64,7 @@ func getLibraryGeneratedPath(m generateLibraryInterface, g generatorBackend) str
 func inouts(m generateLibraryInterface, ctx blueprint.ModuleContext) []inout {
 	var io inout
 	g := getBackend(ctx)
-	io.srcIn = m.getSources(ctx)
+	io.srcIn = utils.PrefixDirs(m.getSources(ctx), g.sourcePrefix())
 	io.genIn = getGeneratedFiles(ctx)
 	io.out = m.outputs(g)
 	return []inout{io}

--- a/core/generated.go
+++ b/core/generated.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2019 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -386,7 +386,7 @@ func (m *generateCommon) getAliasList() []string {
 func (m *generateSource) Inouts(ctx blueprint.ModuleContext) []inout {
 	var io inout
 	g := getBackend(ctx)
-	io.srcIn = m.generateCommon.Properties.GetSrcs(ctx)
+	io.srcIn = utils.PrefixDirs(m.getSources(ctx), g.sourcePrefix())
 	io.genIn = utils.NewStringSlice(m.generateCommon.Properties.SourceProps.Specials, getGeneratedFiles(ctx))
 	io.out = m.outputs(g)
 	if m.Properties.Depfile != "" {
@@ -450,8 +450,8 @@ func (m *transformSource) Inouts(ctx blueprint.ModuleContext) []inout {
 	// empty, and the other has a single element.
 	empty := []string{}
 
-	for _, src := range m.generateCommon.Properties.GetSrcs(ctx) {
-		ins := []string{src}
+	for _, src := range m.getSources(ctx) {
+		ins := []string{filepath.Join(g.sourcePrefix(), src)}
 		outs := []string{}
 		depfile := ""
 		implicitSrcs := []string{}


### PR DESCRIPTION
This change adds source directory prefix to ensure that every ninja
build element have a proper path and doesn't relies on relative path.
To avoid colisions in path definition for Linux and Android
implementation source getting function has been split to relative
path and work directory path.

Change-Id: I7e808f70981ebe1e4909e03ee9694b5636cd7f6c
Signed-off-by: Michal Widera <michal.widera@arm.com>