### PR TITLE
Bob bootstrap improvements

### DIFF
--- a/.travis/run_build_tests.sh
+++ b/.travis/run_build_tests.sh
@@ -5,7 +5,7 @@ trap "echo '<------------- run_build_tests.sh failed'" ERR
 export TEST_NON_ASCII_IN_ENV_HASH='ó'
 cd ${BOB_ROOT}/tests/
 rm -rf build-test # Cleanup test directory
-BUILDDIR=build-test ./bootstrap
+./bootstrap -o build-test
 cd build-test
 # Test by explicitly requesting the `bob_tests` alias, which should include all
 # test cases, including alias tests, which can't just set `build_by_default`.

--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,8 +18,11 @@
 # SRCDIR - Path to base of source tree. This can be relative to PWD or absolute.
 # BUILDDIR - Build output directory. This can be relative to PWD or absolute.
 # CONFIGNAME - Name of the configuration file.
+# BLUEPRINT_LIST_FILE - Path to file listing all Blueprint input files.
+#                       This can be relative to PWD or absolute.
 # BOB_CONFIG_OPTS - Configuration options to be used when calling the
 #                   configuration system.
+# BOB_CONFIG_PLUGINS - Configuration system plugins to use
 # TOPNAME - Name used for Bob Blueprint files.
 
 # The location that this script is called from determines the working
@@ -60,14 +63,19 @@ if [[ -z "$BOB_CONFIG_PLUGINS" ]]; then
   export BOB_CONFIG_PLUGINS=""
 fi
 
-# Create the build directory
-mkdir -p "$BUILDDIR"
+if [ "${BUILDDIR}" = "." ] ; then
+    WORKDIR=.
+else
+    # Create the build directory
+    mkdir -p "$BUILDDIR"
 
-# Relative path from build directory to working directory
-WORKDIR=$(relative_path "${BUILDDIR}" $(pwd))
+    # Relative path from build directory to working directory
+    WORKDIR=$(relative_path "${BUILDDIR}" $(pwd))
+fi
 
-# Calculate Bob directory relative to working directory and absolute
+# Calculate Bob directory relative to working directory, build directory and absolute
 BOB_DIR="$(relative_path $(pwd) "${SCRIPT_DIR}")"
+BOB_DIR_FROM_BUILD="$(relative_path $(bob_realpath "${BUILDDIR}") "${SCRIPT_DIR}")"
 BOB_DIR_ABS="$(bob_realpath "${SCRIPT_DIR}")"
 
 export BOOTSTRAP="${BOB_DIR}/bootstrap.bash"
@@ -100,11 +108,11 @@ rsync -c "${BUILDDIR}/.bob.bootstrap.tmp" "${BUILDDIR}/.bob.bootstrap"
 
 if [ ${SRCDIR:0:1} != '/' ]; then
     # Use relative symlinks
-    ln -sf "${WORKDIR}/${BOB_DIR}/config.bash" "${BUILDDIR}/config"
-    ln -sf "${WORKDIR}/${BOB_DIR}/menuconfig.bash" "${BUILDDIR}/menuconfig"
-    ln -sf "${WORKDIR}/${BOB_DIR}/bob.bash" "${BUILDDIR}/bob"
-    ln -sf "${WORKDIR}/${BOB_DIR}/bob_graph.bash" "${BUILDDIR}/bob_graph"
-    ln -sf "${WORKDIR}/${BOB_DIR}/config_system/mconfigfmt.py" "${BUILDDIR}/mconfigfmt"
+    ln -sf "${BOB_DIR_FROM_BUILD}/config.bash" "${BUILDDIR}/config"
+    ln -sf "${BOB_DIR_FROM_BUILD}/menuconfig.bash" "${BUILDDIR}/menuconfig"
+    ln -sf "${BOB_DIR_FROM_BUILD}/bob.bash" "${BUILDDIR}/bob"
+    ln -sf "${BOB_DIR_FROM_BUILD}/bob_graph.bash" "${BUILDDIR}/bob_graph"
+    ln -sf "${BOB_DIR_FROM_BUILD}/config_system/mconfigfmt.py" "${BUILDDIR}/mconfigfmt"
 else
     # Use absolute symlinks
     ln -sf "${BOB_DIR_ABS}/config.bash" "${BUILDDIR}/config"

--- a/tests/bootstrap
+++ b/tests/bootstrap
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,20 +15,67 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is expected to be called from within the bob/tests directory
-#
 # This script is always using a relative path to SRCDIR, so BUILDDIR
-# and SRCDIR should be moved together (i.e. BUILDDIR is not
+# and SRCDIR should be moved together (i.e. BUILDDIR location is not
 # independent of SRCDIR).
 
+BASENAME=$(basename $0)
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
-if [ "$SCRIPT_DIR" != "." ]; then
-	echo "SCRIPT_DIR:$SCRIPT_DIR"
-	echo "bootstrap needs to be run inside tests directory"
-	exit 1
-fi
+
+function usage() {
+    cat <<EOF
+$BASENAME
+
+Bootstraps an output directory for Bob tests. This script allows
+working directory and build output directory to be independently
+set.
+
+Usage:
+ source_dir/$BASENAME -o path
+
+Options
+  -o DIR  Output directory. Defaults to build.
+  -h      Help text
+
+The working directory is set to match the current working directory.
+
+The build output directory is set to the directory specified by the -o
+option.
+
+The source directory is inferred from the location of $BASENAME, and
+cannot be independently changed.
+
+EOF
+}
 
 source "${SCRIPT_DIR}/bootstrap_utils.sh"
+
+PARAMS=$(getopt -o "o:h" --name ${BASENAME} -- "$@")
+
+eval set -- "$PARAMS"
+unset PARAMS
+
+while true ; do
+    case $1 in
+        -o)
+            BUILDDIR=$2
+            shift 2
+            ;;
+        -h)
+            usage
+            exit
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "Unrecognized option $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
 
 # Select a BUILDDIR if not provided one
 if [[ -z "$BUILDDIR" ]]; then
@@ -43,15 +90,15 @@ create_link .. "${SCRIPT_DIR}/bob"
 # Bootstrap Bob
 export CONFIGNAME="bob.config"
 export TOPNAME="build.bp"
-export SRCDIR="."
+export SRCDIR="${SCRIPT_DIR}"
 export BUILDDIR
 export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 
-${SCRIPT_DIR}/bob/bootstrap_linux.bash
+"${SCRIPT_DIR}/bob/bootstrap_linux.bash"
 
 # Pick up some info that bob has worked out
 BOOTSTRAP=".bob.bootstrap"
-source ${BUILDDIR}/${BOOTSTRAP}
+source "${BUILDDIR}/${BOOTSTRAP}"
 
 # Setup the buildme script to just run bob
 ln -sf "bob" "${BUILDDIR}/buildme"


### PR DESCRIPTION
Update the common bootstrap script for Bob so that it allows source
directory, working directory and build directory to be set
independently.

Update test bootstrap to allow us to test this. There are still some
fixes that need to be done in Bob in order for the tests to work when
bootstrapped from outside the test directory. Because of this the
example bootstrap script is left as is for now too. However the check
in bob/tests/bootstrap is removed so that we're able to easily check
if things are working.

Change-Id: I31e3e6cafd004a6a0329b032d39c68129cf5440a
Signed-off-by: David Kilroy <david.kilroy@arm.com>