### PR TITLE
Prefix include directories with ${SrcDir}

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -212,7 +212,7 @@ func (m *library) GenerateBuildAction(sb *strings.Builder, binType int, ctx blue
 
 	sb.WriteString("LOCAL_C_INCLUDES := " + strings.Join(includes, " ") + "\n")
 	cflagsList := utils.NewStringSlice(m.Properties.Cflags, m.Properties.Export_cflags)
-	_, exportedCflags := m.GetExportedVariables(ctx)
+	_, _, exportedCflags := m.GetExportedVariables(ctx)
 	cflagsList = append(cflagsList, exportedCflags...)
 	sb.WriteString("LOCAL_CFLAGS := " + strings.Join(utils.Filter(cflagsList, moduleCompileFlags), " ") + "\n")
 	sb.WriteString("LOCAL_CPPFLAGS := " + strings.Join(utils.Filter(m.Properties.Cxxflags, moduleCompileFlags), " ") + "\n")

--- a/core/library.go
+++ b/core/library.go
@@ -373,7 +373,7 @@ func (l *library) GetGeneratedHeaders(ctx blueprint.ModuleContext) (includeDirs 
 	return
 }
 
-func (l *library) GetExportedVariables(ctx blueprint.ModuleContext) (exportedIncludes, exportedCflags []string) {
+func (l *library) GetExportedVariables(ctx blueprint.ModuleContext) (expLocalIncludes, expIncludes, expCflags []string) {
 	visited := map[string]bool{}
 	ctx.VisitDirectDeps(func(dep blueprint.Module) {
 
@@ -390,19 +390,14 @@ func (l *library) GetExportedVariables(ctx blueprint.ModuleContext) (exportedInc
 
 			switch lib := dep.(type) {
 			case *staticLibrary:
-				// Static libraries dependencies are in reversed order
-				// so prepend to match the specified order
-				exportedIncludes = append(exportedIncludes, lib.Properties.Export_include_dirs...)
-				exportedIncludes = append(exportedIncludes, lib.Properties.Export_local_include_dirs...)
-				exportedCflags = append(exportedCflags, lib.Properties.Export_cflags...)
+				expLocalIncludes = append(expLocalIncludes, lib.Properties.Export_local_include_dirs...)
+				expIncludes = append(expIncludes, lib.Properties.Export_include_dirs...)
+				expCflags = append(expCflags, lib.Properties.Export_cflags...)
 
 			case *sharedLibrary:
-				exportedIncludes = append(exportedIncludes,
-					lib.Properties.Export_local_include_dirs...)
-				exportedIncludes = append(exportedIncludes,
-					lib.Properties.Export_include_dirs...)
-				exportedCflags = append(exportedCflags,
-					lib.Properties.Export_cflags...)
+				expLocalIncludes = append(expLocalIncludes, lib.Properties.Export_local_include_dirs...)
+				expIncludes = append(expIncludes, lib.Properties.Export_include_dirs...)
+				expCflags = append(expCflags, lib.Properties.Export_cflags...)
 			}
 		}
 	})


### PR DESCRIPTION
This should allow the output directory to be used as the working
directory.

Modify GetExportedVariables to return local and global include path
separately, so we can prefix ${SrcDir} without calling IsAbs(). The
comment that is being removed in this function is redundant and no
longer applies to the code (this applied prior to the graph orderring
algorithm).

Change-Id: I1db6a7d431954fed32297ff5e602dec556281938
Signed-off-by: David Kilroy <david.kilroy@arm.com>