### PR TITLE
Support passing flags to pkg-config

### DIFF
--- a/config_system/__init__.py
+++ b/config_system/__init__.py
@@ -15,4 +15,5 @@
 
 from .general import init_config, get_config, get_config_bool, \
     get_config_int, get_config_string,  get_config_list, read_config, \
-    set_config, can_enable, get_options_selecting, get_options_depending_on
+    set_config, can_enable, get_options_selecting, get_options_depending_on, \
+    get_mconfig_dir

--- a/config_system/general.py
+++ b/config_system/general.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import re
 import logging
 
@@ -156,11 +157,19 @@ def enforce_dependent_values(auto_fix=False):
         elif c['datatype'] == 'int':
             set_config_internal(i, 0)
 
+__mconfig_dir = ""
+def get_mconfig_dir():
+    """
+    Retrieve the path to the input option database.
+    """
+    return __mconfig_dir
+
 def init_config(options_filename, ignore_missing=False):
     from . import lex
     from . import lex_wrapper
     from . import syntax
 
+    global __mconfig_dir
     global configuration
     global menu_data
     try:
@@ -173,6 +182,7 @@ def init_config(options_filename, ignore_missing=False):
     except syntax.ParseError as e:
         logger.debug("Parse error")
         exit(1)
+    __mconfig_dir = os.path.dirname(options_filename)
     menu_data = menu_parse(configuration)
 
     set_initial_values()


### PR DESCRIPTION
Also support the string "%MCONFIGDIR%" in PKG_CONFIG_FLAGS and
PKG_CONFIG_PATH, replacing it with the path to the database file
during host explore. This allows pkg-config to be pointed at files
within the source tree of a project.

Change-Id: Ic39da0e96a24cdd575c61ad5bbee6ee2f465997e
Signed-off-by: David Kilroy <david.kilroy@arm.com>