### PR TITLE
Transform variables to strong types

### DIFF
--- a/core/defaults.go
+++ b/core/defaults.go
@@ -27,15 +27,15 @@ type defaults struct {
 	library
 }
 
-func (m *defaults) supportedVariants() []string {
-	return []string{tgtTypeHost, tgtTypeTarget}
+func (m *defaults) supportedVariants() []tgtType {
+	return []tgtType{tgtTypeHost, tgtTypeTarget}
 }
 
 func (m *defaults) disable() {
 	panic("disable() called on Default")
 }
 
-func (m *defaults) setVariant(variant string) {
+func (m *defaults) setVariant(variant tgtType) {
 	m.library.setVariant(variant)
 }
 
@@ -67,10 +67,10 @@ func defaultDepsMutator(mctx blueprint.BottomUpMutatorContext) {
 	}
 	if gsc, ok := getGenerateCommon(mctx.Module()); ok {
 		if len(gsc.Properties.Flag_defaults) > 0 {
-			tgtType := gsc.Properties.Target
-			if !(tgtType == tgtTypeHost || tgtType == tgtTypeTarget) {
+			tgt := gsc.Properties.Target
+			if !(tgt == tgtTypeHost || tgt == tgtTypeTarget) {
 				panic(fmt.Errorf("Module %s uses flag_defaults '%v' but has invalid target type '%s'",
-					mctx.ModuleName(), gsc.Properties.Flag_defaults, tgtType))
+					mctx.ModuleName(), gsc.Properties.Flag_defaults, tgt))
 			}
 			mctx.AddDependency(mctx.Module(), defaultDepTag, gsc.Properties.Flag_defaults...)
 		}

--- a/core/external_library.go
+++ b/core/external_library.go
@@ -36,9 +36,9 @@ func (m *externalLib) shortName() string    { return m.Name() }
 func (m *externalLib) outputs(g generatorBackend) []string { return []string{} }
 
 // Implement the splittable interface so "normal" libraries can depend on external ones.
-func (m *externalLib) supportedVariants() []string          { return []string{tgtTypeHost, tgtTypeTarget} }
+func (m *externalLib) supportedVariants() []tgtType         { return []tgtType{tgtTypeHost, tgtTypeTarget} }
 func (m *externalLib) disable()                             {}
-func (m *externalLib) setVariant(string)                    {}
+func (m *externalLib) setVariant(tgtType)                   {}
 func (m *externalLib) getSplittableProps() *SplittableProps { return &SplittableProps{} }
 
 // External libraries have no actions - they are already built.

--- a/core/gen_library.go
+++ b/core/gen_library.go
@@ -72,8 +72,8 @@ func inouts(m generateLibraryInterface, ctx blueprint.ModuleContext) []inout {
 
 //// Support Splittable
 
-func (m *generateLibrary) supportedVariants() []string {
-	return []string{m.generateCommon.Properties.Target}
+func (m *generateLibrary) supportedVariants() []tgtType {
+	return []tgtType{m.generateCommon.Properties.Target}
 }
 
 func (m *generateLibrary) disable() {
@@ -81,7 +81,7 @@ func (m *generateLibrary) disable() {
 	panic("disable() called on GenerateLibrary")
 }
 
-func (m *generateLibrary) setVariant(variant string) {
+func (m *generateLibrary) setVariant(variant tgtType) {
 	// No need to actually track this, as a single target is always supported
 }
 

--- a/core/generated.go
+++ b/core/generated.go
@@ -109,7 +109,7 @@ type GenerateProps struct {
 	Flag_defaults []string
 
 	// The target type - must be either "host" or "target"
-	Target string
+	Target tgtType
 }
 
 type generateCommon struct {
@@ -175,7 +175,7 @@ func (m *generateCommon) features() *Features {
 	return &m.Properties.Features
 }
 
-func (m *generateCommon) getTarget() string {
+func (m *generateCommon) getTarget() tgtType {
 	return m.Properties.Target
 }
 
@@ -187,15 +187,15 @@ func (m *generateCommon) getInstallDepPhonyNames(ctx blueprint.ModuleContext) []
 	return getShortNamesForDirectDepsWithTags(ctx, installDepTag)
 }
 
-func (m *generateCommon) supportedVariants() []string {
-	return []string{m.Properties.Target}
+func (m *generateCommon) supportedVariants() []tgtType {
+	return []tgtType{m.Properties.Target}
 }
 
 func (m *generateCommon) disable() {
 	*m.Properties.Enabled = false
 }
 
-func (m *generateCommon) setVariant(variant string) {
+func (m *generateCommon) setVariant(variant tgtType) {
 	if variant != m.Properties.Target {
 		panic(fmt.Errorf("Variant mismatch: %s != %s", variant, m.Properties.Target))
 	}
@@ -271,10 +271,10 @@ func (m *generateSource) topLevelProperties() []interface{} {
 
 // Returns the tool binary for a generateSource module. This is different from the "tool"
 // in that it used to depend on a bob_binary module
-func (m *generateCommon) getHostBin(ctx blueprint.ModuleContext) (string, string) {
+func (m *generateCommon) getHostBin(ctx blueprint.ModuleContext) (string, tgtType) {
 	g := getBackend(ctx)
 	toolBin := ""
-	toolTarget := ""
+	toolTarget := tgtTypeUnknown
 
 	ctx.VisitDirectDepsIf(
 		func(m blueprint.Module) bool {
@@ -316,7 +316,7 @@ func getDependentArgsAndFiles(ctx blueprint.ModuleContext, args map[string]strin
 	return
 }
 
-func (m *generateCommon) getArgs(ctx blueprint.ModuleContext) (string, map[string]string, []string, string) {
+func (m *generateCommon) getArgs(ctx blueprint.ModuleContext) (string, map[string]string, []string, tgtType) {
 	g := getBackend(ctx)
 
 	tc := g.getToolchain(m.Properties.Target)

--- a/core/library.go
+++ b/core/library.go
@@ -167,7 +167,7 @@ type BuildProps struct {
 	// Compiler prefix for kernel build
 	Kernel_compiler string
 
-	TargetType string `blueprint:"mutated"`
+	TargetType tgtType `blueprint:"mutated"`
 }
 
 // A Build represents the whole tree of properties for a 'library' object,
@@ -265,7 +265,7 @@ func (l *library) features() *Features {
 	return &l.Properties.Features
 }
 
-func (l *library) getTarget() string {
+func (l *library) getTarget() tgtType {
 	return l.Properties.TargetType
 }
 
@@ -285,12 +285,12 @@ func (l *library) getAliasList() []string {
 	return l.Properties.getAliasList()
 }
 
-func (l *library) supportedVariants() (tgtTypes []string) {
+func (l *library) supportedVariants() (tgts []tgtType) {
 	if l.Properties.isHostSupported() {
-		tgtTypes = append(tgtTypes, tgtTypeHost)
+		tgts = append(tgts, tgtTypeHost)
 	}
 	if l.Properties.isTargetSupported() {
-		tgtTypes = append(tgtTypes, tgtTypeTarget)
+		tgts = append(tgts, tgtTypeTarget)
 	}
 	return
 }
@@ -300,7 +300,7 @@ func (l *library) disable() {
 	l.Properties.Enabled = &f
 }
 
-func (l *library) setVariant(tgt string) {
+func (l *library) setVariant(tgt tgtType) {
 	l.Properties.TargetType = tgt
 }
 
@@ -321,7 +321,7 @@ func (l *library) altName() string {
 
 func (l *library) altShortName() string {
 	if len(l.supportedVariants()) > 1 {
-		return l.altName() + "__" + l.Properties.TargetType
+		return l.altName() + "__" + string(l.Properties.TargetType)
 	}
 	return l.altName()
 }
@@ -331,7 +331,7 @@ func (l *library) altShortName() string {
 // disambiguate.
 func (l *library) shortName() string {
 	if len(l.supportedVariants()) > 1 {
-		return l.Name() + "__" + l.Properties.TargetType
+		return l.Name() + "__" + string(l.Properties.TargetType)
 	}
 	return l.Name()
 }

--- a/core/linux.go
+++ b/core/linux.go
@@ -93,19 +93,19 @@ type singleOutputModule interface {
 
 type targetableModule interface {
 	singleOutputModule
-	getTarget() string
+	getTarget() tgtType
 }
 
 // Where to put generated shared libraries to simplify linking
 // As long as the module is targetable, we can infer the library path
 func getSharedLibLinkPath(t targetableModule) string {
-	return filepath.Join("${BuildDir}", t.getTarget(), "shared", t.outputName()+".so")
+	return filepath.Join("${BuildDir}", string(t.getTarget()), "shared", t.outputName()+".so")
 }
 
 // Where to put generated binaries in order to make sure generated binaries
 // are available in the same directory as compiled binaries
 func getBinaryPath(t targetableModule) string {
-	return filepath.Join("${BuildDir}", t.getTarget(), "executable", t.outputName())
+	return filepath.Join("${BuildDir}", string(t.getTarget()), "executable", t.outputName())
 }
 
 // Generate the build actions for a generateSource module and populates the outputs.
@@ -115,7 +115,7 @@ func (g *linuxGenerator) generateCommonActions(m *generateCommon, ctx blueprint.
 
 	ldLibraryPath := ""
 	if _, ok := args["host_bin"]; ok {
-		ldLibraryPath += "LD_LIBRARY_PATH=" + filepath.Join("${BuildDir}", hostTarget, "shared") + ":$$LD_LIBRARY_PATH "
+		ldLibraryPath += "LD_LIBRARY_PATH=" + filepath.Join("${BuildDir}", string(hostTarget), "shared") + ":$$LD_LIBRARY_PATH "
 	}
 	utils.StripUnusedArgs(args, cmd)
 	args["depfile"] = ""
@@ -248,7 +248,7 @@ var cxxRule = pctx.StaticRule("cxx",
 	}, "cxxcompiler", "cflags", "cxxflags", "build_wrapper")
 
 func (l *library) ObjDir() string {
-	return filepath.Join("${BuildDir}", l.Properties.TargetType, "objects", l.Name()) + string(os.PathSeparator)
+	return filepath.Join("${BuildDir}", string(l.Properties.TargetType), "objects", l.Name()) + string(os.PathSeparator)
 }
 
 // This function has common support to compile objs for static libs, shared libs and binaries.
@@ -401,7 +401,7 @@ func (l *library) GetStaticLibs(ctx blueprint.ModuleContext) []string {
 }
 
 func (g *linuxGenerator) staticLibOutputDir(m *staticLibrary) string {
-	return filepath.Join("${BuildDir}", m.Properties.TargetType, "static")
+	return filepath.Join("${BuildDir}", string(m.Properties.TargetType), "static")
 }
 
 // The rule for building a static library
@@ -518,15 +518,15 @@ func (l *library) getSharedLibFlags(ctx blueprint.ModuleContext) (flags []string
 }
 
 func (l *library) getSharedLibraryDir() string {
-	return filepath.Join("${BuildDir}", l.Properties.TargetType, "shared")
+	return filepath.Join("${BuildDir}", string(l.Properties.TargetType), "shared")
 }
 
 func (g *linuxGenerator) sharedLibOutputDir(m *sharedLibrary) string {
 	return m.library.getSharedLibraryDir()
 }
 
-func (g *linuxGenerator) sharedLibsDir(targetType string) string {
-	return filepath.Join("${BuildDir}", targetType, "shared")
+func (g *linuxGenerator) sharedLibsDir(tgt tgtType) string {
+	return filepath.Join("${BuildDir}", string(tgt), "shared")
 }
 
 func (l *library) getCommonLibArgs(ctx blueprint.ModuleContext) map[string]string {
@@ -655,7 +655,7 @@ func (g *linuxGenerator) sharedActions(m *sharedLibrary, ctx blueprint.ModuleCon
 }
 
 func (g *linuxGenerator) binaryOutputDir(m *binary) string {
-	return filepath.Join("${BuildDir}", m.Properties.TargetType, "executable")
+	return filepath.Join("${BuildDir}", string(m.Properties.TargetType), "executable")
 }
 
 var executableRule = pctx.StaticRule("executable",

--- a/core/splitter.go
+++ b/core/splitter.go
@@ -35,13 +35,13 @@ type SplittableProps struct {
 // the different variants by the splitterMutator
 type splittable interface {
 	// Retrieve all the different variations to create
-	supportedVariants() []string
+	supportedVariants() []tgtType
 
 	// Disables the module is no variations supported
 	disable()
 
 	// Set the particular variant
-	setVariant(string)
+	setVariant(tgtType)
 
 	// Get the properties related to which variants are available
 	getSplittableProps() *SplittableProps
@@ -104,10 +104,18 @@ func supportedVariantsMutator(mctx blueprint.TopDownMutatorContext) {
 	})
 }
 
+func tgtToString(tgts []tgtType) []string {
+	variants := make([]string, len(tgts))
+	for i, v := range tgts {
+		variants[i] = string(v)
+	}
+	return variants
+}
+
 // Creates all the supported variants of splittable modules, including defaults.
 func splitterMutator(mctx blueprint.BottomUpMutatorContext) {
 	if s, ok := mctx.Module().(splittable); ok {
-		variants := s.supportedVariants()
+		variants := tgtToString(s.supportedVariants())
 		if len(variants) == 0 {
 			s.disable()
 		} else {
@@ -117,7 +125,7 @@ func splitterMutator(mctx blueprint.BottomUpMutatorContext) {
 				if !ok {
 					panic(errors.New("newly created variation is not splittable - should not happen"))
 				}
-				newsplit.setVariant(v)
+				newsplit.setVariant(tgtType(v))
 			}
 		}
 	}

--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -245,9 +245,9 @@ func (tc toolchainGnuCross) getStdCxxHeaderDirs() []string {
 	}
 }
 
-func newToolchainGnuCommon(config *bobConfig, tgtType string) (tc toolchainGnuCommon) {
+func newToolchainGnuCommon(config *bobConfig, tgt tgtType) (tc toolchainGnuCommon) {
 	props := config.Properties
-	tc.prefix = props.GetString(tgtType + "_gnu_prefix")
+	tc.prefix = props.GetString(string(tgt) + "_gnu_prefix")
 	tc.arBinary = tc.prefix + props.GetString("ar_binary")
 	tc.asBinary = tc.prefix + props.GetString("as_binary")
 	tc.gccBinary = tc.prefix + props.GetString("gnu_cc_binary")
@@ -261,7 +261,7 @@ func newToolchainGnuNative(config *bobConfig) (tc toolchainGnuNative) {
 }
 func newToolchainGnuCross(config *bobConfig) (tc toolchainGnuCross) {
 	tc.toolchainGnuCommon = newToolchainGnuCommon(config, tgtTypeTarget)
-	tc.cflags = strings.Split(config.Properties.GetString(tgtTypeTarget+"_gnu_flags"), " ")
+	tc.cflags = strings.Split(config.Properties.GetString(string(tgtTypeTarget)+"_gnu_flags"), " ")
 	tc.ldflags = utils.NewStringSlice(tc.cflags)
 	return
 }
@@ -313,13 +313,13 @@ func (tc toolchainClangCommon) getLinker() (tool string, flags []string) {
 	return tc.clangxxBinary, tc.ldflags
 }
 
-func newToolchainClangCommon(config *bobConfig, gnu toolchainGnu, tgtType string) (tc toolchainClangCommon) {
+func newToolchainClangCommon(config *bobConfig, gnu toolchainGnu, tgt tgtType) (tc toolchainClangCommon) {
 	props := config.Properties
-	tc.prefix = props.GetString(tgtType + "_clang_prefix")
+	tc.prefix = props.GetString(string(tgt) + "_clang_prefix")
 	tc.clangBinary = tc.prefix + props.GetString("clang_cc_binary")
 	tc.clangxxBinary = tc.prefix + props.GetString("clang_cxx_binary")
-	tc.useGnuLibs = props.GetBool(tgtType + "_clang_use_gnu_libs")
-	tc.useGnuStl = props.GetBool(tgtType + "_clang_use_gnu_stl")
+	tc.useGnuLibs = props.GetBool(string(tgt) + "_clang_use_gnu_libs")
+	tc.useGnuStl = props.GetBool(string(tgt) + "_clang_use_gnu_stl")
 	tc.gnu = gnu
 
 	if tc.useGnuLibs || tc.useGnuStl {
@@ -329,7 +329,7 @@ func newToolchainClangCommon(config *bobConfig, gnu toolchainGnu, tgtType string
 		tc.cflags = append(tc.cflags, gnuInstallArg)
 		tc.ldflags = append(tc.ldflags, gnuInstallArg)
 	}
-	if !props.GetBool(tgtType + "_clang_standalone") {
+	if !props.GetBool(string(tgt) + "_clang_standalone") {
 		// Add the GNU toolchain's binary directories to Clang's binary search
 		// path, so that Clang can find the correct linker. If the GNU toolchain
 		// is a "system" toolchain (e.g. in /usr/bin), its binaries will already
@@ -422,9 +422,9 @@ func (tc toolchainArmClang) getLinker() (string, []string) {
 	return tc.cxxBinary, tc.cflags
 }
 
-func newToolchainArmClangCommon(config *bobConfig, tgtType string) (tc toolchainArmClang) {
+func newToolchainArmClangCommon(config *bobConfig, tgt tgtType) (tc toolchainArmClang) {
 	props := config.Properties
-	tc.prefix = props.GetString(tgtType + "_gnu_prefix")
+	tc.prefix = props.GetString(string(tgt) + "_gnu_prefix")
 	tc.arBinary = tc.prefix + props.GetString("armclang_ar_binary")
 	tc.asBinary = tc.prefix + props.GetString("armclang_as_binary")
 	tc.ccBinary = tc.prefix + props.GetString("armclang_cc_binary")
@@ -438,7 +438,7 @@ func newToolchainArmClangNative(config *bobConfig) (tc toolchainArmClangNative) 
 }
 func newToolchainArmClangCross(config *bobConfig) (tc toolchainArmClangCross) {
 	tc.toolchainArmClang = newToolchainArmClangCommon(config, tgtTypeTarget)
-	tc.cflags = strings.Split(config.Properties.GetString(tgtTypeTarget+"_armclang_flags"), " ")
+	tc.cflags = strings.Split(config.Properties.GetString(string(tgtTypeTarget)+"_armclang_flags"), " ")
 	return
 }
 
@@ -447,8 +447,8 @@ type toolchainSet struct {
 	target toolchain
 }
 
-func (tcs *toolchainSet) getToolchain(tgtType string) toolchain {
-	if tgtType == tgtTypeHost {
+func (tcs *toolchainSet) getToolchain(tgt tgtType) toolchain {
+	if tgt == tgtTypeHost {
 		return tcs.host
 	}
 	return tcs.target


### PR DESCRIPTION
Utilize strongly typed variables to explicitly inform about
currently used variable. This may bring some slight improvement for code
optimization and overall performance.

Change-Id: Ie54aca3813c295783a2c581256e9245187409a29
Signed-off-by: Michal Widera <michal.widera@arm.com>