### PR TITLE
Handle empty GCC field on Android

### DIFF
--- a/mconfig/toolchain.Mconfig
+++ b/mconfig/toolchain.Mconfig
@@ -211,3 +211,21 @@ config TARGET_CLANG_USE_GNU_STL
 	help
 	  Detect the location of the configured GNU toolchain's
 	  STL implementation, and pass this to Clang.
+
+config HOST_CLANG_STANDALONE
+	bool "Host Clang standalone"
+	depends on HOST_TOOLCHAIN_CLANG
+	default y if ANDROID
+	help
+	  Clang has been configured so that it doesn't need to
+	  reference other toolchains to find things like startup
+	  libraries or the linker.
+
+config TARGET_CLANG_STANDALONE
+	bool "Target Clang standalone"
+	depends on TARGET_TOOLCHAIN_CLANG
+	default y if ANDROID
+	help
+	  Clang has been configured so that it doesn't need to
+	  reference other toolchains to find things like startup
+	  libraries or the linker.


### PR DESCRIPTION
During Android build panic error should be issued only when GNU
Assembler binary and GNU Archiver binary is in use

Change-Id: Iabc357370d239f9de79757f790c777b89a45e629
Signed-off-by: Michal Widera <michal.widera@arm.com>