### PR TITLE
Support kernel build with clang for Android

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -942,6 +942,7 @@ func (g *androidMkGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.
 		"--module-dir \"$(output_module_dir)\" $(extra_includes) " +
 		"--sources $(sources) $(kbuild_extra_symbols) " +
 		"--kernel \"$(kernel_dir)\" --cross-compile \"$(kernel_compiler)\" " +
+		"$(cc_flag) $(hostcc_flag) $(clang_triple_flag) " +
 		"$(kbuild_options) --extra-cflags \"$(extra_cflags)\" $(make_args)"
 
 	sb.WriteString("\techo " + cmd + "\n")

--- a/core/linux.go
+++ b/core/linux.go
@@ -842,13 +842,14 @@ var kbuildRule = pctx.StaticRule("kbuild",
 			"--module-dir $output_module_dir $extra_includes " +
 			"--sources $in $kbuild_extra_symbols " +
 			"--kernel $kernel_dir --cross-compile '$kernel_compiler' " +
+			"$cc_flag $hostcc_flag $clang_triple_flag " +
 			"$kbuild_options --extra-cflags '$extra_cflags' $make_args",
 		Depfile:     "$out.d",
 		Deps:        blueprint.DepsGCC,
 		Pool:        blueprint.Console,
 		Description: "$out",
-	}, "kmod_build", "extra_includes", "extra_cflags", "kbuild_extra_symbols", "kernel_dir",
-	"kernel_compiler", "kbuild_options", "make_args", "output_module_dir")
+	}, "kmod_build", "extra_includes", "extra_cflags", "kbuild_extra_symbols", "kernel_dir", "kernel_compiler",
+	"kbuild_options", "make_args", "output_module_dir", "cc_flag", "hostcc_flag", "clang_triple_flag")
 
 func (g *linuxGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.ModuleContext) {
 	builtModule := filepath.Join(g.kernelModOutputDir(m), m.Name()+".ko")

--- a/example/Mconfig
+++ b/example/Mconfig
@@ -57,6 +57,21 @@ config TARGET_CLANG_TRIPLE
 	string
 	default "x86_64-linux-gnu"
 
+config KERNEL_CC
+	string
+	default "clang" if ANDROID
+	help
+	  Compiler family to use in kernel module builds.
+	  Kernel builds refer to this as CC
+
+config KERNEL_CLANG_TRIPLE
+	string
+	depends on KERNEL_CC = "clang"
+	default "aarch64-linux-gnu"
+	help
+	  Clang triple to use for kernel modules builds.
+	  Kernel builds refer to this as CLANG_TRIPLE.
+
 # Update this to reflect the path to Bob within the superproject
 source "bob-build/mconfig/toolchain.Mconfig"
 

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -57,6 +57,21 @@ config TARGET_CLANG_TRIPLE
 	string
 	default "x86_64-linux-gnu"
 
+config KERNEL_CC
+	string
+	default "clang" if ANDROID
+	help
+	  Compiler family to use in kernel module builds.
+	  Kernel builds refer to this as CC
+
+config KERNEL_CLANG_TRIPLE
+	string
+	depends on KERNEL_CC = "clang"
+	default "aarch64-linux-gnu"
+	help
+	  Clang triple to use for kernel modules builds.
+	  Kernel builds refer to this as CLANG_TRIPLE.
+
 source "bob/mconfig/toolchain.Mconfig"
 
 config PKG_CONFIG


### PR DESCRIPTION
Add configuration options allowing the user to control whether clang is
used for kernel module builds. Update kmod_build.py to pass the options
on to kernel the make call as required.

Change-Id: I2742e4562a6f66d7e0bf56a86733129549fb0dae
Signed-off-by: Michal Widera <michal.widera@arm.com>