### PR TITLE
Prefix build_wrapper with ${SrcDir}

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2019 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -395,6 +395,17 @@ func pathMutator(mctx blueprint.BottomUpMutatorContext) {
 	}
 }
 
+type buildWrapperProcessor interface {
+	processBuildWrapper(blueprint.BaseModuleContext)
+}
+
+// Prefixes build_wrapper with source path if necessary
+func buildWrapperMutator(mctx blueprint.BottomUpMutatorContext) {
+	if p, ok := mctx.Module().(buildWrapperProcessor); ok {
+		p.processBuildWrapper(mctx)
+	}
+}
+
 func collectReexportDependenciesMutator(mctx blueprint.TopDownMutatorContext) {
 	mainModule := mctx.Module()
 	if e, ok := mainModule.(enableable); ok {
@@ -564,6 +575,7 @@ func Main() {
 	ctx.RegisterBottomUpMutator("check_lib_fields", checkLibraryFieldsMutator).Parallel()
 	ctx.RegisterBottomUpMutator("strip_empty_components", stripEmptyComponentsMutator).Parallel()
 	ctx.RegisterBottomUpMutator("process_paths", pathMutator).Parallel()
+	ctx.RegisterBottomUpMutator("process_build_wrapper", buildWrapperMutator).Parallel()
 	ctx.RegisterTopDownMutator("supported_variants", supportedVariantsMutator).Parallel()
 	ctx.RegisterBottomUpMutator(splitterMutatorName, splitterMutator).Parallel()
 	ctx.RegisterTopDownMutator("target", targetMutator).Parallel()

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -212,8 +212,12 @@ to modules linking with the current library.
 
 ----
 ### **bob_module.build_wrapper** (optional)
-Wrapper for all build commands (object file
-compilation **and** linking). This can be used, for example, to enable `ccache`:
+Wrapper for all build commands (object file compilation **and**
+linking). If the first word looks like a relative path (it doesn't
+start with '/' but contains '/' characters), it is assumed that the
+script is in the project directory.
+
+This can be used, for example, to enable `ccache`:
 
 ```bp
 bob_defaults {


### PR DESCRIPTION
The working directory can be set to the build output directory, so
build wrapper commands must be prefixed if they are local scripts.

Change-Id: Ieb453f0ea00869550ee80091a602fd5eaf970621
Signed-off-by: David Kilroy <david.kilroy@arm.com>