### PR TITLE
Add kernel options as a build properties

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -941,7 +941,7 @@ func (g *androidMkGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.
 		"--common-root $(local_path) " +
 		"--module-dir \"$(output_module_dir)\" $(extra_includes) " +
 		"--sources $(sources) $(kbuild_extra_symbols) " +
-		"--kernel \"$(kernel_dir)\" --cross-compile \"$(kernel_compiler)\" " +
+		"--kernel \"$(kernel_dir)\" --cross-compile \"$(kernel_cross_compile)\" " +
 		"$(cc_flag) $(hostcc_flag) $(clang_triple_flag) " +
 		"$(kbuild_options) --extra-cflags \"$(extra_cflags)\" $(make_args)"
 

--- a/core/library.go
+++ b/core/library.go
@@ -165,7 +165,13 @@ type BuildProps struct {
 	// Kernel directory location
 	Kernel_dir string
 	// Compiler prefix for kernel build
-	Kernel_compiler string
+	Kernel_cross_compile string
+	// Kernel target compiler
+	Kernel_cc string
+	// Kernel host compiler
+	Kernel_hostcc string
+	// Target triple when using clang as the compiler
+	Kernel_clang_triple string
 
 	TargetType tgtType `blueprint:"mutated"`
 }

--- a/core/linux.go
+++ b/core/linux.go
@@ -841,14 +841,14 @@ var kbuildRule = pctx.StaticRule("kbuild",
 			"--common-root ${SrcDir} " +
 			"--module-dir $output_module_dir $extra_includes " +
 			"--sources $in $kbuild_extra_symbols " +
-			"--kernel $kernel_dir --cross-compile '$kernel_compiler' " +
+			"--kernel $kernel_dir --cross-compile '$kernel_cross_compile' " +
 			"$cc_flag $hostcc_flag $clang_triple_flag " +
 			"$kbuild_options --extra-cflags '$extra_cflags' $make_args",
 		Depfile:     "$out.d",
 		Deps:        blueprint.DepsGCC,
 		Pool:        blueprint.Console,
 		Description: "$out",
-	}, "kmod_build", "extra_includes", "extra_cflags", "kbuild_extra_symbols", "kernel_dir", "kernel_compiler",
+	}, "kmod_build", "extra_includes", "extra_cflags", "kbuild_extra_symbols", "kernel_dir", "kernel_cross_compile",
 	"kbuild_options", "make_args", "output_module_dir", "cc_flag", "hostcc_flag", "clang_triple_flag")
 
 func (g *linuxGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.ModuleContext) {

--- a/docs/module_types/bob_defaults.md
+++ b/docs/module_types/bob_defaults.md
@@ -78,9 +78,12 @@ bob_defaults {
     kbuild_options: ["CONFIG_MY_OPTION=y"],
     extra_symbols: ["bob_kernel_module.name"],
     make_args: ["--ignore-errors"],
-    kernel_dir: "/kernes/linux/",
-    kernel_compiler: "prefix",
-    // ^^ kernel module related stuff
+    kernel_dir: "/kernel/linux/",
+    kernel_cross_compile: "prefix",
+    kernel_cc: "target",
+    kernel_hostcc: "host",
+    kernel_clang_triple: "triple",
+    // ^^ kernel module building related stuff
 
     install_group: "bob_install_group.name",
     install_deps: ["bob_resource.name"],

--- a/docs/module_types/bob_kernel_module.md
+++ b/docs/module_types/bob_kernel_module.md
@@ -50,7 +50,10 @@ bob_kernel_module {
     extra_symbols: ["bob_kernel_module.name"],
     make_args: ["SOME_MAKE_VARIABLE=3"],
     kernel_dir: "{{.kernel_dir}}",
-    kernel_compiler: "{{.kernel_prefix}}",
+    kernel_cross_compile: "{{.kernel_prefix}}",
+    kernel_cc: "{{.kernel_cc}}",
+    kernel_hostcc: "{{.kernel_hostcc}}",
+    kernel_clang_triple: "{{.kernel_clang_triple}}",
 
     install_group: "bob_install_group.name",
     install_deps: ["bob_resource.name"],
@@ -82,5 +85,17 @@ Arguments to pass to kernel make invocation.
 Kernel directory location.
 
 ----
-### **bob_kernel_module.kernel_compiler** (optional)
+### **bob_kernel_module.kernel_cross_compile** (optional)
 Compiler prefix for kernel build.
+
+----
+### **bob_kernel_module.kernel_cc** (optional)
+Kernel target compiler.
+
+----
+### **bob_kernel_module.kernel_hostcc** (optional)
+Kernel host compiler.
+
+----
+### **bob_kernel_module.kernel_clang_triple** (optional)
+Target triple when using clang as the compiler.

--- a/example/Mconfig
+++ b/example/Mconfig
@@ -57,21 +57,6 @@ config TARGET_CLANG_TRIPLE
 	string
 	default "x86_64-linux-gnu"
 
-config KERNEL_CC
-	string
-	default "clang" if ANDROID
-	help
-	  Compiler family to use in kernel module builds.
-	  Kernel builds refer to this as CC
-
-config KERNEL_CLANG_TRIPLE
-	string
-	depends on KERNEL_CC = "clang"
-	default "aarch64-linux-gnu"
-	help
-	  Clang triple to use for kernel modules builds.
-	  Kernel builds refer to this as CLANG_TRIPLE.
-
 # Update this to reflect the path to Bob within the superproject
 source "bob-build/mconfig/toolchain.Mconfig"
 

--- a/scripts/kmod_build.py
+++ b/scripts/kmod_build.py
@@ -84,9 +84,13 @@ def build_module(output_dir, module_ko, kdir, module_dir, make_args, extra_cflag
 
 
 def get_tool_abspath(tool):
+    """Get absolute path to tool if argument contains a path otherwise assume it's a $PATH tool
+    :param tool: path to tool or $PATH prefix
+    :return: Absolute path or tool
+    """
     if tool and os.path.dirname(tool):
         return os.path.abspath(tool)
-    return None
+    return tool
 
 
 if __name__ == "__main__":
@@ -140,8 +144,6 @@ if __name__ == "__main__":
     abs_kdir = os.path.abspath(args.kernel)
     search_path = [os.path.abspath(d) for d in args.include_dir]
 
-    # Don't abspath toolset if it's just a prefix for something already
-    # inside $PATH (i.e. it doesn't contain a directory part):
     cross_compile = get_tool_abspath(args.cross_compile)
     target_cc = get_tool_abspath(args.cc)
     host_cc = get_tool_abspath(args.hostcc)

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -57,21 +57,6 @@ config TARGET_CLANG_TRIPLE
 	string
 	default "x86_64-linux-gnu"
 
-config KERNEL_CC
-	string
-	default "clang" if ANDROID
-	help
-	  Compiler family to use in kernel module builds.
-	  Kernel builds refer to this as CC
-
-config KERNEL_CLANG_TRIPLE
-	string
-	depends on KERNEL_CC = "clang"
-	default "aarch64-linux-gnu"
-	help
-	  Clang triple to use for kernel modules builds.
-	  Kernel builds refer to this as CLANG_TRIPLE.
-
 source "bob/mconfig/toolchain.Mconfig"
 
 config PKG_CONFIG


### PR DESCRIPTION
This change adds kernel build properties as a build properties.
Also fix condition when cross_compile doesn't contain a path which
result with an empty toolset path

Change-Id: Ie2ff65564741bd860a2a1b4807f78e2f8da7ff16
Signed-off-by: Michal Widera <michal.widera@arm.com>