### PR TITLE
Fix kernel module include handling

### DIFF
--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -121,8 +121,13 @@ func (m *kernelModule) generateKbuildArgs(ctx blueprint.ModuleContext) map[strin
 
 	extraCflags := m.build().BuildProps.Cflags
 
-	for _, includeDir := range m.build().BuildProps.Include_dirs {
+	for _, includeDir := range m.build().BuildProps.Local_include_dirs {
 		includeDir = "-I" + filepath.Join(g.sourcePrefix(), includeDir)
+		extraIncludePaths = append(extraIncludePaths, includeDir)
+	}
+
+	for _, includeDir := range m.build().BuildProps.Include_dirs {
+		includeDir = "-I" + includeDir
 		extraIncludePaths = append(extraIncludePaths, includeDir)
 	}
 

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -187,28 +187,27 @@ Value to use on Android for `LOCAL_MODULE_OWNER`
 
 ----
 ### **bob_module.include_dirs** (optional)
-The list of include dirs to use that is relative
-to the source directory.
+A list of include directories to use. These are expected to be system
+headers, and will usually be an absolute path. On Android these can be
+relative to `$ANDROID_TOP`.
 
 ----
 ### **bob_module.local_include_dirs** (optional)
-The list of include dirs to use that is relative to the
-build.bp file.
-
-Include directories are added with the `local_include_dirs`
-parameter. The paths added are relative to the directory
-of the `build.bp` file. This can be used for generated headers
-or if there are system headers not on the normal include path.
-
-----
-### **bob_module.export_local_include_dirs** (optional)
-Include dirs (relative to module directory) to be
-exported to modules linking with the current library.
+A list of include directories to use. These are relative to the
+`build.bp` containing the module definition, and expected to be within
+the source heirarchy.
 
 ----
 ### **bob_module.export_include_dirs** (optional)
-Include dirs (path relative to root) to be exported
-to modules linking with the current library.
+A list of include directories, similar to `include_dirs`. These
+directories also get added to the include paths of any module that
+links to the current library.
+
+----
+### **bob_module.export_local_include_dirs** (optional)
+A list of include directories to use, similar to
+`local_include_dirs`. These directories also get added to the include
+paths of any module that links to the current library.
 
 ----
 ### **bob_module.build_wrapper** (optional)


### PR DESCRIPTION
local_include_dirs must get anchored to the source
directory. include_dirs should be absolute system paths.

Update include directory documentation.

Change-Id: Ib1d41df334a077606077409972b1e156277ab92b
Signed-off-by: David Kilroy <david.kilroy@arm.com>