### PR TITLE
Run Android.mk generation in ANDROID_BUILD_TOP

### DIFF
--- a/bob.bootstrap.version
+++ b/bob.bootstrap.version
@@ -1,2 +1,2 @@
 # Version number use to identify whether the user needs to re-boostrap their build directory.
-BOB_VERSION="1"
+BOB_VERSION="2"

--- a/core/android_make.go
+++ b/core/android_make.go
@@ -924,7 +924,6 @@ func (g *androidMkGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.
 
 	args := m.generateKbuildArgs(ctx)
 	args["sources"] = "$(addprefix $(LOCAL_PATH)/,$(LOCAL_SRC_FILES))"
-	args["kmod_build"] = "$(LOCAL_PATH)/" + args["kmod_build"]
 	args["local_path"] = "$(LOCAL_PATH)"
 
 	// Create a target-specific variable declaration for each required parameter.

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -143,8 +143,18 @@ func glob(ctx blueprint.ModuleContext, globs []string, excludes []string) []stri
 
 	for _, file := range globs {
 		if strings.ContainsAny(file, "*?[") {
+			// Globs need to be calculated relative to the source
+			// directory (not the working directory), so add it
+			// here, and remove it afterwards.
+			file = filepath.Join(srcdir, file)
 			matches, _ := ctx.GlobWithDeps(file, excludes)
-			files = append(files, matches...)
+			for _, match := range matches {
+				rel, err := filepath.Rel(srcdir, match)
+				if err != nil {
+					panic(err)
+				}
+				files = append(files, rel)
+			}
 		} else if !utils.Contains(excludes, file) {
 			files = append(files, file)
 		}

--- a/example/bootstrap_android.bash
+++ b/example/bootstrap_android.bash
@@ -72,12 +72,15 @@ while true ; do
     esac
 done
 
-if [ -z "$OUT" ]; then
-    echo "Error: \$OUT not set: Did you run 'lunch'?"
-    exit 1
-fi
+[[ -n ${OUT} ]] || { echo "\$OUT is not set - did you run 'lunch'?"; exit 1; }
+[[ -n ${ANDROID_BUILD_TOP} ]] || { echo "\$ANDROID_BUILD_TOP is not set - did you run 'lunch'?"; exit 1; }
 
-PROJ_DIR="$(dirname $0)"
+source "${SCRIPT_DIR}/${BOB_DIR}/pathtools.bash"
+
+PROJ_DIR=$(relative_path "${ANDROID_BUILD_TOP}" "${SCRIPT_DIR}")
+
+# Change to the working directory
+cd "${ANDROID_BUILD_TOP}"
 
 ### Variables required for Bob and Android.mk bootstrap ###
 

--- a/scripts/generate_android_inc.bash
+++ b/scripts/generate_android_inc.bash
@@ -57,14 +57,8 @@ elif [[ -z $NINJA ]]; then
     echo "\$NINJA not set!"
     exit 1
 else
-    # The Ninja path is relative to the root of the Android tree, but Bob is
-    # run from the project directory.
-    NINJA=`relative_path "${PATH_TO_PROJ}" "${NINJA}"`
-
     # Use the Go shipped with Android on P and later, where it's recent enough (>= 1.10).
-    [[ $PLATFORM_SDK_VERSION -ge 28 ]] && export GOROOT=`bob_realpath prebuilts/go/linux-x86/`
-
-    cd "${PATH_TO_PROJ}"
+    [[ ${PLATFORM_SDK_VERSION} -ge 28 ]] && export GOROOT=prebuilts/go/linux-x86/
 
     "$BUILDDIR/buildme"
 

--- a/tests/bootstrap_android
+++ b/tests/bootstrap_android
@@ -74,16 +74,19 @@ while true ; do
     esac
 done
 
-if [ -z "$OUT" ]; then
-    echo "Error: \$OUT not set: Did you run 'lunch'?"
-    exit 1
-fi
+[[ -n ${OUT} ]] || { echo "\$OUT is not set - did you run 'lunch'?"; exit 1; }
+[[ -n ${ANDROID_BUILD_TOP} ]] || { echo "\$ANDROID_BUILD_TOP is not set - did you run 'lunch'?"; exit 1; }
 
 # The tests need a symlink in the source directory to the parent bob
 # directory, as Blueprint won't accept ..
 create_link .. "${SCRIPT_DIR}/${BOB_DIR}"
 
-PROJ_DIR="$(dirname $0)"
+source "${SCRIPT_DIR}/${BOB_DIR}/pathtools.bash"
+
+PROJ_DIR=$(relative_path "${ANDROID_BUILD_TOP}" "${SCRIPT_DIR}")
+
+# Change to the working directory
+cd "${ANDROID_BUILD_TOP}"
 
 ### Variables required for Bob and Android.mk bootstrap ###
 


### PR DESCRIPTION
Change the current directory when 'building' for Android (i.e.
generating `Android.mk`) from the source directory to
`ANDROID_BUILD_TOP`, which is the CWD for the actual compilation, too.

Update the `glob` function to temporarily add the source directory to
the path before calling `GlobWithDeps`. Without this, globs will
silently return zero matches, causing build failures later, because the
source files inside a glob are relative to the source directory, not the
working directory.

Change-Id: Ie8d6f357fb7b270899f0a2de7a50df0fb54a9ead
Signed-off-by: Chris Diamand <chris.diamand@arm.com>