### PR TITLE
Fix --extra-cflags argument usage in kmod_build.py call

### DIFF
--- a/core/linux.go
+++ b/core/linux.go
@@ -843,7 +843,7 @@ var kbuildRule = pctx.StaticRule("kbuild",
 			"--sources $in $kbuild_extra_symbols " +
 			"--kernel $kernel_dir --cross-compile '$kernel_cross_compile' " +
 			"$cc_flag $hostcc_flag $clang_triple_flag " +
-			"$kbuild_options --extra-cflags '$extra_cflags' $make_args",
+			"$kbuild_options --extra-cflags='$extra_cflags' $make_args",
 		Depfile:     "$out.d",
 		Deps:        blueprint.DepsGCC,
 		Pool:        blueprint.Console,


### PR DESCRIPTION
Works:
$ kmod_build.py --extra-cflags '-Wall -Wextra'

Fails:
$ kmod_build.py --extra-cflags '-Wall'
Error: argument --extra-cflags: expected one argument

When we try to set --extra-cflags to a single option when calling
kmod_build.py, argparse ends up seeing the option (intended for make
CFLAGS) as an option to kmod_build.py. This is because shell expands the
quoting, and argparse is just seeing -Wall.

Change-Id: I4827f47cea89c5c874925a8af51c1bef28c25536
Signed-off-by: Michal Widera <michal.widera@arm.com>