### PR TITLE
Explain why config options were ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ highlight.css
 
 # PyCharm
 .idea/
+
+# pytest
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,10 @@ before_install:
   - export -f travis_time_start
   - export -f travis_time_finish
   - sudo apt-get update
-  - sudo apt-get install -y rsync python-ply python3 python3-ply
+  - |
+    sudo apt-get install -y rsync python3 \
+     python-ply  python-pytest  python-pytest-catchlog  python-mock  python-pytest-mock \
+    python3-ply python3-pytest python3-pytest-catchlog python3-mock python3-pytest-mock
 
 install:
   - bash .travis/install-ninja.sh

--- a/.travis/run_all_tests.sh
+++ b/.travis/run_all_tests.sh
@@ -44,6 +44,15 @@ fold_start 'run_formatter_tests.sh'
 fold_end
 ####################
 
+####################
+fold_start 'pytest config_system'
+    # The newer command `pytest` is not available on Ubuntu 16.04, which the
+    # Travis environment uses, so invoke the older `py.test` here.
+    py.test-${PYTHON_SUFFIX} ${BOB_ROOT}/config_system
+    check_result $? "Check pytest config_system: "
+fold_end
+####################
+
 # This test is issued only if build test passed previously
 ####################
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,16 @@ Bob has three kinds of tests:
 
   ```bash
   ./config_system/tests/run_tests.py
+  ./config_system/tests/run_tests_formatter.py
+  pytest ./config_system
   ```
+
+  These tests require the `pytest`, `pytest-catchlog`, `pytest-mock` and `mock`
+  Python packages.
+
+  Note: Do not run `pytest` in the top-level `bob-build` directory; it will
+  fail during test discovery because of the recursive symlink inside the main
+  Bob `tests` directory.
 
 If your contribution is a bugfix, please consider adding a new test to prevent
 future regressions.

--- a/config_system/__init__.py
+++ b/config_system/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .general import init_config, get_config, get_config_bool, \
-    get_config_int, get_config_string,  get_config_list, read_config, \
+from .general import init_config, format_dependency_list, get_config, \
+    get_config_bool, get_config_int, get_config_string, get_config_list, read_config, \
     set_config, can_enable, get_options_selecting, get_options_depending_on, \
     get_mconfig_dir

--- a/config_system/general.py
+++ b/config_system/general.py
@@ -128,6 +128,33 @@ def dependency_list(depends):
 
     return [depends]
 
+
+def format_dependency_list(depends, skip_parens=False):
+    assert depends, "Empty dependency list"
+
+    OPERATOR_FORMAT_MAP = {
+        "and": "&&",
+        "or": "||",
+    }
+
+    if type(depends) == tuple:
+        if len(depends) == 3:
+            left = format_dependency_list(depends[1])
+            right = format_dependency_list(depends[2])
+
+            operator = OPERATOR_FORMAT_MAP.get(depends[0], depends[0])
+            expr = left + " " + operator + " " + right
+            return expr if skip_parens else "(" + expr + ")"
+        elif depends[0] == "not":
+            return "!" + format_dependency_list(depends[1])
+        elif depends[0] == 'string':
+            return '"' + depends[1] + '"'
+        elif depends[0] == 'number':
+            return str(depends[1])
+    elif type(depends) == str:
+        return depends + "[=" + str(get_config(depends)["value"]) + "]"
+
+
 def enforce_dependent_values(auto_fix=False):
     """
     Check that values are consistently set, specifically with respect

--- a/config_system/menuconfig.py
+++ b/config_system/menuconfig.py
@@ -691,12 +691,12 @@ def main():
     issues = counter.errors() + counter.criticals()
     warnings = counter.warnings()
     if issues > 0:
-        sys.exit(2)
+        return 2
     elif warnings > 0:
-        sys.exit(1)
+        return 1
     else:
-        sys.exit(0)
+        return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/config_system/tests/test_update_config.py
+++ b/config_system/tests/test_update_config.py
@@ -1,0 +1,146 @@
+# Copyright 2019 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import os
+import pytest
+import pytest_catchlog
+import pytest_mock
+import sys
+import tempfile
+
+from config_system import general
+from config_system import update_config
+
+
+ignored_option_testdata = [
+    # Attempt to set a non-user-settable option
+    ("""
+config NON_USER_SETTABLE
+	bool
+	default n
+""",
+        ["NON_USER_SETTABLE=y"],
+        "NON_USER_SETTABLE=y was ignored; it has no title, so is not user-settable " + \
+        "(NON_USER_SETTABLE has no unmet dependencies)",
+    ),
+
+    # Specify the same option multiple times with different values
+    ("""
+config USER_SETTABLE_INT_VALUE
+    int "This integer can be set by the user"
+
+config BLA
+    bool
+""",
+        ["USER_SETTABLE_INT_VALUE=3", "BLA=n", "USER_SETTABLE_INT_VALUE=4"],
+        "USER_SETTABLE_INT_VALUE=3 was overridden by later argument USER_SETTABLE_INT_VALUE=4",
+    ),
+
+    # Test the formatting of a simple unmet dependency
+    ("""
+config FALSE
+	bool
+
+config SIMPLE_DEPENDENCIES_NOT_MET
+	bool "Is this simple dependency met?"
+	depends on FALSE
+""",
+        ["SIMPLE_DEPENDENCIES_NOT_MET=y"],
+        "SIMPLE_DEPENDENCIES_NOT_MET=y was ignored; its dependencies were not met: FALSE[=n]",
+    ),
+
+    # Test the formatting of a more complex dependency
+    ("""
+config STRING_VALUE
+	string
+	default "string"
+
+config FALSE
+	bool
+
+config COMPLEX_DEPENDENCIES_NOT_MET
+	bool "Something with a non-trivial dependency"
+	depends on STRING_VALUE = "not_string" && !FALSE
+""",
+        ["COMPLEX_DEPENDENCIES_NOT_MET=y"],
+        "COMPLEX_DEPENDENCIES_NOT_MET=y was ignored; its dependencies were not met: " + \
+        "(STRING_VALUE[=string] = \"not_string\") && !FALSE[=n]",
+    ),
+
+
+    # Test the formatting of an integer expression, including all the
+    # comparison operators
+    ("""
+config INT_VALUE
+	int
+	default 60221409
+
+config ANOTHER_INT_VALUE
+	int
+	default 31415926
+
+config INT_DEPENDENCIES_NOT_MET
+	bool "Check some integer ranges"
+	depends on (INT_VALUE >= 3 && INT_VALUE <= 25) || (INT_VALUE > 100 && INT_VALUE < 200) || INT_VALUE = ANOTHER_INT_VALUE || INT_VALUE != 60221409
+""",
+        ["INT_DEPENDENCIES_NOT_MET=y"],
+        "INT_DEPENDENCIES_NOT_MET=y was ignored; its dependencies were not met: " + \
+        "((((INT_VALUE[=60221409] >= 3) && (INT_VALUE[=60221409] <= 25)) || " + \
+        "((INT_VALUE[=60221409] > 100) && (INT_VALUE[=60221409] < 200))) || " + \
+        "(INT_VALUE[=60221409] = ANOTHER_INT_VALUE[=31415926])) || " + \
+        "(INT_VALUE[=60221409] != 60221409)",
+    ),
+
+    # Check we get the right error message when trying to set an unknown option
+    (
+        "",
+        ["UNKNOWN_CONFIGURATION_OPTION=n"],
+        "unknown configuration option \"UNKNOWN_CONFIGURATION_OPTION\"",
+    ),
+]
+
+
+@pytest.mark.parametrize("mconfig,args,error", ignored_option_testdata)
+def test_ignored_config_option(caplog, mocker, tmpdir, mconfig, args, error):
+    """For each test case, run update_config's `main()` function with the
+    provided Mconfig and command-line arguments. Each case expects exactly one
+    error message, relating to the command-line option provided - check that
+    this is logged.
+    """
+
+    config_fname = tmpdir.join("bob.config")
+    mconfig_fname = tmpdir.join("Mconfig")
+    mconfig_fname.write(mconfig, "wt")
+
+    mocker.patch("config_system.update_config.parse_args", new=lambda: argparse.Namespace(
+        output=str(config_fname),
+        database=str(mconfig_fname),
+        plugin=[],
+        ignore_missing=False,
+        args=args,
+    ))
+
+    returncode = update_config.main()
+
+    errors = []
+    for record in caplog.records:
+        if record.levelno == logging.ERROR:
+            errors.append(record.message)
+
+    assert returncode == 2
+    assert len(errors) == 1
+    assert errors[0] == error

--- a/config_system/update_config.py
+++ b/config_system/update_config.py
@@ -24,8 +24,9 @@ import sys
 
 # This script is actually within our package, so add the package to the python path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from config_system.general import enforce_dependent_values, get_config, init_config, \
-    read_config_file, read_profile_file, set_config_if_prompt, write_config
+from config_system.general import can_enable, enforce_dependent_values, \
+    get_config, init_config, read_config_file, read_profile_file, \
+    set_config_if_prompt, write_config, format_dependency_list
 from config_system import log_handlers
 
 root_logger = logging.getLogger()
@@ -52,6 +53,68 @@ def parse_config_arg(arg):
         return None, None
     else:
         return m.group(1), m.group(2)
+
+
+def rindex(list, value):
+    """Find the last-occurring index of `value` in `list`."""
+    for i in range(len(list) - 1, 0, -1):
+        if list[i] == value:
+            return i
+    return -1
+
+
+def check_value_as_requested(key, requested_value, later_keys, later_values):
+    try:
+        opt = get_config(key)
+    except KeyError:
+        logger.error("unknown configuration option \"%s\"" % key)
+        return
+
+    final_value = opt["value"]
+
+    if opt["datatype"] == "int":
+        final_value = str(final_value)
+
+    if final_value == requested_value:
+        return
+
+    # See if the argument was overridden by a later argument
+    last_idx = rindex(later_keys, key)
+    if last_idx != -1 and later_values[last_idx] != requested_value:
+        logger.error("%s=%s was overridden by later argument %s=%s",
+                     key, requested_value, key, later_values[last_idx])
+        return
+
+    depends = opt.get("depends")
+    if depends and not can_enable(depends):
+        logger.error("%s=%s was ignored; its dependencies were not met: %s",
+                     key, requested_value, format_dependency_list(depends, skip_parens=True))
+        return
+
+    # Check this *after* dependencies. This allows users to investigate why an
+    # option with unmet dependencies wasn't enabled, even if it isn't user-settable.
+    if not opt.get("title"):
+        logger.error("%s=%s was ignored; it has no title, so is not user-settable (%s has no unmet dependencies)",
+                     key, requested_value, key)
+        return
+
+    logger.error("%s=%s was ignored or overriden. Value is '%s' %s %s",
+                 key, requested_value, final_value, type(requested_value), type(final_value))
+
+
+def check_values_as_requested(args):
+    keys = []
+    values = []
+    for arg in args:
+        key, value = parse_config_arg(arg)
+        if key:
+            keys.append(key)
+            values.append(value)
+
+    for i in range(0, len(keys)):
+        key = keys[i]
+        requested_value = values[i]
+        check_value_as_requested(key, requested_value, keys[i+1:], values[i+1:])
 
 
 def parse_args():
@@ -86,18 +149,7 @@ def main():
             read_profile_file(arg)
 
     enforce_dependent_values()
-
-    for arg in args.args:
-        key, value = parse_config_arg(arg)
-        if key:
-            try:
-                final_value = get_config(key)['value']
-            except KeyError:
-                logger.error("unknown configuration option \"%s\"" % key)
-            else:
-                if final_value != value:
-                    logger.error("%s=%s was ignored or overriden. Value is %s" %
-                                (key, value, final_value))
+    check_values_as_requested(args.args)
 
     for plugin in args.plugin:
         path, name = os.path.split(plugin)
@@ -121,12 +173,12 @@ def main():
     issues = counter.errors() + counter.criticals()
     warnings = counter.warnings()
     if issues > 0:
-        sys.exit(2)
+        return 2
     elif warnings > 0:
-        sys.exit(1)
+        return 1
     else:
-        sys.exit(0)
+        return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
When a command-line `OPTION=value` argument is ignored, attempt to
provide an explanation, rather than just giving the cryptic "Value is
..." message.

Because this occurs during an error case, which isn't usually tested,
add a new test to ensure this keeps working. This done using the pytest
framework - in future, the other config system tests will be ported to
use that, so we won't need three different commands to test it.

Note that Pytest has two entry points - `py.test` and `pytest`. `pytest`
is newer, so is recommended in the documentation. However, Travis will
use `py.test`, because that is the only one which exists on the Ubuntu
16.04 environment it uses.

Change-Id: I723d3b7492c2002110921ffefb5bcf5c1dee2d3c
Signed-off-by: Chris Diamand <chris.diamand@arm.com>