### PR TITLE
Use Android's prebuilt ply

### DIFF
--- a/config_system/__init__.py
+++ b/config_system/__init__.py
@@ -13,6 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import sys
+
+# The config system depends on the `ply` parser generator. On Android, this may
+# come as a prebuilt, but may _not_ automatically be added to PYTHONPATH. If
+# we're on Android (tested by checking for `envsetup.mk`), then add the `ply`
+# prebuilt to `sys.path`:
+if os.path.isfile("build/make/core/envsetup.mk"):
+    if os.path.isdir("external/ply/ply"):
+        sys.path.insert(0, "external/ply/ply")
+
 from .general import init_config, format_dependency_list, get_config, \
     get_config_bool, get_config_int, get_config_string, get_config_list, read_config, \
     set_config, can_enable, get_options_selecting, get_options_depending_on, \


### PR DESCRIPTION
Android ships with a copy of the `ply` module, but does not
automatically add it to `PYTHONPATH`.

When building on Android, check for the module, and add it to `sys.path`
if it exists.

To avoid duplicating the code, do this in `__init__.py` (rather than in
the two places which actually `import ply`).

Change-Id: Ibbdb2e00a56997f1fb6b38a192386808ac2d4709
Signed-off-by: Chris Diamand <chris.diamand@arm.com>