### PR TITLE
Standardise build testing

### DIFF
--- a/.travis/run_bootstrap_test.sh
+++ b/.travis/run_bootstrap_test.sh
@@ -11,12 +11,13 @@ PARENT=$(git merge-base origin/master ${TRAVIS_COMMIT})
 if [[ $(git diff --name-only ${PARENT} ${TRAVIS_COMMIT} | grep "bob.bootstrap.version") ]]; then
     echo "Bob version file has change between parent and current commit. Skipping verification step"
 else
-    build_dir=${HOME}/bob_build
+    build_dir=bootstrap_test
     git checkout ${PARENT}
-    cd ${BOB_ROOT}/tests/ && ./bootstrap -o ${build_dir}
-    ${build_dir}/config
-    ${build_dir}/buildme bob_tests
-    cd ${TRAVIS_BUILD_DIR}
+    cd ${BOB_ROOT}/tests
+    rm -rf ${build_dir} # Cleanup test directory
+    ./bootstrap -o ${build_dir}
+    ${build_dir}/config && ${build_dir}/buildme bob_tests
+
     git checkout ${TRAVIS_COMMIT}
     rm ${build_dir}/build.ninja
     ${build_dir}/buildme bob_tests

--- a/.travis/run_build_tests.sh
+++ b/.travis/run_build_tests.sh
@@ -3,10 +3,10 @@ set -eE
 trap "echo '<------------- run_build_tests.sh failed'" ERR
 
 export TEST_NON_ASCII_IN_ENV_HASH='ó'
+build_dir=build-test
 cd ${BOB_ROOT}/tests/
-rm -rf build-test # Cleanup test directory
-./bootstrap -o build-test
-cd build-test
+rm -rf ${build_dir} # Cleanup test directory
+./bootstrap -o ${build_dir}
 # Test by explicitly requesting the `bob_tests` alias, which should include all
 # test cases, including alias tests, which can't just set `build_by_default`.
-./config && ./buildme bob_tests
+${build_dir}/config && ${build_dir}/buildme bob_tests


### PR DESCRIPTION
The normal build test and the bootstrap test should be doing things in
a similar way.

Add a build_dir variable to the normal test.

Change boostrap test to run like the normal test does. Avoid
outputting to ${HOME}, as this is not in our workspace.

Change-Id: I8f9498dc631299cae04232b088d5a28d021d198a
Signed-off-by: David Kilroy <david.kilroy@arm.com>