### PR TITLE
Fix bob tests when work dir is the output dir

### DIFF
--- a/.travis/run_build_tests.sh
+++ b/.travis/run_build_tests.sh
@@ -3,10 +3,29 @@ set -eE
 trap "echo '<------------- run_build_tests.sh failed'" ERR
 
 export TEST_NON_ASCII_IN_ENV_HASH='ó'
-build_dir=build-test
-cd ${BOB_ROOT}/tests/
-rm -rf ${build_dir} # Cleanup test directory
-./bootstrap -o ${build_dir}
+
 # Test by explicitly requesting the `bob_tests` alias, which should include all
 # test cases, including alias tests, which can't just set `build_by_default`.
+
+# Build with working directory in source directory
+build_dir=build-in-src
+cd "${BOB_ROOT}/tests"
+rm -rf ${build_dir} # Cleanup test directory
+./bootstrap -o ${build_dir}
 ${build_dir}/config && ${build_dir}/buildme bob_tests
+
+# Build in an independent working directory
+build_dir=build-indep
+cd "${BOB_ROOT}"
+rm -rf ${build_dir} # Cleanup test directory
+tests/bootstrap -o ${build_dir}
+${build_dir}/config && ${build_dir}/buildme bob_tests
+
+# Build with the working directory in the output directory
+build_dir=build-in-outp
+cd "${BOB_ROOT}"
+rm -rf ${build_dir} # Cleanup test directory
+mkdir ${build_dir}
+cd ${build_dir}
+../tests/bootstrap -o .
+./config && ./buildme bob_tests

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2019 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -133,6 +133,9 @@ func (m *kernelModule) generateKbuildArgs(ctx blueprint.ModuleContext) map[strin
 
 	kmodBuild := filepath.Join(bobdir, "scripts", "kmod_build.py")
 	kdir := m.Properties.Build.Kernel_dir
+	if !filepath.IsAbs(kdir) {
+		kdir = filepath.Join(g.sourcePrefix(), kdir)
+	}
 
 	extraSymbols := ""
 	if len(m.extraSymbolsFiles(ctx)) > 0 {

--- a/docs/module_types/bob_kernel_module.md
+++ b/docs/module_types/bob_kernel_module.md
@@ -82,7 +82,8 @@ Arguments to pass to kernel make invocation.
 
 ----
 ### **bob_kernel_module.kernel_dir** (optional)
-Kernel directory location.
+Kernel directory location. This must either be absolute or relative to
+the top level source directory.
 
 ----
 ### **bob_kernel_module.kernel_cross_compile** (optional)

--- a/tests/export_include_dirs/liba/build.bp
+++ b/tests/export_include_dirs/liba/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2019 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,16 +21,19 @@ bob_static_library {
         "include",
     ],
     android: {
-        // Non-local include dirs are relative to the project root, which on
-        // Android, is the root of the Android tree, not the project using Bob.
-        // So $(LOCAL_PATH) needs to be included here.
+        // export_include_dirs are absolute. On Android, it may also
+        // be the root of the Android tree. So $(LOCAL_PATH) needs to be
+        // included here to test absolute path.
         export_include_dirs: [
             "$(LOCAL_PATH)/export_include_dirs/liba/include2",
         ],
     },
     linux: {
-        export_include_dirs: [
-            "export_include_dirs/liba/include2",
+        // include2 is intended to test export_include_dirs, but on
+        // linux this must be an absolute directory. This leaves
+        // export_include_dirs untested on Linux
+        export_local_include_dirs: [
+            "include2",
         ],
     },
     srcs: ["src/bob_test_liba.c"],

--- a/tests/kernel_module/module/build.bp
+++ b/tests/kernel_module/module/build.bp
@@ -3,12 +3,7 @@ bob_kernel_module {
     /* Usually kernel_dir would be an absolute path. For testing use this
      * workaround to use the spoofed kernel build system included with the Bob
      * tests. */
-    android: {
-        kernel_dir: "$(LOCAL_PATH)/kernel_module/kdir",
-    },
-    linux: {
-        kernel_dir: "kernel_module/kdir",
-    },
+    kernel_dir: "kernel_module/kdir",
     srcs: [
         "Kbuild",
         "test_module.c",


### PR DESCRIPTION
Kernel module kernel_dir is assumed to be absolute or relative to
source path.

We can no longer test export_include_dirs on Linux.

Add travis tests to check building in different locations.

Change-Id: Ida0af224b01f9bf317aa280000d0eef2fc278041
Signed-off-by: David Kilroy <david.kilroy@arm.com>