### PR TITLE
Fix bug in relative_path

### DIFF
--- a/tests/relative_path_tests.sh
+++ b/tests/relative_path_tests.sh
@@ -82,6 +82,12 @@ test_relpath "a/b/c" "x/y/z" "../../../x/y/z"
 test_relpath "a/b" "a/b2/c"  "../b2/c"
 test_relpath "a/b2/c" "a/b"  "../../b"
 
+# Check the special case where the common root is `/`
+test_relpath "/usr" "/bin" "../bin"
+test_relpath "/usr/local/bin" "/bin/bash" "../../../bin/bash"
+test_relpath "/" "/usr/include/stdio.h" "usr/include/stdio.h"
+test_relpath "/bin" "/" ".."
+
 # Cleanup
 rm -rf a x
 


### PR DESCRIPTION
When the iteration in `relative_path` got as far as going back to `/`,
it would get stuck in an infinite loop, because of comparing `${TGT_ABS}
!= ${CMN_PFX}/*` - in this case, CMN_PREFIX=/, so comparing with `//`
would always fail.

This incorrect check would also cause failures in cases like getting the
path from any absolute location to `/` - here, the `if` check would
fail, causing it to fall through into the broken `else` block, hitting
the same infinite loop.

Fix this by adding a `path_is_parent` helper, which has special handling
for `/`. Add some tests, and where appropriate, strip off trailing
slashes before joining paths to ensure we don't get double `//` path
dividers.

Add some tests, using some commonly-available system directories.

Change-Id: Idfe1a2eb291edd91bbd69fe53e172e93113f89c5
Signed-off-by: Chris Diamand <chris.diamand@arm.com>