### PR TITLE
Move path processing for generated sources

### DIFF
--- a/core/generated.go
+++ b/core/generated.go
@@ -376,7 +376,9 @@ func (m *generateCommon) getSources(ctx blueprint.ModuleContext) []string {
 }
 
 func (m *generateCommon) processPaths(ctx blueprint.BaseModuleContext) {
+	g := getBackend(ctx)
 	m.Properties.SourceProps.processPaths(ctx)
+	m.Properties.Export_gen_include_dirs = utils.PrefixDirs(m.Properties.Export_gen_include_dirs, g.sourceOutputDir(m))
 }
 
 func (m *generateCommon) getAliasList() []string {

--- a/core/library.go
+++ b/core/library.go
@@ -384,9 +384,7 @@ func (l *library) GetGeneratedHeaders(ctx blueprint.ModuleContext) (includeDirs 
 					return
 				}
 
-				includeDirs = append(includeDirs,
-					utils.PrefixDirs(gs.Properties.Export_gen_include_dirs,
-						g.sourceOutputDir(gs))...)
+				includeDirs = append(includeDirs, gs.Properties.Export_gen_include_dirs...)
 				// Generated headers are "order-only". That means that a source file does not need to rebuild
 				// if a generated header changes, just that it must be built after a generated header.
 				// The source file _will_ be rebuilt if it uses the header (since that is registered in the


### PR DESCRIPTION
Move prefix of the source directories for generated sources from library
GetGeneratedHeaders to processPaths as a first step to implement
referenced include dirs

Change-Id: I118ed2a9364efee874a0f2b1862ee0a3a6760616
Signed-off-by: Michal Widera <michal.widera@arm.com>