### PR TITLE
Change source encapsulation tests for android

### DIFF
--- a/tests/source_encapsulation/build.bp
+++ b/tests/source_encapsulation/build.bp
@@ -116,8 +116,10 @@ bob_binary {
 bob_binary {
     name: "validate_source_encapsulation_complex",
     generated_headers: ["encapsulation_source3_complex"],
-    build_wrapper: "source_encapsulation/check_includes.py",
     srcs: ["complex.c"],
+    linux: {
+        build_wrapper: "source_encapsulation/check_includes.py",
+    },
 }
 
 bob_alias {


### PR DESCRIPTION
This change disable part of the testcase which is currently not
implemented for Android related builds. Build wrapper command is
currently not available to use for Android builds, thus to allow testing
Bob it was required to issue it only for Linux builds.

Change-Id: I7cd0ab7dc2068b67a9c226a9b1b18d62cdf8a606
Signed-off-by: Michal Widera <michal.widera@arm.com>