### PR TITLE
Add copyright checker to Travis

### DIFF
--- a/.travis/checks/check-copyright.sh
+++ b/.travis/checks/check-copyright.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+BOB_ROOT=$(dirname ${0})/../..
+cd "${BOB_ROOT}"
+COPYRIGHT="copyright\s+[0-9,\s-]+"
+CHECKED_COMMIT=${TRAVIS_COMMIT:-HEAD}
+PARENT=$(git merge-base origin/master ${CHECKED_COMMIT})
+
+exit=0
+# Skip copyright verification when commit has revert in the title
+for commit in $(git log --pretty="%H"  ${PARENT}..${CHECKED_COMMIT}); do
+    title=$(git log --oneline -1 ${commit})
+    echo $title
+    if echo $title | grep -iq "revert"; then
+        continue
+    fi
+    for file in $(git diff --name-only --diff-filter=ACM ${commit}^ ${commit}); do
+        date_str=$(git show "${commit}:${file}" | head -15 | grep -iE "${COPYRIGHT}")
+        if [[ "${date_str}" == "" ]]; then
+            continue
+        fi
+        if [[ "${date_str}" != *"$(git show -s --format=%cd --date=format:%Y ${commit})"* ]]; then
+            echo " ${file} is missing year update of copyright"
+            exit+=1
+        fi
+    done
+done
+
+exit $exit

--- a/.travis/checks/run-checks.sh
+++ b/.travis/checks/run-checks.sh
@@ -16,7 +16,6 @@ fold_start 'Check:gofmt'
 fold_end
 ####################
 
-
 ####################
 fold_start 'Check:pep8'
     bash .travis/checks/check-pep8.sh
@@ -24,6 +23,12 @@ fold_start 'Check:pep8'
 fold_end
 ####################
 
+####################
+fold_start 'Check:copyright'
+    bash .travis/checks/check-copyright.sh
+    check_result $? "copyright:"
+fold_end
+####################
 
 ####################
 fold_start 'Check:signoff'


### PR DESCRIPTION
Verify current commit against parent to get files changed across the
commit then check if the current year is present in the copyright string
Avoid checking commit for copyright strings if the revert is triggered

Change-Id: Ieca245b9ecc9625b0ac0a30d5847b87483a94dc2
Signed-off-by: Michal Widera <michal.widera@arm.com>