### PR TITLE
User settable rpath

### DIFF
--- a/core/library.go
+++ b/core/library.go
@@ -138,6 +138,10 @@ type BuildProps struct {
 	// Files in the source directory that the wrapper depends on.
 	Build_wrapper_deps []string
 
+	// Adds DT_RPATH symbol to binaries and shared libraries so that they can find
+	// their dependencies at runtime.
+	Add_lib_dirs_to_rpath *bool
+
 	// This is a shared library that pulls in one or more shared
 	// libraries to resolve symbols that the binary needs. This is
 	// useful where a named library is the standard library to link
@@ -231,6 +235,13 @@ func (l *Build) isForwardingSharedLibrary() bool {
 		return false
 	}
 	return *l.Forwarding_shlib
+}
+
+func (l *Build) isRpathWanted() bool {
+	if l.Add_lib_dirs_to_rpath == nil {
+		return false
+	}
+	return *l.Add_lib_dirs_to_rpath
 }
 
 func (l *Build) getBuildWrapperAndDeps(ctx blueprint.ModuleContext) (string, []string) {

--- a/core/linux.go
+++ b/core/linux.go
@@ -531,17 +531,18 @@ func (l *library) getSharedLibFlags(ctx blueprint.ModuleContext) (flags []string
 	if hasForwardingLib {
 		flags = append(flags, "-fuse-ld=bfd")
 	}
-
-	if installPath, ok := l.Properties.InstallableProps.getInstallGroupPath(); ok {
-		for _, path := range libPaths {
-			out, err := filepath.Rel(installPath, path)
-			if err != nil {
-				panic(fmt.Errorf("Could not find relative path for: %s due to: %e", path, err))
+	if l.Properties.isRpathWanted() {
+		if installPath, ok := l.Properties.InstallableProps.getInstallGroupPath(); ok {
+			flags = append(flags, "-Wl,--enable-new-dtags")
+			for _, path := range libPaths {
+				out, err := filepath.Rel(installPath, path)
+				if err != nil {
+					panic(fmt.Errorf("Could not find relative path for: %s due to: %e", path, err))
+				}
+				flags = append(flags, "-Wl,-rpath='$$ORIGIN/"+out+"'")
 			}
-			flags = append(flags, "-Wl,-rpath='$$ORIGIN/"+out+"'")
 		}
 	}
-
 	return
 }
 

--- a/docs/module_types/bob_binary.md
+++ b/docs/module_types/bob_binary.md
@@ -55,6 +55,8 @@ bob_binary {
     build_wrapper: "ccache",
     build_wrapper_deps: ["config.py"],
 
+    add_lib_dirs_to_rpath: true,
+
     install_group: "bob_install_group.name",
     install_deps: ["module_name"],
     relative_install_path: "unit/objects",

--- a/docs/module_types/bob_shared_library.md
+++ b/docs/module_types/bob_shared_library.md
@@ -62,7 +62,9 @@ bob_shared_library {
 
     build_wrapper: "ccache",
     build_wrapper_deps: ["config.py"],
+
     forwarding_shlib: true,
+    add_lib_dirs_to_rpath: true,
 
     install_group: "bob_install_group.name",
     install_deps: ["bob_resource.name"],

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -250,6 +250,15 @@ the BFD linker.
 This isn't guaranteed to work on Android.
 
 ----
+### **bob_module.add_lib_dirs_to_rpath** (optional)
+If true, the module's shared libraries' directories will be added to
+its DT_RUNPATH entry. This allows the libraries to be found at runtime
+without setting LD_LIBRARY_PATH or putting them in a standard system
+location like `/usr/`."
+
+**Default value:** false
+
+----
 ### **bob_module.install_group** (optional)
 Module specifying an installation directory.
 


### PR DESCRIPTION
This change adds an option to previously created share of runtime path
between shared libraries and binaries. This change modify behavior of it
that the user need to explicitly mark each of shared libraries and
binaries to follow their rpath.

Change-Id: I89e6ab32e73112a4f6025f821777c2c49a1feda3
Signed-off-by: Michal Widera <michal.widera@arm.com>