### PR TITLE
Fix exporting of external include dirs

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -605,6 +605,7 @@ func Main() {
 
 		ctx.RegisterTopDownMutator("find_required_modules", findRequiredModulesMutator).Parallel()
 
+		ctx.RegisterTopDownMutator("check_reexport_libs", checkReexportLibsMutator).Parallel()
 		ctx.RegisterTopDownMutator("collect_reexport_lib_dependencies", collectReexportLibsDependenciesMutator).Parallel()
 		ctx.RegisterBottomUpMutator("apply_reexport_lib_dependencies", applyReexportLibsDependenciesMutator).Parallel()
 		ctx.RegisterTopDownMutator("encapsulates_mutator", encapsulatesMutator).Parallel()

--- a/core/library.go
+++ b/core/library.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"github.com/google/blueprint"
@@ -450,17 +449,6 @@ func (l *library) processBuildWrapper(ctx blueprint.BaseModuleContext) {
 	l.Properties.Build.Target.processBuildWrapper(ctx)
 }
 
-func getLibrary(i interface{}) (*library, bool) {
-	v := reflect.Indirect(reflect.ValueOf(i))
-	field := v.FieldByName("library")
-	ok := false
-	var l *library
-	if field.IsValid() {
-		l, ok = field.Addr().Interface().(*library)
-	}
-	return l, ok
-}
-
 type staticLibrary struct {
 	library
 }
@@ -611,6 +599,16 @@ func getBinaryOrSharedLib(m blueprint.Module) (*library, bool) {
 	return nil, false
 }
 
+func getLibrary(m blueprint.Module) (*library, bool) {
+	if bsl, ok := getBinaryOrSharedLib(m); ok {
+		return bsl, true
+	} else if sl, ok := m.(*staticLibrary); ok {
+		return &sl.library, true
+	}
+
+	return nil, false
+}
+
 func checkLibraryFieldsMutator(mctx blueprint.BottomUpMutatorContext) {
 	m := mctx.Module()
 	if b, ok := m.(*binary); ok {
@@ -637,7 +635,24 @@ func checkLibraryFieldsMutator(mctx blueprint.BottomUpMutatorContext) {
 		sl.checkField(len(props.Static_libs) == 0, "static_libs")
 		sl.checkField(props.Forwarding_shlib == nil, "forwarding_shlib")
 	}
+}
 
+// Check that each module only reexports libraries that it is actually using.
+func checkReexportLibsMutator(ctx blueprint.TopDownMutatorContext) {
+	if l, ok := getLibrary(ctx.Module()); ok {
+		for _, lib := range l.Properties.Reexport_libs {
+			if !utils.ListsContain(lib,
+				l.Properties.Shared_libs,
+				l.Properties.Static_libs,
+				l.Properties.Header_libs,
+				l.Properties.Whole_static_libs,
+				l.Properties.Export_shared_libs,
+				l.Properties.Export_static_libs,
+				l.Properties.Export_header_libs) {
+				panic(fmt.Errorf("%s reexports unused library %s", ctx.ModuleName(), lib))
+			}
+		}
+	}
 }
 
 // Traverse the dependency tree, following all StaticDepTag and WholeStaticDepTag links.

--- a/tests/external_libs/build.bp
+++ b/tests/external_libs/build.bp
@@ -41,10 +41,49 @@ bob_binary {
     },
 }
 
+// Attempt to use the external shared library using a "proxy" static library.
+// This checks that exported header paths are getting correctly propagated.
+
+bob_static_library {
+    name: "libbob_test_external_shared_proxy",
+    export_shared_libs: ["libbob_test_external_shared"],
+    // export_shared_libs just makes the final link use `-l$LIBNAME` - to
+    // propagate the include paths, we also need reexport_libs.
+    reexport_libs: ["libbob_test_external_shared"],
+    enabled: false,
+    android: {
+        enabled: true,
+    },
+}
+
+bob_static_library {
+    name: "use_external_lib_proxy",
+    srcs: ["use_external_shared_via_proxy.c"],
+    export_static_libs: ["libbob_test_external_shared_proxy"],
+    enabled: false,
+    android: {
+        enabled: true,
+    },
+}
+
+// This binary isn't required for the actual test - it just ensures that the
+// above library is included in the default build.
+bob_binary {
+    name: "use_external_lib_proxy_user",
+    srcs: ["external_lib.c"],
+    cflags: ["-DFUNC_NAME=main"],
+    static_libs: ["use_external_lib_proxy"],
+    enabled: false,
+    android: {
+        enabled: true,
+    },
+}
+
 bob_alias {
     name: "bob_test_external_libs",
     srcs: [
         "use_external_libs",
         "use_external_header",
+        "use_external_lib_proxy_user",
     ],
 }

--- a/tests/external_libs/use_external_shared_via_proxy.c
+++ b/tests/external_libs/use_external_shared_via_proxy.c
@@ -1,0 +1,5 @@
+#include "external_shared.h"
+
+int external_shared_via_proxy(void) {
+    return external_shared();
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -96,6 +96,15 @@ func Contains(list []string, x string) bool {
 	return false
 }
 
+func ListsContain(x string, lists ...[]string) bool {
+	for _, list := range lists {
+		if Contains(list, x) {
+			return true
+		}
+	}
+	return false
+}
+
 func Filter(predicate func(string) bool, lists ...[]string) (ret []string) {
 	for _, list := range lists {
 		for _, s := range list {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2019 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,6 +105,13 @@ func Test_Contains(t *testing.T) {
 	assertFalse(t, Contains([]string{}, "anything"), "empty list")
 	assertFalse(t, Contains([]string{}, ""), "empty strings")
 	assertTrue(t, Contains([]string{""}, ""), "empty strings")
+}
+
+func Test_ListsContain(t *testing.T) {
+	assertTrue(t, ListsContain("y", []string{"a", "b"}, []string{"x", "y"}), "multiple lists")
+	assertFalse(t, ListsContain("not present", []string{}, []string{""}), "empty list")
+	assertFalse(t, ListsContain("not present"), "no lists")
+	assertTrue(t, ListsContain("", []string{"hello", "", "world"}), "empty search term")
 }
 
 func Test_Filter(t *testing.T) {


### PR DESCRIPTION
Add a test case for the issue where re-exported libraries' include
directories were not being propagated to users. This was caused by not
specifying `LOCAL_EXPORT_[SHARED|STATIC|HEADER]_LIBRARIES` in the
generated makefiles.

Note that there is no `LOCAL_EXPORT_[...]_CFLAGS` equivalent in
Android.mk, because all exported cflags are propagated as far as the
final linking module. This is why `android_make.go` _appears_ to be only
re-exporting the include paths, rather than all cflags.

Add a check in a backend-independent mutator to verify that modules only
re-export libraries that they are actually using.

Change-Id: I309b7077321adae1d0e858a1e3f6fb3d15102c2d
Signed-off-by: Chris Diamand <chris.diamand@arm.com>