### PR TITLE
Fix export_gen_include_dirs on Android

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -736,9 +736,8 @@ func (g *androidMkGenerator) genStaticActions(m *generateStaticLibrary, ctx blue
 		g.generateCommonActions(sb, &m.generateCommon, ctx, inouts)
 
 		// Add prebuilt outputs
-		includeDirs := utils.PrefixDirs(m.generateCommon.Properties.Export_gen_include_dirs, g.sourceOutputDir(&m.generateCommon))
 		declarePrebuiltStaticLib(sb, m.altShortName(), getLibraryGeneratedPath(m, g),
-			strings.Join(includeDirs, " "),
+			strings.Join(m.generateCommon.Properties.Export_gen_include_dirs, " "),
 			m.generateCommon.Properties.Target != tgtTypeHost)
 
 		androidMkWriteString(ctx, m.altShortName(), sb)
@@ -751,9 +750,8 @@ func (g *androidMkGenerator) genSharedActions(m *generateSharedLibrary, ctx blue
 		g.generateCommonActions(sb, &m.generateCommon, ctx, inouts)
 
 		// Add prebuilt outputs
-		includeDirs := utils.PrefixDirs(m.generateCommon.Properties.Export_gen_include_dirs, g.sourceOutputDir(&m.generateCommon))
 		declarePrebuiltSharedLib(sb, m.altShortName(), getLibraryGeneratedPath(m, g),
-			strings.Join(includeDirs, " "),
+			strings.Join(m.generateCommon.Properties.Export_gen_include_dirs, " "),
 			m.generateCommon.Properties.Target != tgtTypeHost)
 
 		androidMkWriteString(ctx, m.altShortName(), sb)


### PR DESCRIPTION
Commit b87f82191362 moved path processing into a mutator, but only
fixed up the Linux backend. Update the Android backend so that the
correct include path is exported.

Change-Id: Id53fca0c5f8b0d9b0297771d2cbf0a0434a0a36b
Signed-off-by: David Kilroy <david.kilroy@arm.com>