### PR TITLE
Improve symlink replacement on install

### DIFF
--- a/core/linux.go
+++ b/core/linux.go
@@ -755,7 +755,7 @@ func (*linuxGenerator) aliasActions(m *alias, ctx blueprint.ModuleContext) {
 
 var installRule = pctx.StaticRule("install",
 	blueprint.RuleParams{
-		Command:     "cp -f $in $out",
+		Command:     "rm -f $out; cp $in $out",
 		Description: "$out",
 	})
 
@@ -782,7 +782,7 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 		rulename := "install"
 		tool := filepath.Join(g.sourcePrefix(), ctx.ModuleDir(), props.Post_install_tool)
 
-		cmd := "cp $in $out ; " + props.Post_install_cmd
+		cmd := "rm -f $out; cp $in $out ; " + props.Post_install_cmd
 
 		args["bob_config"] = configPath
 		args["tool"] = tool


### PR DESCRIPTION
When something is changed from a symlink to a non-symlink, then we
should remove the target before copying it.

Change-Id: Ia7f58569f130a65f4b0f046423ec141af9fbe0fa
Signed-off-by: David Kilroy <david.kilroy@arm.com>