### PR TITLE
Standardise and document template functions

### DIFF
--- a/core/template.go
+++ b/core/template.go
@@ -82,7 +82,7 @@ func regMatch(rule string, input string) bool {
 	return match
 }
 
-func regReplaceString(rule string, input string, replace string) string {
+func regReplace(rule string, input string, replace string) string {
 	re := regexp.MustCompile(rule)
 	return re.ReplaceAllString(input, replace)
 }
@@ -96,10 +96,11 @@ func matchSrcs(input string) string {
 func ApplyTemplate(props interface{}, properties *configProperties) {
 	stringvalues := properties.StringMap()
 	funcmap := make(map[string]interface{})
-	funcmap["toUpper"] = strings.ToUpper
+	funcmap["to_upper"] = strings.ToUpper
+	funcmap["to_lower"] = strings.ToLower
 	funcmap["split"] = strings.Split
-	funcmap["match"] = regMatch
-	funcmap["replace"] = regReplaceString
+	funcmap["reg_match"] = regMatch
+	funcmap["reg_replace"] = regReplace
 	funcmap["match_srcs"] = matchSrcs
 	propsVal := reflect.Indirect(reflect.ValueOf(props))
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -57,15 +57,29 @@ Features must not have the same name as any Bob module property.
 ## Templated parameters
 This feature allows for string replacements, using
 [Go's built-in template system](https://golang.org/pkg/text/template/).
-For example:
 
-`{{.param}}` - will be replaced with the value of `param` in the
-config. If `param` is a boolean value, `1` will be used for true
-and `0` for false.
+Configuration values are provided to the Go templates as data (as a
+map), and can be accessed by using keys, so `{{.param}}` will be
+replaced with the value of `param` from the config. If `param` is a
+boolean value, `1` will be used for true and `0` for false.
 
-`{{toUpper .param}}` - an upper-case variant of the parameter
+A few custom functions are implemented by Bob:
 
-And lot more. [Check Go template package.](https://golang.org/pkg/text/template/)
+`{{to_upper .param}}` - return the parameter as upper case
+
+`{{to_lower .param}}` - return the parameter as lower case
+
+`{{split .param sep}}` - separate the parameter into an array on each occurence of `sep`
+
+`{{reg_match regexp .param}}` - test if the parameter matches a regular expression
+
+`{{reg_replace regexp .param replace_re}}` - regular expression replacement on parameter
+
+`{{match_srcs file_glob}}` - expand to matching files in the module's
+                             `srcs` property (only valid in `ldflags`,
+                             `cmd` and `args`)
+
+Go templates natively support more. [Check Go template package.](https://golang.org/pkg/text/template/)
 
 #### Example
 This example shows an enum-like config option, `COLOR`, which is chosen based on

--- a/docs/user_guide/code_generation.md
+++ b/docs/user_guide/code_generation.md
@@ -129,8 +129,10 @@ outputs `${tool} -i ${in} ${out}`; for multiple inputs _and_ multiple
 outputs `${tool} -i ${in} -o ${out}` can work, as long as the tool is
 taught to parse the command line appropriately.
 
-Commands that use specific flags to identify a particular input/output
-are not well catered for.
+Commands that use specific flags to identify a particular output are
+not well catered for. For inputs, the template `{{match_srcs
+\"file.txt\"}}` can be used to name a particular file from the
+module's `src` list.
 
 The `${in}` variable contains all source files from `srcs` and
 `generated_sources`. The `${out}` variable contains all the outputs


### PR DESCRIPTION
We have a few different custom functions available via Go templates,
with varying naming convention. Standardise on snake case. Also prefix
regular expression functions with `reg_`.

Since we support `to_upper`, also support the converse, `to_lower`.

With {{match_srcs}} reduce the number of properties we allow it on.
The issue is that depending on the property, the dependencies need to
be setup slightly differently. Things kind-of work as is, but there
could be some subtle issues. Therefore support:

 * the primary case where ldflags needs to reference a file

 * ability for bob_generate_* to reference specific files in its cmd

Change-Id: I793933dc4e67d3fcea25c958a76dbbb4eb5fd25e
Signed-off-by: David Kilroy <david.kilroy@arm.com>