### PR TITLE
Fix minor lint issues

### DIFF
--- a/core/external_library.go
+++ b/core/external_library.go
@@ -26,7 +26,7 @@ type externalLib struct {
 	blueprint.SimpleName
 }
 
-func (l *externalLib) topLevelProperties() []interface{} { return []interface{}{} }
+func (m *externalLib) topLevelProperties() []interface{} { return []interface{}{} }
 
 func (m *externalLib) outputName() string   { return m.Name() }
 func (m *externalLib) altName() string      { return m.outputName() }

--- a/core/feature.go
+++ b/core/feature.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2019 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -97,7 +97,7 @@ func (f *Features) Init(availableFeatures []string, list ...interface{}) {
 	f.BlueprintEmbed = instancePtr.Interface()
 
 	instance := reflect.Indirect(instancePtr)
-	for i, _ := range availableFeatures {
+	for i := range availableFeatures {
 		propsInFeature := instance.Field(i).Addr().Interface().(*singleFeature)
 		propsInFeature.BlueprintEmbed = reflect.New(propsType).Interface()
 	}

--- a/scripts/setup_workspace_for_bob.bash
+++ b/scripts/setup_workspace_for_bob.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -97,6 +97,8 @@ fi
 if [ $UNBIND -eq 0 ]; then
     bind "${BOB_PATH}/blueprint" "${OUTPUT_PATH}/src/github.com/google/blueprint"
     bind "${BOB_PATH}" "${OUTPUT_PATH}/src/github.com/ARM-software/bob-build"
+
+    GOPATH=${OUTPUT_PATH} go get github.com/stretchr/testify
 
     echo "Go-compatible workspace created at ${OUTPUT_PATH}"
 else


### PR DESCRIPTION
Use a consistent identifier for externalLib.

Remove an unused 2nd loop argument.

When setting up the workspace, ensure testify is available.

Change-Id: Iadddf2a07f4559afbd0ddc901a5ddd6357482b14
Signed-off-by: David Kilroy <david.kilroy@arm.com>