### PR TITLE
Generate JSON during config

### DIFF
--- a/bob.bash
+++ b/bob.bash
@@ -35,11 +35,11 @@ if [[ "${BOB_BOOTSTRAP_VERSION}" != "${BOB_VERSION}" ]]; then
     exit 1
 fi
 
-# Convert Mconfig into Go-readable JSON. Because this is run at every rebuild
-# (rather than every bootstrap or re-configuration), this also adds a hash of
-# the environment into the config, so that Bob is rerun and the Ninja is
-# updated if a relevant environment variable is changed.
-python "${BOB_DIR}/scripts/generate_config_json.py" --database "${SRCDIR}/Mconfig" --output "${BUILDDIR}/config.json" ${BOB_CONFIG_OPTS} "${BUILDDIR}/${CONFIGNAME}"
+# Refresh the configuration. This means that options changed or added since the
+# last build will be chosen from their defaults automatically, so that users
+# don't have to reconfigure manually if the config database changes.
+python "${BOB_DIR}/config_system/update_config.py" \
+    --database "${SRCDIR}/Mconfig" --config "${BUILDDIR}/${CONFIGNAME}" ${BOB_CONFIG_OPTS}
 
 # Source the pathtools script - we need bob_realpath for CCACHE_BASEDIR.
 source "${BOB_DIR}/pathtools.bash"

--- a/bootstrap/utils.bash
+++ b/bootstrap/utils.bash
@@ -22,6 +22,8 @@ function write_bootstrap() {
         BOB_CONFIG_PLUGIN_OPTS="${BOB_CONFIG_PLUGIN_OPTS} -p ${i}"
     done
 
+    BOB_CONFIG_PLUGIN_OPTS="${BOB_CONFIG_PLUGIN_OPTS} -p ${BOB_DIR}/scripts/generate_config_json"
+
     source "${BOB_DIR}/bob.bootstrap.version"
 
     sed -e "s|@@WorkDir@@|${WORKDIR}|" \

--- a/config.bash
+++ b/config.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,10 +47,9 @@ done
 cd "${WORKDIR}"
 exit_status=0
 
-"${BOB_DIR}/config_system/update_config.py" -d "${SRCDIR}/Mconfig" ${BOB_CONFIG_OPTS} ${BOB_CONFIG_PLUGIN_OPTS} -o "${BUILDDIR}/${CONFIGNAME}.tmp" "${ARG_TARGET[@]}" || exit_status=$?
-
-# when warnings/errors occurred we still want to sync settings
-rsync -I -c "${BUILDDIR}/${CONFIGNAME}.tmp" "${BUILDDIR}/${CONFIGNAME}"
+"${BOB_DIR}/config_system/update_config.py" --new -d "${SRCDIR}/Mconfig" \
+    ${BOB_CONFIG_OPTS} ${BOB_CONFIG_PLUGIN_OPTS} \
+    -c "${BUILDDIR}/${CONFIGNAME}" "${ARG_TARGET[@]}" || exit_status=$?
 
 if [ "$exit_status" -eq "1" ]; then # warnings occurred
     exit 0

--- a/config_system/config_system/general.py
+++ b/config_system/config_system/general.py
@@ -17,6 +17,9 @@ import logging
 import os
 import re
 
+from config_system import utils
+
+
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
@@ -203,12 +206,16 @@ def get_mconfig_dir():
     return __mconfig_dir
 
 
-def init_config(options_filename, ignore_missing=False):
+def init_config(options_filename, _config_filename, ignore_missing=False):
     from config_system import lex, lex_wrapper, syntax
 
     global __mconfig_dir
+    global config_filename
     global configuration
     global menu_data
+
+    config_filename = _config_filename
+
     try:
         lexer = lex_wrapper.LexWrapper(ignore_missing)
         lexer.source(options_filename)
@@ -278,14 +285,14 @@ def read_config_file(config_filename):
 
 
 def read_config(options_filename, config_filename, ignore_missing):
-    init_config(options_filename, ignore_missing)
+    init_config(options_filename, config_filename, ignore_missing)
     read_config_file(config_filename)
     enforce_dependent_values(True)
 
 
 def write_config(config_filename):
     enforce_dependent_values()
-    with open(config_filename, "wt") as f:
+    with utils.open_and_write_if_changed(config_filename) as f:
         for i in sorted(configuration['order']):
             (i_type, i_symbol) = configuration['order'][i]
             if i_type in ["config", "menuconfig"]:

--- a/config_system/config_system/utils.py
+++ b/config_system/config_system/utils.py
@@ -1,0 +1,49 @@
+# Copyright 2019 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import logging
+import os
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+
+logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def open_and_write_if_changed(fname):
+    """Return a file-like object which buffers whatever is written to it. When
+    closing, compare the new content with the existing file, and avoid writing
+    to the file if no changes were made. This prevents the mtime being updated
+    unnecessarily.
+    """
+    buf = StringIO()
+    yield buf
+
+    same_content = False
+    try:
+        if os.path.isfile(fname):
+            with open(fname, "rt") as fp:
+                original_content = fp.read()
+                same_content = buf.getvalue() == original_content
+    finally:
+        if not same_content:
+            logger.debug("Updating {}".format(fname))
+            with open(fname, "wt") as fp:
+                fp.write(buf.getvalue())

--- a/config_system/menuconfig.py
+++ b/config_system/menuconfig.py
@@ -619,7 +619,6 @@ def gui_main(stdscr):
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("config", help="Path to the input configuration file (*.config)")
-    parser.add_argument("-o", "--output", help="Path to the output file")
     parser.add_argument("-d", "--database", default="Mconfig",
                         help="Path to the configuration database (Mconfig)")
     parser.add_argument("--debug", action="store_true", dest="debug", help="Enable debug logging")
@@ -627,7 +626,6 @@ def parse_args():
                         help="Post configuration plugin to execute", default=[])
     parser.add_argument("--ignore-missing", action="store_true", default=False,
                         help="Ignore missing database files included with 'source'")
-    parser.add_argument("args", nargs="*")
     return parser.parse_args()
 
 
@@ -651,8 +649,6 @@ def main():
 
     args = parse_args()
 
-    if args.output is None:
-        args.output = args.config
     if args.debug:
         root_logger.setLevel(logging.DEBUG)  # Update root logger
 
@@ -679,7 +675,7 @@ def main():
                 import traceback
                 traceback.print_tb(sys.exc_info()[2])
 
-        general.write_config(args.output)
+        general.write_config(args.config)
 
     # Flush all log messages on exit
     msgBuffer.close()

--- a/config_system/tests/test_update_config.py
+++ b/config_system/tests/test_update_config.py
@@ -120,8 +120,9 @@ def test_ignored_config_option(caplog, mocker, tmpdir, mconfig, args, error):
     mconfig_fname.write(mconfig, "wt")
 
     mocker.patch("update_config.parse_args", new=lambda: argparse.Namespace(
-        output=str(config_fname),
+        config=str(config_fname),
         database=str(mconfig_fname),
+        new=False,
         plugin=[],
         ignore_missing=False,
         args=args,

--- a/config_system/update_config.py
+++ b/config_system/update_config.py
@@ -24,7 +24,8 @@ import sys
 
 from config_system import log_handlers
 from config_system.general import enforce_dependent_values, get_config, init_config, \
-    read_profile_file, set_config_if_prompt, write_config, can_enable, format_dependency_list
+    read_config, read_profile_file, set_config_if_prompt, write_config, \
+    can_enable, format_dependency_list
 
 root_logger = logging.getLogger()
 root_logger.setLevel(logging.WARNING)
@@ -117,10 +118,12 @@ def check_values_as_requested(args):
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-o', '--output', required=True,
-                        help='Path to the output file')
+    parser.add_argument("-c", "--config", required=True,
+                        help="Path to the configuration file (*.config)")
     parser.add_argument('-d', '--database', default="Mconfig",
                         help='Path to the configuration database (Mconfig)')
+    parser.add_argument("-n", "--new", action="store_true", default=False,
+                        help="Create the configuration instead of resetting to default values")
     parser.add_argument('-p', '--plugin', action='append',
                         help='Post configuration plugin to execute',
                         default=[])
@@ -133,7 +136,10 @@ def parse_args():
 def main():
     args = parse_args()
 
-    init_config(args.database, args.ignore_missing)
+    if args.new:
+        init_config(args.database, args.config, args.ignore_missing)
+    else:
+        read_config(args.database, args.config, args.ignore_missing)
 
     files = []
     setters = []
@@ -166,7 +172,7 @@ def main():
             import traceback
             traceback.print_tb(sys.exc_info()[2])
 
-    write_config(args.output)
+    write_config(args.config)
 
     issues = counter.errors() + counter.criticals()
     warnings = counter.warnings()

--- a/menuconfig.bash
+++ b/menuconfig.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,10 +27,9 @@ source "${BOOTSTRAP}"
 cd "${WORKDIR}"
 exit_status=0
 
-"${BOB_DIR}/config_system/menuconfig.py" -d "${SRCDIR}/Mconfig" ${BOB_CONFIG_OPTS} ${BOB_CONFIG_PLUGIN_OPTS} -o "${BUILDDIR}/${CONFIGNAME}.tmp" "${BUILDDIR}/${CONFIGNAME}" || exit_status=$?
-
-# when warnings/errors occurred we still want to sync settings
-rsync -I -c "${BUILDDIR}/${CONFIGNAME}.tmp" "${BUILDDIR}/${CONFIGNAME}"
+"${BOB_DIR}/config_system/menuconfig.py" -d "${SRCDIR}/Mconfig" \
+    ${BOB_CONFIG_OPTS} ${BOB_CONFIG_PLUGIN_OPTS} \
+    "${BUILDDIR}/${CONFIGNAME}" || exit_status=$?
 
 if [ "$exit_status" -eq "1" ]; then # warnings occurred
     exit 0

--- a/scripts/minimal_config.py
+++ b/scripts/minimal_config.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 # This script will read the config file and output a minimal json file
 # containing just the user settable options.
 
-def generate_config_json(database_fname, config_fname, ignore_missing):
+def config_to_json(database_fname, config_fname, ignore_missing):
     config_system.read_config(database_fname, config_fname, ignore_missing)
     config_list = config_system.get_config_list()
 
@@ -61,22 +61,7 @@ def generate_config_json(database_fname, config_fname, ignore_missing):
                 logger.critical(msg % (datatype, str(value)))
                 sys.exit(1)
 
-    return json.dumps(configs,
-                      sort_keys=True, indent=4, separators=(',', ': '))
-
-
-# Write 'text' to file 'fname' only if the content will change.
-def write_if_different(fname, text):
-    same_content = False
-    if os.path.isfile(fname):
-        with open(fname, "r+") as fp:
-            original = fp.read()
-            same_content = text == original
-
-    if not same_content:
-        logger.info("Writing config JSON to %s" % fname)
-        with open(fname, "w") as fp:
-            fp.write(text)
+    return configs
 
 
 def main():
@@ -98,8 +83,9 @@ def main():
         logger.error("No such file: %s" % args.config)
         sys.exit(1)
 
-    text = generate_config_json(args.database, args.config, args.ignore_missing)
-    write_if_different(args.output, text)
+    json_config = config_to_json(args.database, args.config, args.ignore_missing)
+    with config_system.utils.open_and_write_if_changed(args.output) as fp:
+        json.dump(json_config, fp, sort_keys=True, indent=4, separators=(',', ': '))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Write the JSON version of the config whenever the .config file is
generated, by making the `generate_config_json` script a Bob plugin
instead.

This is required for Soong, where there is no equivalent of the
`buildme` script to do this.

Change-Id: I7ab58efc0d58fea7da6ba9db0323d705aa211a7c
Signed-off-by: Chris Diamand <chris.diamand@arm.com>