### PR TITLE
Soong tweaks

### DIFF
--- a/Android.bp.in
+++ b/Android.bp.in
@@ -52,10 +52,6 @@ bootstrap_go_package {
         "core/linux.go",
         "@@SOONG_CONFIG_GO@@",
     ],
-    testSrcs: [
-        "core/feature_test.go",
-        "core/template_test.go",
-    ],
     pkgPath: "github.com/ARM-software/bob-build/core",
 }
 
@@ -67,9 +63,6 @@ bootstrap_go_package {
     srcs: [
         "graph/graph.go",
     ],
-    testSrcs: [
-        "graph/graph_test.go"
-    ],
     pkgPath: "github.com/ARM-software/bob-build/graph",
 }
 
@@ -77,9 +70,6 @@ bootstrap_go_package {
     name: "bob-utils-@@PROJ_NAME@@",
     srcs: [
         "utils/utils.go",
-    ],
-    testSrcs: [
-        "utils/utils_test.go",
     ],
     pkgPath: "github.com/ARM-software/bob-build/utils",
 }

--- a/bootstrap_soong.bash
+++ b/bootstrap_soong.bash
@@ -53,7 +53,6 @@ create_config_symlinks "$(relative_path "${BUILDDIR}" "${BOB_DIR}")" "${BUILDDIR
 
 CONFIG_JSON="${BUILDDIR}/config.json"
 SOONG_CONFIG_GO="${BUILDDIR}/soong_config.go"
-SOONG_CONFIG_GO_FROM_BOB=$(relative_path "${BOB_DIR}" "${SOONG_CONFIG_GO}")
 
 # Create a Go file containing the path to the config file, which will be
 # compiled into the Soong plugin. This is required because the module factories
@@ -64,6 +63,8 @@ sed -e "s#@@CONFIG_JSON@@#${CONFIG_JSON}#" \
     "${BOB_DIR}/core/soong_config.go.in" > "${TMP_GO_CONFIG}"
 rsync --checksum "${TMP_GO_CONFIG}" "${SOONG_CONFIG_GO}"
 rm -f "${TMP_GO_CONFIG}"
+
+SOONG_CONFIG_GO_FROM_BOB=$(relative_path "${BOB_DIR}" "${SOONG_CONFIG_GO}")
 
 # Set up Bob's Android.bp
 pushd "${BOB_DIR}" >&/dev/null


### PR DESCRIPTION
A couple issues encountered when setting up to build the soong plugin.

Since we added testify usage in our tests, soong complains. For now
avoid mentioning any of our tests in Android.bp.in

relative_path currently requires the target to exist, so we can only
calculate SOONG_CONFIG_FROM_BOB after we have generated
soong_config.go.

Change-Id: I0ec8d2349c24de31a7dc41b221c2e20136be965d
Signed-off-by: David Kilroy <david.kilroy@arm.com>