### PR TITLE
Make menuconfig arguments available to plugins

### DIFF
--- a/config_system/config_system/__init__.py
+++ b/config_system/config_system/__init__.py
@@ -32,9 +32,12 @@ from config_system.general import \
     get_config_int, \
     get_config_list, \
     get_config_string, \
-    get_mconfig_dir, \
     get_options_depending_on, \
     get_options_selecting, \
     init_config, \
     read_config, \
     set_config  # nopep8: E402 module level import not at top of file
+
+from config_system.utils import \
+    get_config_dir, \
+    get_mconfig_dir  # nopep8: E402 module level import not at top of file

--- a/config_system/config_system/general.py
+++ b/config_system/config_system/general.py
@@ -196,25 +196,11 @@ def enforce_dependent_values(auto_fix=False):
             set_config_internal(i, 0)
 
 
-__mconfig_dir = ""
-
-
-def get_mconfig_dir():
-    """
-    Retrieve the path to the input option database.
-    """
-    return __mconfig_dir
-
-
-def init_config(options_filename, _config_filename, ignore_missing=False):
+def init_config(options_filename, ignore_missing=False):
     from config_system import lex, lex_wrapper, syntax
 
-    global __mconfig_dir
-    global config_filename
     global configuration
     global menu_data
-
-    config_filename = _config_filename
 
     try:
         lexer = lex_wrapper.LexWrapper(ignore_missing)
@@ -226,7 +212,6 @@ def init_config(options_filename, _config_filename, ignore_missing=False):
     except syntax.ParseError as e:
         logger.debug("Parse error")
         exit(1)
-    __mconfig_dir = os.path.dirname(options_filename)
     menu_data = menu_parse(configuration)
 
     set_initial_values()
@@ -285,7 +270,7 @@ def read_config_file(config_filename):
 
 
 def read_config(options_filename, config_filename, ignore_missing):
-    init_config(options_filename, config_filename, ignore_missing)
+    init_config(options_filename, ignore_missing)
     read_config_file(config_filename)
     enforce_dependent_values(True)
 

--- a/config_system/config_system/utils.py
+++ b/config_system/config_system/utils.py
@@ -26,6 +26,9 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+__args = None
+
+
 @contextlib.contextmanager
 def open_and_write_if_changed(fname):
     """Return a file-like object which buffers whatever is written to it. When
@@ -47,3 +50,27 @@ def open_and_write_if_changed(fname):
             logger.debug("Updating {}".format(fname))
             with open(fname, "wt") as fp:
                 fp.write(buf.getvalue())
+
+
+def get_config_dir():
+    """
+    Retrieve the path to the directory containing the configuration file.
+    """
+    return os.path.dirname(__args.config)
+
+
+def get_mconfig_dir():
+    """
+    Retrieve the path to the directory containing the input option database.
+    """
+    return os.path.dirname(__args.database)
+
+
+def parse_args(parser):
+    """
+    Capture input arguments so that we can supply wrapper functions to
+    plugins to retrieve interesting values.
+    """
+    global __args
+    __args = parser.parse_args()
+    return __args

--- a/config_system/menuconfig.py
+++ b/config_system/menuconfig.py
@@ -23,7 +23,7 @@ import logging
 import os
 import sys
 
-from config_system import general, log_handlers
+from config_system import general, log_handlers, utils
 
 logger = logging.getLogger(__name__)
 
@@ -626,7 +626,7 @@ def parse_args():
                         help="Post configuration plugin to execute", default=[])
     parser.add_argument("--ignore-missing", action="store_true", default=False,
                         help="Ignore missing database files included with 'source'")
-    return parser.parse_args()
+    return utils.parse_args(parser)
 
 
 def main():

--- a/config_system/update_config.py
+++ b/config_system/update_config.py
@@ -22,7 +22,7 @@ import os
 import re
 import sys
 
-from config_system import log_handlers
+from config_system import log_handlers, utils
 from config_system.general import enforce_dependent_values, get_config, init_config, \
     read_config, read_profile_file, set_config_if_prompt, write_config, \
     can_enable, format_dependency_list
@@ -130,14 +130,14 @@ def parse_args():
     parser.add_argument('--ignore-missing', action='store_true', default=False,
                         help="Ignore missing database files included with 'source'")
     parser.add_argument('args', nargs="*")
-    return parser.parse_args()
+    return utils.parse_args(parser)
 
 
 def main():
     args = parse_args()
 
     if args.new:
-        init_config(args.database, args.config, args.ignore_missing)
+        init_config(args.database, args.ignore_missing)
     else:
         read_config(args.database, args.config, args.ignore_missing)
 

--- a/scripts/generate_config_json.py
+++ b/scripts/generate_config_json.py
@@ -63,7 +63,7 @@ def config_to_json():
 
 
 def plugin_exec():
-    output_dir = os.path.dirname(config_system.general.config_filename)
+    output_dir = config_system.get_config_dir()
     json_filename = os.path.join(output_dir, "config.json")
     json_config = config_to_json()
     with config_system.utils.open_and_write_if_changed(json_filename) as fp:


### PR DESCRIPTION
In commit e53161f277b we modified the prototype of init_config() to
record the filename that would be used to save the config file, for
use by a plugin. This broke some external code that is also calling
init_config().

It doesn't actually make sense to pass a filename in this call, so
come up with an alternative way to get the filename.

Provide a wrapper for parse_args(), so that we can keep a copy of all
the arguments for any invocation. Provide wrapper functions to get the
appropriate options. Remove some custom code that was doing something
similar for the database directory.

Change-Id: I0dfb052986581a4aff61d948554607737d49af68
Signed-off-by: David Kilroy <david.kilroy@arm.com>