### PR TITLE
Correct Testify argument order

### DIFF
--- a/core/feature_test.go
+++ b/core/feature_test.go
@@ -161,18 +161,18 @@ func createTestModuleAndFeatures() (testProps, configProperties) {
 func Test_should_return_expected_default_values_when_using_setup_function(t *testing.T) {
 	module, properties := createTestModuleAndFeatures()
 
-	assert.Equalf(t, properties.features["feature_a"], true, "feature_a should be enabled by default")
-	assert.Equalf(t, properties.features["feature_b"], true, "feature_b should be enabled by default")
-	assert.Equalf(t, properties.features["feature_c"], true, "feature_c should be enabled by default")
-	assert.Equalf(t, properties.features["feature_d"], true, "feature_d should be enabled by default")
+	assert.True(t, properties.features["feature_a"], "feature_a should be enabled by default")
+	assert.True(t, properties.features["feature_b"], "feature_b should be enabled by default")
+	assert.True(t, properties.features["feature_c"], "feature_c should be enabled by default")
+	assert.True(t, properties.features["feature_d"], "feature_d should be enabled by default")
 
-	assert.Equalf(t, module.FieldA, "a", "module.FieldA should be equal to default value")
-	assert.Equalf(t, module.FieldB, "b", "module.FieldB should be equal to default value")
-	assert.Equalf(t, module.FieldC, "c", "module.FieldC should be equal to default value")
-	assert.Equalf(t, module.FieldD, "d", "module.FieldD should be equal to default value")
-	assert.Equalf(t, module.FieldE, "e", "module.FieldE should be equal to default value")
-	assert.Equalf(t, module.FieldF, "f", "module.FieldF should be equal to default value")
-	assert.Equalf(t, module.FieldG, "g", "module.FieldG should be equal to default value")
+	assert.Equalf(t, "a", module.FieldA, "module.FieldA should be equal to default value")
+	assert.Equalf(t, "b", module.FieldB, "module.FieldB should be equal to default value")
+	assert.Equalf(t, "c", module.FieldC, "module.FieldC should be equal to default value")
+	assert.Equalf(t, "d", module.FieldD, "module.FieldD should be equal to default value")
+	assert.Equalf(t, "e", module.FieldE, "module.FieldE should be equal to default value")
+	assert.Equalf(t, "f", module.FieldF, "module.FieldF should be equal to default value")
+	assert.Equalf(t, "g", module.FieldG, "module.FieldG should be equal to default value")
 }
 
 func Test_should_not_change_when_appending_empty_features(t *testing.T) {
@@ -197,18 +197,18 @@ func Test_should_append_matching_properties_when_one_feature_is_enabled(t *testi
 	properties.features["feature_c"] = false
 	properties.features["feature_d"] = false
 
-	assert.Equalf(t, properties.features["feature_b"], true, "Feature should be enabled")
+	assert.True(t, properties.features["feature_b"], "Feature should be enabled")
 	if err := module.AppendProps([]interface{}{&module}, &properties); err != nil {
 		panic(err)
 	}
 
-	assert.Equalf(t, module.FieldA, "a", "module.FieldA incorrect")
-	assert.Equalf(t, module.FieldB, "bProps_b", "module.FieldB incorrect")
-	assert.Equalf(t, module.FieldC, "c", "module.FieldC incorrect")
-	assert.Equalf(t, module.FieldD, "d", "module.FieldD can't be changed") // No feature has this property
-	assert.Equalf(t, module.FieldE, "e", "module.FieldE incorrect")
-	assert.Equalf(t, module.FieldF, "f", "module.FieldF incorrect")
-	assert.Equalf(t, module.FieldG, "g", "module.FieldG incorrect")
+	assert.Equalf(t, "a", module.FieldA, "module.FieldA incorrect")
+	assert.Equalf(t, "bProps_b", module.FieldB, "module.FieldB incorrect")
+	assert.Equalf(t, "c", module.FieldC, "module.FieldC incorrect")
+	assert.Equalf(t, "d", module.FieldD, "module.FieldD can't be changed") // No feature has this property
+	assert.Equalf(t, "e", module.FieldE, "module.FieldE incorrect")
+	assert.Equalf(t, "f", module.FieldF, "module.FieldF incorrect")
+	assert.Equalf(t, "g", module.FieldG, "module.FieldG incorrect")
 }
 
 func Test_should_not_modify_when_no_feature_is_enabled(t *testing.T) {
@@ -222,13 +222,13 @@ func Test_should_not_modify_when_no_feature_is_enabled(t *testing.T) {
 		panic(err)
 	}
 
-	assert.Equalf(t, module.FieldA, "a", "module.FieldA incorrect")
-	assert.Equalf(t, module.FieldB, "b", "module.FieldB incorrect")
-	assert.Equalf(t, module.FieldC, "c", "module.FieldC incorrect")
-	assert.Equalf(t, module.FieldD, "d", "module.FieldD can't be changed") // No feature has this property
-	assert.Equalf(t, module.FieldE, "e", "module.FieldE incorrect")
-	assert.Equalf(t, module.FieldF, "f", "module.FieldF incorrect")
-	assert.Equalf(t, module.FieldG, "g", "module.FieldG incorrect")
+	assert.Equalf(t, "a", module.FieldA, "module.FieldA incorrect")
+	assert.Equalf(t, "b", module.FieldB, "module.FieldB incorrect")
+	assert.Equalf(t, "c", module.FieldC, "module.FieldC incorrect")
+	assert.Equalf(t, "d", module.FieldD, "module.FieldD can't be changed") // No feature has this property
+	assert.Equalf(t, "e", module.FieldE, "module.FieldE incorrect")
+	assert.Equalf(t, "f", module.FieldF, "module.FieldF incorrect")
+	assert.Equalf(t, "g", module.FieldG, "module.FieldG incorrect")
 }
 
 func Test_should_append_properties_in_desired_order_when_using_append_props(t *testing.T) {
@@ -241,13 +241,13 @@ func Test_should_append_properties_in_desired_order_when_using_append_props(t *t
 	if err := module.AppendProps([]interface{}{&module}, &properties); err != nil {
 		panic(err)
 	}
-	assert.Equalf(t, module.FieldA, "aProps_a", "module.FieldA incorrect")
-	assert.Equalf(t, module.FieldB, "bProps_b", "module.FieldB incorrect")
-	assert.Equalf(t, module.FieldC, "cProps_c", "module.FieldC incorrect")
-	assert.Equalf(t, module.FieldD, "d", "module.FieldD can't be changed") // No feature has this property
-	assert.Equalf(t, module.FieldE, "e", "module.FieldE incorrect")
-	assert.Equalf(t, module.FieldF, "f", "module.FieldF incorrect")
-	assert.Equalf(t, module.FieldG, "gProps_g", "module.FieldG incorrect")
+	assert.Equalf(t, "aProps_a", module.FieldA, "module.FieldA incorrect")
+	assert.Equalf(t, "bProps_b", module.FieldB, "module.FieldB incorrect")
+	assert.Equalf(t, "cProps_c", module.FieldC, "module.FieldC incorrect")
+	assert.Equalf(t, "d", module.FieldD, "module.FieldD can't be changed") // No feature has this property
+	assert.Equalf(t, "e", module.FieldE, "module.FieldE incorrect")
+	assert.Equalf(t, "f", module.FieldF, "module.FieldF incorrect")
+	assert.Equalf(t, "gProps_g", module.FieldG, "module.FieldG incorrect")
 
 	properties.features["feature_a"] = false
 	properties.features["feature_b"] = false
@@ -257,13 +257,13 @@ func Test_should_append_properties_in_desired_order_when_using_append_props(t *t
 	if err := module.AppendProps([]interface{}{&module}, &properties); err != nil {
 		panic(err)
 	}
-	assert.Equalf(t, module.FieldA, "aProps_a+D_a", "module.FieldA incorrect")
-	assert.Equalf(t, module.FieldB, "bProps_b+D_b", "module.FieldB incorrect")
-	assert.Equalf(t, module.FieldC, "cProps_c+D_c", "module.FieldC incorrect")
-	assert.Equalf(t, module.FieldD, "d", "module.FieldD can't be changed") // No feature has this property
-	assert.Equalf(t, module.FieldE, "e+D_e", "module.FieldE incorrect")
-	assert.Equalf(t, module.FieldF, "f+D_f", "module.FieldF incorrect")
-	assert.Equalf(t, module.FieldG, "gProps_g+D_g", "module.FieldG incorrect")
+	assert.Equalf(t, "aProps_a+D_a", module.FieldA, "module.FieldA incorrect")
+	assert.Equalf(t, "bProps_b+D_b", module.FieldB, "module.FieldB incorrect")
+	assert.Equalf(t, "cProps_c+D_c", module.FieldC, "module.FieldC incorrect")
+	assert.Equalf(t, "d", module.FieldD, "module.FieldD can't be changed") // No feature has this property
+	assert.Equalf(t, "e+D_e", module.FieldE, "module.FieldE incorrect")
+	assert.Equalf(t, "f+D_f", module.FieldF, "module.FieldF incorrect")
+	assert.Equalf(t, "gProps_g+D_g", module.FieldG, "module.FieldG incorrect")
 
 	properties.features["feature_a"] = false
 	properties.features["feature_b"] = true
@@ -273,13 +273,13 @@ func Test_should_append_properties_in_desired_order_when_using_append_props(t *t
 	if err := module.AppendProps([]interface{}{&module}, &properties); err != nil {
 		panic(err)
 	}
-	assert.Equalf(t, module.FieldA, "aProps_a+D_a+D_a", "module.FieldA incorrect")
-	assert.Equalf(t, module.FieldB, "bProps_b+D_bProps_b+D_b", "module.FieldB incorrect")
-	assert.Equalf(t, module.FieldC, "cProps_c+D_c+D_c", "module.FieldC incorrect")
-	assert.Equalf(t, module.FieldD, "d", "module.FieldD can't be changed") // No feature has this property
-	assert.Equalf(t, module.FieldE, "e+D_e+D_e", "module.FieldE incorrect")
-	assert.Equalf(t, module.FieldF, "f+D_f+D_f", "module.FieldF incorrect")
-	assert.Equalf(t, module.FieldG, "gProps_g+D_g+D_g", "module.FieldG incorrect")
+	assert.Equalf(t, "aProps_a+D_a+D_a", module.FieldA, "module.FieldA incorrect")
+	assert.Equalf(t, "bProps_b+D_bProps_b+D_b", module.FieldB, "module.FieldB incorrect")
+	assert.Equalf(t, "cProps_c+D_c+D_c", module.FieldC, "module.FieldC incorrect")
+	assert.Equalf(t, "d", module.FieldD, "module.FieldD can't be changed") // No feature has this property
+	assert.Equalf(t, "e+D_e+D_e", module.FieldE, "module.FieldE incorrect")
+	assert.Equalf(t, "f+D_f+D_f", module.FieldF, "module.FieldF incorrect")
+	assert.Equalf(t, "gProps_g+D_g+D_g", module.FieldG, "module.FieldG incorrect")
 }
 
 //  It is important that names start from uppercase, otherwise they aren't exported (when nested)
@@ -335,8 +335,8 @@ func Test_should_append_properties_when_using_nested_destinations(t *testing.T) 
 		panic(err)
 	}
 
-	assert.Equalf(t, module.testSource.Properties.A, "mod_a+value_a", "module.testSource.Properties.A incorrect")
-	assert.Equalf(t, module.testInstall.Properties.B, "mod_b+value_b", "module.testInstall.Properties.B incorrect")
+	assert.Equalf(t, "mod_a+value_a", module.testSource.Properties.A, "module.testSource.Properties.A incorrect")
+	assert.Equalf(t, "mod_b+value_b", module.testInstall.Properties.B, "module.testInstall.Properties.B incorrect")
 }
 
 func Test_should_append_props_when_using_nested_structs(t *testing.T) {
@@ -418,23 +418,23 @@ func Test_should_append_props_when_using_nested_structs(t *testing.T) {
 		panic(err)
 	}
 
-	assert.Equalf(t, module.TestModuleCommon.Properties.A, "mod_TestSourceProps.A+feature.A",
+	assert.Equalf(t, "mod_TestSourceProps.A+feature.A", module.TestModuleCommon.Properties.A,
 		"module.TestModuleCommon.Properties.A incorrect")
-	assert.Equalf(t, module.TestModuleCommon.Properties.B, "mod_TestInstallProps.B+feature.B",
+	assert.Equalf(t, "mod_TestInstallProps.B+feature.B", module.TestModuleCommon.Properties.B,
 		"module.TestModuleCommon.Properties.B incorrect")
-	assert.Equalf(t, *module.TestModuleCommon.Properties.Nested.Bar, true,
+	assert.Equalf(t, true, *module.TestModuleCommon.Properties.Nested.Bar,
 		" module.TestModuleCommon.Properties.Nested.Bar incorrect")
-	assert.Equalf(t, module.TestModuleCommon.Properties.Nested.Foo, "mod_foo+feature.Foo",
+	assert.Equalf(t, "mod_foo+feature.Foo", module.TestModuleCommon.Properties.Nested.Foo,
 		"module.TestModuleCommon.Properties.Nested.Foo incorrect")
-	assert.Equalf(t, module.TestModuleCommon.Properties.TestSourceProps.A, "mod_TestSourceProps.A+feature.A",
+	assert.Equalf(t, "mod_TestSourceProps.A+feature.A", module.TestModuleCommon.Properties.TestSourceProps.A,
 		"module.TestModuleCommon.Properties.TestSourceProps.A incorrect")
-	assert.Equalf(t, module.TestModuleCommon.Properties.TestInstallProps.B, "mod_TestInstallProps.B+feature.B",
+	assert.Equalf(t, "mod_TestInstallProps.B+feature.B", module.TestModuleCommon.Properties.TestInstallProps.B,
 		"module.TestModuleCommon.Properties.TestInstallProps.B incorrect")
 }
 
 func Test_should_not_squash_when_one_structs_passed(t *testing.T) {
 	squashed := coalesceTypes(typesOf(testPropsGroupA{})...)
-	assert.Equalf(t, reflect.TypeOf(testPropsGroupA{}), squashed, "Types should be the same")
+	assert.Equalf(t, squashed, reflect.TypeOf(testPropsGroupA{}), "Types should be the same")
 }
 
 func Test_should_composite_new_type(t *testing.T) {

--- a/core/template_test.go
+++ b/core/template_test.go
@@ -81,23 +81,23 @@ func TestApplyTemplate(t *testing.T) {
 	ApplyTemplate(&props, config)
 
 	// Check templates are expanded in normal strings
-	assert.Equalf(t, props.StrA, "alpha", "StrA incorrect")
-	assert.Equalf(t, props.StrB, "beta", "StrB incorrect")
-	assert.Equalf(t, props.StrC, "gamma", "StrC incorrect")
+	assert.Equalf(t, "alpha", props.StrA, "StrA incorrect")
+	assert.Equalf(t, "beta", props.StrB, "StrB incorrect")
+	assert.Equalf(t, "gamma", props.StrC, "StrC incorrect")
 
 	// Check 'booleans'. These are actually strings as far as the
 	// template code is concerned
-	assert.Equalf(t, props.B1, "1", "B1 incorrect")
-	assert.Equalf(t, props.B2, "0", "B2 incorrect")
+	assert.Equalf(t, "1", props.B1, "B1 incorrect")
+	assert.Equalf(t, "0", props.B2, "B2 incorrect")
 
 	// Check templates have been expanded in arrays of strings
-	assert.Equalf(t, arr[0], "alpha", "arr[0] incorrect")
-	assert.Equalf(t, arr[1], "beta", "arr[1] incorrect")
-	assert.Equalf(t, arr[2], "gamma", "arr[2] incorrect")
+	assert.Equalf(t, "alpha", arr[0], "arr[0] incorrect")
+	assert.Equalf(t, "beta", arr[1], "arr[1] incorrect")
+	assert.Equalf(t, "gamma", arr[2], "arr[2] incorrect")
 
 	// Check templates have been expanded in pointers to strings
-	assert.Equalf(t, refA, "alpha1", "refA incorrect")
-	assert.Equalf(t, refB, "beta0", "refB incorrect")
+	assert.Equalf(t, "alpha1", refA, "refA incorrect")
+	assert.Equalf(t, "beta0", refB, "refB incorrect")
 }
 
 type testNestedProperties struct {
@@ -149,29 +149,29 @@ func TestApplyTemplateNested(t *testing.T) {
 	ApplyTemplate(&props, config)
 
 	// Check templates are expanded in normal strings
-	assert.Equalf(t, props.A.StrA, "alpha", "A.StrA incorrect")
-	assert.Equalf(t, props.A.StrB, "beta", "A.StrB incorrect")
-	assert.Equalf(t, props.A.StrC, "gamma", "A.StrC incorrect")
-	assert.Equalf(t, props.B.StrA, "gamma", "B.StrA incorrect")
-	assert.Equalf(t, props.B.StrB, "alpha", "B.StrB incorrect")
-	assert.Equalf(t, props.B.StrC, "beta", "B.StrC incorrect")
+	assert.Equalf(t, "alpha", props.A.StrA, "A.StrA incorrect")
+	assert.Equalf(t, "beta", props.A.StrB, "A.StrB incorrect")
+	assert.Equalf(t, "gamma", props.A.StrC, "A.StrC incorrect")
+	assert.Equalf(t, "gamma", props.B.StrA, "B.StrA incorrect")
+	assert.Equalf(t, "alpha", props.B.StrB, "B.StrB incorrect")
+	assert.Equalf(t, "beta", props.B.StrC, "B.StrC incorrect")
 
 	// Check 'booleans'. These are actually strings as far as the
 	// template code is concerned
-	assert.Equalf(t, props.A.B1, "1", "A.B1 incorrect")
-	assert.Equalf(t, props.A.B2, "0", "A.B2 incorrect")
-	assert.Equalf(t, props.B.B1, "0", "B.B1 incorrect")
-	assert.Equalf(t, props.B.B2, "1", "B.B2 incorrect")
+	assert.Equalf(t, "1", props.A.B1, "A.B1 incorrect")
+	assert.Equalf(t, "0", props.A.B2, "A.B2 incorrect")
+	assert.Equalf(t, "0", props.B.B1, "B.B1 incorrect")
+	assert.Equalf(t, "1", props.B.B2, "B.B2 incorrect")
 
 	// Check templates have been expanded in arrays of strings
-	assert.Equalf(t, arr[0], "alpha", "arr[0] incorrect")
-	assert.Equalf(t, arr[1], "beta", "arr[1] incorrect")
-	assert.Equalf(t, arr[2], "gamma", "arr[2] incorrect")
-	assert.Equalf(t, arrB[0], "beta", "arrB[0] incorrect")
-	assert.Equalf(t, arrB[1], "gamma", "arrB[1] incorrect")
-	assert.Equalf(t, arrB[2], "alpha", "arrB[2] incorrect")
+	assert.Equalf(t, "alpha", arr[0], "arr[0] incorrect")
+	assert.Equalf(t, "beta", arr[1], "arr[1] incorrect")
+	assert.Equalf(t, "gamma", arr[2], "arr[2] incorrect")
+	assert.Equalf(t, "beta", arrB[0], "arrB[0] incorrect")
+	assert.Equalf(t, "gamma", arrB[1], "arrB[1] incorrect")
+	assert.Equalf(t, "alpha", arrB[2], "arrB[2] incorrect")
 
 	// Check templates have been expanded in pointers to strings
-	assert.Equalf(t, refA, "alpha1", "refA incorrect")
-	assert.Equalf(t, refB, "beta0", "refB incorrect")
+	assert.Equalf(t, "alpha1", refA, "refA incorrect")
+	assert.Equalf(t, "beta0", refB, "refB incorrect")
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -45,19 +45,6 @@ func Test_IsNotCompilableSource(t *testing.T) {
 	assert.False(t, IsNotCompilableSource("bla.S"), "bla.S")
 }
 
-func assertArraysEqual(t *testing.T, test []string, correct []string) {
-	if len(test) != len(correct) {
-		t.Errorf("Length mismatch: %d != %d", len(test), len(correct))
-		return
-	}
-
-	for i := range test {
-		if test[i] != correct[i] {
-			t.Errorf("Bad prefix for index %d: '%s' != '%s'", i, test[i], correct[i])
-		}
-	}
-}
-
 func Test_PrefixAll(t *testing.T) {
 	if len(PrefixAll([]string{}, "myprefix")) != 0 {
 		t.Errorf("Incorrect handling of empty list")
@@ -67,7 +54,7 @@ func Test_PrefixAll(t *testing.T) {
 	prefix := "!>@@\""
 	correct := []string{"!>@@\"abc def", "!>@@\";1234	;''"}
 
-	assert.Equal(t, PrefixAll(in, prefix), correct)
+	assert.Equal(t, correct, PrefixAll(in, prefix))
 }
 
 func Test_PrefixDirs(t *testing.T) {
@@ -79,7 +66,7 @@ func Test_PrefixDirs(t *testing.T) {
 	prefix := "$(LOCAL_PATH)"
 	correct := []string{"$(LOCAL_PATH)/src/foo.c", "$(LOCAL_PATH)/include/bar.h"}
 
-	assert.Equal(t, PrefixDirs(in, prefix), correct)
+	assert.Equal(t, correct, PrefixDirs(in, prefix))
 }
 
 func Test_SortedKeys(t *testing.T) {
@@ -88,7 +75,7 @@ func Test_SortedKeys(t *testing.T) {
 		"aardvark": "insects",
 		"./a.out":  "bits",
 	}
-	assert.Equal(t, SortedKeys(in), []string{"./a.out", "Zebra", "aardvark"})
+	assert.Equal(t, []string{"./a.out", "Zebra", "aardvark"}, SortedKeys(in))
 }
 
 func Test_SortedKeysBoolMap(t *testing.T) {
@@ -99,7 +86,7 @@ func Test_SortedKeysBoolMap(t *testing.T) {
 	correct := []string{"2 + 2 = 5", "Alphabetic characters should appear after numbers"}
 	out := SortedKeysBoolMap(in)
 
-	assert.Equal(t, out, correct)
+	assert.Equal(t, correct, out)
 }
 
 func Test_Contains(t *testing.T) {
@@ -121,11 +108,11 @@ func Test_Filter(t *testing.T) {
 	testFilter := func(elem string) bool { return unicode.IsUpper(rune(elem[0])) }
 	in := []string{"Alpha", "beta", "Gamma", "Delta", "epsilon"}
 	filtered := Filter(testFilter, in)
-	assert.Equal(t, filtered, []string{"Alpha", "Gamma", "Delta"})
+	assert.Equal(t, []string{"Alpha", "Gamma", "Delta"}, filtered)
 
 	in2 := []string{"chi", "psi", "Omega"}
 	filtered = Filter(testFilter, in, in2)
-	assert.Equal(t, filtered, []string{"Alpha", "Gamma", "Delta", "Omega"})
+	assert.Equal(t, []string{"Alpha", "Gamma", "Delta", "Omega"}, filtered)
 
 }
 
@@ -133,23 +120,23 @@ func Test_Difference(t *testing.T) {
 	in := []string{"1", "1", "2", "3", "5", "8", "13", "21"}
 	sub := []string{"2", "8", "21"}
 	correct := []string{"1", "1", "3", "5", "13"}
-	assert.Equal(t, Difference(in, sub), correct)
+	assert.Equal(t, correct, Difference(in, sub))
 }
 
 func Test_AppendUnique(t *testing.T) {
 	// AppendIfUnique is tested via AppendUnique.
 	assert.Equal(t,
+		[]string{"test"},
 		AppendUnique([]string{},
-			[]string{"test"}),
-		[]string{"test"})
+			[]string{"test"}))
 	assert.Equal(t,
+		[]string{"ab", "cd", "", "ef"},
 		AppendUnique([]string{"ab", "cd"},
-			[]string{"", "", "ef"}),
-		[]string{"ab", "cd", "", "ef"})
+			[]string{"", "", "ef"}))
 	assert.Equal(t,
+		[]string{"ab", "cd"},
 		AppendUnique([]string{"ab", "cd"},
-			[]string{"cd", "ab"}),
-		[]string{"ab", "cd"})
+			[]string{"cd", "ab"}))
 }
 
 func Test_Find(t *testing.T) {
@@ -158,23 +145,23 @@ func Test_Find(t *testing.T) {
 }
 
 func Test_Remove(t *testing.T) {
-	assert.Equal(t, Remove([]string{"abc", "abcde"}, "abcd"),
-		[]string{"abc", "abcde"})
-	assert.Equal(t, Remove([]string{"abc", "abcde"}, "abcde"),
-		[]string{"abc"})
-	assert.Equal(t, Remove([]string{"abc", "abcde"}, "abc"),
-		[]string{"abcde"})
+	assert.Equal(t, []string{"abc", "abcde"},
+		Remove([]string{"abc", "abcde"}, "abcd"))
+	assert.Equal(t, []string{"abc"},
+		Remove([]string{"abc", "abcde"}, "abcde"))
+	assert.Equal(t, []string{"abcde"},
+		Remove([]string{"abc", "abcde"}, "abc"))
 }
 
 func Test_Reversed(t *testing.T) {
-	assert.Equal(t, Reversed([]string{}),
-		[]string{})
-	assert.Equal(t, Reversed([]string{""}),
-		[]string{""})
-	assert.Equal(t, Reversed([]string{"123", "234"}),
-		[]string{"234", "123"})
-	assert.Equal(t, Reversed([]string{"", "234", "..<>"}),
-		[]string{"..<>", "234", ""})
+	assert.Equal(t, []string{},
+		Reversed([]string{}))
+	assert.Equal(t, []string{""},
+		Reversed([]string{""}))
+	assert.Equal(t, []string{"234", "123"},
+		Reversed([]string{"123", "234"}))
+	assert.Equal(t, []string{"..<>", "234", ""},
+		Reversed([]string{"", "234", "..<>"}))
 }
 
 func Test_StripUnusedArgs(t *testing.T) {
@@ -187,12 +174,12 @@ func Test_StripUnusedArgs(t *testing.T) {
 		"out":      "source.o",
 	}
 	StripUnusedArgs(args, "${compiler} -o ${out} ${in} ${args}")
-	assert.Equal(t, SortedKeys(args), []string{"args", "compiler", "in", "out"})
+	assert.Equal(t, []string{"args", "compiler", "in", "out"}, SortedKeys(args))
 }
 
 func Test_Trim(t *testing.T) {
-	assert.Equal(t, Trim([]string{"", " hello ", "world", "	"}),
-		[]string{"hello", "world"})
+	assert.Equal(t, []string{"hello", "world"},
+		Trim([]string{"", " hello ", "world", "	"}))
 }
 
 func Test_Join(t *testing.T) {
@@ -238,8 +225,8 @@ func Test_NewStringSlice(t *testing.T) {
 	fmt.Printf("B = %v\n", arrB)
 	// C = [1 2 3 4 5 C]
 	fmt.Printf("C = %v\n", arrC)
-	assert.Equal(t, arrC, []string{"1", "2", "3", "4", "5", "C"})
-	assert.Equal(t, arrB, []string{"1", "2", "3", "4", "5", "B"})
+	assert.Equal(t, []string{"1", "2", "3", "4", "5", "C"}, arrC)
+	assert.Equal(t, []string{"1", "2", "3", "4", "5", "B"}, arrB)
 }
 
 // Below example code with problematic append() call, this is why we have utils.NewStringSlice


### PR DESCRIPTION
Testify's Equal and Equalf function arguments are (testing.T,
expected, actual,...) whereas Bob original assert function had the
expected and actual the other way around. Update the test code calling
these functions so that when we do get failures the test report isn't
so confusing.

Where we test against true, use True instead.

Also remove the now unused assertArraysEqual() function.

Change-Id: I87ef11b616fbdde2587555d37a304edae26d638f
Signed-off-by: David Kilroy <david.kilroy@arm.com>