### PR TITLE
Feature.Init should take configProperties

### DIFF
--- a/core/alias.go
+++ b/core/alias.go
@@ -76,7 +76,7 @@ func (m *alias) GenerateBuildActions(ctx blueprint.ModuleContext) {
 // Create the structure representing the bob_alias
 func aliasFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &alias{}
-	module.Properties.Features.Init(config.getAvailableFeatures(), AliasProps{})
+	module.Properties.Features.Init(config.Properties, AliasProps{})
 	return module, []interface{}{&module.Properties, &module.SimpleName.Properties}
 }
 

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -119,11 +119,6 @@ type bobConfig struct {
 	Properties *configProperties
 }
 
-// getAvailableFeatures returns all available features that can be used in .bp
-func (config *bobConfig) getAvailableFeatures() []string {
-	return config.Properties.featureList
-}
-
 // SourceProps defines module properties that are used to identify the
 // source files associated with a module.
 type SourceProps struct {

--- a/core/feature.go
+++ b/core/feature.go
@@ -75,15 +75,15 @@ func typesOf(list ...interface{}) []reflect.Type {
 // Name of each property in this struct is custom feature name.
 // Blueprint will inflate this structure with data read from .bp files.
 // Only exported properties can be set so property name MUST start from capital letter.
-func (f *Features) Init(availableFeatures []string, list ...interface{}) {
+func (f *Features) Init(properties *configProperties, list ...interface{}) {
 	if len(list) == 0 {
 		panic("List can't be empty")
 	}
 
 	propsType := coalesceTypes(typesOf(list...)...)
-	fields := make([]reflect.StructField, len(availableFeatures))
+	fields := make([]reflect.StructField, len(properties.featureList))
 
-	for i, featureName := range availableFeatures {
+	for i, featureName := range properties.featureList {
 		fields[i] = reflect.StructField{
 			Name: featurePropertyName(featureName),
 			Type: reflect.TypeOf(singleFeature{}),
@@ -95,7 +95,7 @@ func (f *Features) Init(availableFeatures []string, list ...interface{}) {
 	f.BlueprintEmbed = instancePtr.Interface()
 
 	instance := reflect.Indirect(instancePtr)
-	for i := range availableFeatures {
+	for i := range properties.featureList {
 		propsInFeature := instance.Field(i).Addr().Interface().(*singleFeature)
 		propsInFeature.BlueprintEmbed = reflect.New(propsType).Interface()
 	}

--- a/core/feature_test.go
+++ b/core/feature_test.go
@@ -135,7 +135,9 @@ func createTestModuleAndFeatures() (testProps, configProperties) {
 		"feature_d",
 	}
 
-	module.Init(featuresNames,
+	properties := enabledFeatures(featuresNames...)
+
+	module.Init(&properties,
 		testPropsGroupA{},
 		testPropsGroupB{},
 		testPropsGroupC{},
@@ -154,7 +156,6 @@ func createTestModuleAndFeatures() (testProps, configProperties) {
 	module.injectData("Feature_d", "FieldE", "+D_e")
 	module.injectData("Feature_d", "FieldF", "+D_f")
 
-	properties := enabledFeatures(featuresNames...)
 	return module, properties
 }
 
@@ -180,7 +181,7 @@ func Test_should_not_change_when_appending_empty_features(t *testing.T) {
 
 	// BlueprintEmbed must be inited! So BlueprintEmbed can't be nil!
 	module.Init( // Just make new Init so we will have "empty structure"
-		properties.featureList,
+		&properties,
 		testPropsGroupA{},
 		testPropsGroupB{},
 		testPropsGroupC{},
@@ -318,7 +319,9 @@ func Test_should_append_properties_when_using_nested_destinations(t *testing.T) 
 
 	// We need to init all available features (important)
 	featureNames := []string{"my_feature_a", "my_feature_b"}
-	module.Properties.Init(featureNames, TestSourceProps{}, TestInstallProps{})
+	properties := enabledFeatures(featureNames...)
+
+	module.Properties.Init(&properties, TestSourceProps{}, TestInstallProps{})
 
 	////////////////////////////////////////////////////////////////////////////////////////////////
 	// Injecting data to features. This is only for test purpose. Normally this step would be skipped
@@ -330,7 +333,6 @@ func Test_should_append_properties_when_using_nested_destinations(t *testing.T) 
 	dst := []interface{}{&module.testSource.Properties.TestSourceProps,
 		&module.testInstall.Properties.TestInstallProps}
 
-	properties := enabledFeatures(featureNames...)
 	if err := module.Properties.AppendProps(dst, &properties); err != nil {
 		panic(err)
 	}
@@ -376,7 +378,8 @@ func Test_should_append_props_when_using_nested_structs(t *testing.T) {
 
 	// We need to init all available features (important)
 	featureNames := []string{"my_feature"}
-	module.Properties.Init(featureNames, TestDerivedModuleProps{}, TestModuleCommonProps{})
+	properties := enabledFeatures(featureNames...)
+	module.Properties.Init(&properties, TestDerivedModuleProps{}, TestModuleCommonProps{})
 
 	// This is how 'my_feature' struct will look like
 	// My_feature: struct
@@ -413,7 +416,6 @@ func Test_should_append_props_when_using_nested_structs(t *testing.T) {
 	dst := []interface{}{&module.Properties.TestDerivedModuleProps,
 		&module.TestModuleCommon.Properties.TestModuleCommonProps}
 
-	properties := enabledFeatures(featureNames...)
 	if err := module.Properties.AppendProps(dst, &properties); err != nil {
 		panic(err)
 	}
@@ -449,9 +451,8 @@ func Test_should_composite_new_type(t *testing.T) {
 	}
 
 	// We need to init all available features (important)
-	module.Init([]string{
-		"feature_compose",
-	},
+	properties := enabledFeatures("feature_compose")
+	module.Init(&properties,
 		testPropsGroupA{},
 		testPropsGroupB{},
 	)

--- a/core/gen_binary.go
+++ b/core/gen_binary.go
@@ -58,7 +58,7 @@ func (m *generateBinary) GenerateBuildActions(ctx blueprint.ModuleContext) {
 
 func genBinaryFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &generateBinary{}
-	module.generateCommon.Properties.Features.Init(config.getAvailableFeatures(), GenerateProps{})
+	module.generateCommon.Properties.Features.Init(config.Properties, GenerateProps{})
 	return module, []interface{}{
 		&module.SimpleName.Properties,
 		&module.generateCommon.Properties,

--- a/core/gen_shared.go
+++ b/core/gen_shared.go
@@ -58,7 +58,7 @@ func (m *generateSharedLibrary) GenerateBuildActions(ctx blueprint.ModuleContext
 
 func genSharedLibFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &generateSharedLibrary{}
-	module.generateCommon.Properties.Features.Init(config.getAvailableFeatures(), GenerateProps{},
+	module.generateCommon.Properties.Features.Init(config.Properties, GenerateProps{},
 		GenerateLibraryProps{})
 	return module, []interface{}{
 		&module.SimpleName.Properties,

--- a/core/gen_static.go
+++ b/core/gen_static.go
@@ -58,7 +58,7 @@ func (m *generateStaticLibrary) GenerateBuildActions(ctx blueprint.ModuleContext
 
 func genStaticLibFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &generateStaticLibrary{}
-	module.generateCommon.Properties.Features.Init(config.getAvailableFeatures(), GenerateProps{},
+	module.generateCommon.Properties.Features.Init(config.Properties, GenerateProps{},
 		GenerateLibraryProps{})
 	return module, []interface{}{
 		&module.SimpleName.Properties,

--- a/core/generated.go
+++ b/core/generated.go
@@ -563,7 +563,7 @@ type transformSource struct {
 
 func generateSourceFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &generateSource{}
-	module.generateCommon.Properties.Features.Init(config.getAvailableFeatures(),
+	module.generateCommon.Properties.Features.Init(config.Properties,
 		GenerateProps{}, GenerateSourceProps{})
 	return module, []interface{}{&module.generateCommon.Properties, &module.Properties,
 		&module.SimpleName.Properties}
@@ -571,7 +571,7 @@ func generateSourceFactory(config *bobConfig) (blueprint.Module, []interface{}) 
 
 func transformSourceFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &transformSource{}
-	module.generateCommon.Properties.Features.Init(config.getAvailableFeatures(),
+	module.generateCommon.Properties.Features.Init(config.Properties,
 		GenerateProps{}, TransformSourceProps{})
 	return module, []interface{}{&module.generateCommon.Properties,
 		&module.Properties,

--- a/core/install.go
+++ b/core/install.go
@@ -240,14 +240,14 @@ func (m *resource) getAliasList() []string {
 
 func installGroupFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &installGroup{}
-	module.Properties.Features.Init(config.getAvailableFeatures(), InstallGroupProps{})
+	module.Properties.Features.Init(config.Properties, InstallGroupProps{})
 	return module, []interface{}{&module.Properties,
 		&module.SimpleName.Properties}
 }
 
 func resourceFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &resource{}
-	module.Properties.Features.Init(config.getAvailableFeatures(), ResourceProps{})
+	module.Properties.Features.Init(config.Properties, ResourceProps{})
 	return module, []interface{}{&module.Properties,
 		&module.SimpleName.Properties}
 }

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -190,10 +190,9 @@ func (m *kernelModule) GenerateBuildActions(ctx blueprint.ModuleContext) {
 
 func kernelModuleFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &kernelModule{}
-	availableFeatures := config.getAvailableFeatures()
-	module.Properties.Features.Init(availableFeatures, BuildProps{})
-	module.Properties.Build.Target.Init(availableFeatures, BuildProps{})
-	module.Properties.Build.Host.Init(availableFeatures, BuildProps{})
+	module.Properties.Features.Init(config.Properties, BuildProps{})
+	module.Properties.Build.Target.Init(config.Properties, BuildProps{})
+	module.Properties.Build.Host.Init(config.Properties, BuildProps{})
 
 	return module, []interface{}{&module.Properties, &module.SimpleName.Properties}
 }

--- a/core/library.go
+++ b/core/library.go
@@ -571,10 +571,9 @@ func (m *binary) GenerateBuildActions(ctx blueprint.ModuleContext) {
 }
 
 func (l *library) LibraryFactory(config *bobConfig, module blueprint.Module) (blueprint.Module, []interface{}) {
-	availableFeatures := config.getAvailableFeatures()
-	l.Properties.Features.Init(availableFeatures, BuildProps{})
-	l.Properties.Build.Host.Features.Init(availableFeatures, BuildProps{})
-	l.Properties.Build.Target.Features.Init(availableFeatures, BuildProps{})
+	l.Properties.Features.Init(config.Properties, BuildProps{})
+	l.Properties.Build.Host.Features.Init(config.Properties, BuildProps{})
+	l.Properties.Build.Target.Features.Init(config.Properties, BuildProps{})
 
 	return module, []interface{}{&l.Properties, &l.SimpleName.Properties}
 }


### PR DESCRIPTION
This limits the use of properties.featureList to config_props.go and
feature.go, so in the future, any refactoring of how features work
should not affect other modules.

Note that this restricts features to the boolean properties in the
configuration.

Change-Id: I2482903945a70b4dd9091f0091a876a705363499
Signed-off-by: David Kilroy <david.kilroy@arm.com>