### PR TITLE
Post install improvements

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -314,7 +314,9 @@ func (m *library) GenerateBuildAction(sb *strings.Builder, bt binType, ctx bluep
 			// Setup args like we do for bob_generated_*
 			args := map[string]string{}
 			args["bob_config"] = "$(BOB_ANDROIDMK_DIR)/" + configName
-			args["tool"] = filepath.Join("$(LOCAL_PATH)", ctx.ModuleDir(), m.Properties.Post_install_tool)
+			if m.Properties.Post_install_tool != nil {
+				args["tool"] = *m.Properties.Post_install_tool
+			}
 			args["out"] = "$(LOCAL_INSTALLED_MODULE)"
 
 			// We can't use target specific variables in make due to

--- a/core/android_make.go
+++ b/core/android_make.go
@@ -310,7 +310,7 @@ func (m *library) GenerateBuildAction(sb *strings.Builder, bt binType, ctx bluep
 
 	if ok {
 		sb.WriteString("LOCAL_MODULE_RELATIVE_PATH:=" + m.Properties.Relative_install_path + "\n")
-		if m.Properties.Post_install_cmd != "" {
+		if m.Properties.Post_install_cmd != nil {
 			// Setup args like we do for bob_generated_*
 			args := map[string]string{}
 			args["bob_config"] = "$(BOB_ANDROIDMK_DIR)/" + configName
@@ -322,7 +322,8 @@ func (m *library) GenerateBuildAction(sb *strings.Builder, bt binType, ctx bluep
 			// We can't use target specific variables in make due to
 			// the way LOCAL_POST_INSTALL_CMD is
 			// implemented. Therefore expand all variable use here.
-			cmd := m.Properties.Post_install_cmd
+			cmd := strings.Replace(*m.Properties.Post_install_cmd, "${args}",
+				strings.Join(m.Properties.Post_install_args, " "), -1)
 			for key, value := range args {
 				cmd = strings.Replace(cmd, "${"+key+"}", value, -1)
 			}

--- a/core/generated.go
+++ b/core/generated.go
@@ -395,6 +395,7 @@ func (m *generateCommon) getSources(ctx abstr.ModuleContext) []string {
 
 func (m *generateCommon) processPaths(ctx abstr.ModuleContext, g generatorBackend) {
 	m.Properties.SourceProps.processPaths(ctx, g)
+	m.Properties.InstallableProps.processPaths(ctx, g)
 	m.Properties.Export_gen_include_dirs = utils.PrefixDirs(m.Properties.Export_gen_include_dirs, g.sourceOutputDir(m))
 }
 

--- a/core/install.go
+++ b/core/install.go
@@ -19,6 +19,7 @@ package core
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/google/blueprint"
 
@@ -86,11 +87,17 @@ type InstallableProps struct {
 	// Path to install to, relative to the install_group's path
 	Relative_install_path string
 	// Script used during post install
-	Post_install_tool string
+	Post_install_tool *string
 	// Command to execute on file(s) after they are installed
 	Post_install_cmd string
 	// The path retrieved from the install group so we don't need to walk dependencies to get it
 	Install_path *string `blueprint:"mutated"`
+}
+
+func (props *InstallableProps) processPaths(ctx abstr.ModuleContext, g generatorBackend) {
+	if props.Post_install_tool != nil {
+		*props.Post_install_tool = filepath.Join(g.sourcePrefix(), ctx.ModuleDir(), *props.Post_install_tool)
+	}
 }
 
 func (props *InstallableProps) getInstallGroupPath() (string, bool) {
@@ -234,6 +241,7 @@ func (m *resource) getInstallableProps() *InstallableProps {
 
 func (m *resource) processPaths(ctx abstr.ModuleContext, g generatorBackend) {
 	m.Properties.SourceProps.processPaths(ctx, g)
+	m.Properties.InstallableProps.processPaths(ctx, g)
 }
 
 func (m *resource) getAliasList() []string {

--- a/core/install.go
+++ b/core/install.go
@@ -89,7 +89,9 @@ type InstallableProps struct {
 	// Script used during post install
 	Post_install_tool *string
 	// Command to execute on file(s) after they are installed
-	Post_install_cmd string
+	Post_install_cmd *string
+	// Arguments to post install command
+	Post_install_args []string
 	// The path retrieved from the install group so we don't need to walk dependencies to get it
 	Install_path *string `blueprint:"mutated"`
 }

--- a/core/library.go
+++ b/core/library.go
@@ -256,10 +256,12 @@ func (l *Build) getBuildWrapperAndDeps(ctx blueprint.ModuleContext) (string, []s
 	return "", []string{}
 }
 
-// Add module paths to srcs, exclude_srcs, local_include_dirs and export_local_include_dirs
+// Add module paths to srcs, exclude_srcs, local_include_dirs, export_local_include_dirs
+// and post_install_tool
 func (l *Build) processPaths(ctx abstr.ModuleContext, g generatorBackend) {
 	prefix := ctx.ModuleDir()
 	l.SourceProps.processPaths(ctx, g)
+	l.InstallableProps.processPaths(ctx, g)
 	l.Local_include_dirs = utils.PrefixDirs(l.Local_include_dirs, prefix)
 	l.Export_local_include_dirs = utils.PrefixDirs(l.Export_local_include_dirs, prefix)
 

--- a/core/linux.go
+++ b/core/linux.go
@@ -780,12 +780,14 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 	deps := []string{}
 	if props.Post_install_cmd != "" {
 		rulename := "install"
-		tool := filepath.Join(g.sourcePrefix(), ctx.ModuleDir(), props.Post_install_tool)
 
 		cmd := "rm -f $out; cp $in $out ; " + props.Post_install_cmd
 
 		args["bob_config"] = configPath
-		args["tool"] = tool
+		if props.Post_install_tool != nil {
+			args["tool"] = *props.Post_install_tool
+			deps = append(deps, *props.Post_install_tool)
+		}
 		utils.StripUnusedArgs(args, props.Post_install_cmd)
 
 		rule = ctx.Rule(pctx,
@@ -795,7 +797,6 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 				Description: "$out",
 			},
 			utils.SortedKeys(args)...)
-		deps = append(deps, tool)
 	}
 
 	// Check if this is a resource

--- a/core/linux.go
+++ b/core/linux.go
@@ -778,17 +778,20 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 	rule := installRule
 	args := map[string]string{}
 	deps := []string{}
-	if props.Post_install_cmd != "" {
+	if props.Post_install_cmd != nil {
 		rulename := "install"
 
-		cmd := "rm -f $out; cp $in $out ; " + props.Post_install_cmd
+		cmd := "rm -f $out; cp $in $out ; " + *props.Post_install_cmd
+
+		// Expand args immediately
+		cmd = strings.Replace(cmd, "${args}", strings.Join(props.Post_install_args, " "), -1)
 
 		args["bob_config"] = configPath
 		if props.Post_install_tool != nil {
 			args["tool"] = *props.Post_install_tool
 			deps = append(deps, *props.Post_install_tool)
 		}
-		utils.StripUnusedArgs(args, props.Post_install_cmd)
+		utils.StripUnusedArgs(args, cmd)
 
 		rule = ctx.Rule(pctx,
 			rulename,

--- a/docs/module_types/bob_binary.md
+++ b/docs/module_types/bob_binary.md
@@ -60,7 +60,8 @@ bob_binary {
     install_deps: ["module_name"],
     relative_install_path: "unit/objects",
     post_install_tool: "post_install.py",
-    post_install_cmd: "${tool} ${out} ARGS...",
+    post_install_cmd: "${tool} ${args} ${out}",
+    post_install_args: ["arg1", "arg2"],
 
     // features available
 }

--- a/docs/module_types/bob_defaults.md
+++ b/docs/module_types/bob_defaults.md
@@ -88,7 +88,8 @@ bob_defaults {
     install_deps: ["bob_resource.name"],
     relative_install_path: "unit/objects",
     post_install_tool: "post_install.py",
-    post_install_cmd: "${tool} ${out} ARGS...",
+    post_install_cmd: "${tool} ${args} ${out}",
+    post_install_args: ["arg1", "arg2"],
 
     // features available
 }

--- a/docs/module_types/bob_generate_library.md
+++ b/docs/module_types/bob_generate_library.md
@@ -58,7 +58,8 @@ bob_generate_shared_library {
     install_deps: ["bob_resource.name"],
     relative_install_path: "unit/objects",
     post_install_tool: "post_install.py",
-    post_install_cmd: "${tool} ${out} ARGS...",
+    post_install_cmd: "${tool} ${args} ${out}",
+    post_install_args: ["arg1", "arg2"],
 }
 ```
 

--- a/docs/module_types/bob_generate_source.md
+++ b/docs/module_types/bob_generate_source.md
@@ -56,7 +56,8 @@ bob_generate_source {
     install_deps: ["bob_resource.name"],
     relative_install_path: "unit/objects",
     post_install_tool: "post_install.py",
-    post_install_cmd: "${tool} ${out} ARGS...",
+    post_install_cmd: "${tool} ${args} ${out}",
+    post_install_args: ["arg1", "arg2"],
 }
 ```
 

--- a/docs/module_types/bob_kernel_module.md
+++ b/docs/module_types/bob_kernel_module.md
@@ -59,7 +59,8 @@ bob_kernel_module {
     install_deps: ["bob_resource.name"],
     relative_install_path: "unit/objects",
     post_install_tool: "post_install.py",
-    post_install_cmd: "${tool} ${out} ARGS...",
+    post_install_cmd: "${tool} ${args} ${out}",
+    post_install_args: ["arg1", "arg2"],
 
     // features available
 }

--- a/docs/module_types/bob_resource.md
+++ b/docs/module_types/bob_resource.md
@@ -30,7 +30,8 @@ bob_resource {
     install_deps: ["bob_resource.name"],
     relative_install_path: "unit/objects",
     post_install_tool: "post_install.py",
-    post_install_cmd: "${tool} ${out} ARGS...",
+    post_install_cmd: "${tool} ${args} ${out}",
+    post_install_args: ["arg1", "arg2"],
 
     tags: ["optional"],
 

--- a/docs/module_types/bob_shared_library.md
+++ b/docs/module_types/bob_shared_library.md
@@ -69,7 +69,8 @@ bob_shared_library {
     install_deps: ["bob_resource.name"],
     relative_install_path: "unit/objects",
     post_install_tool: "post_install.py",
-    post_install_cmd: "${tool} ${out} ARGS...",
+    post_install_cmd: "${tool} ${args} ${out}",
+    post_install_args: ["arg1", "arg2"],
 }
 ```
 

--- a/docs/module_types/bob_static_library.md
+++ b/docs/module_types/bob_static_library.md
@@ -80,7 +80,8 @@ bob_static_library {
     install_deps: ["bob_resource.name"],
     relative_install_path: "unit/objects",
     post_install_tool: "post_install.py",
-    post_install_cmd: "${tool} ${out} ARGS...",
+    post_install_cmd: "${tool} ${args} ${out}",
+    post_install_args: ["arg1", "arg2"],
 }
 ```
 

--- a/docs/module_types/bob_transform_source.md
+++ b/docs/module_types/bob_transform_source.md
@@ -63,7 +63,8 @@ bob_transform_source {
     install_deps: ["bob_resource.name"],
     relative_install_path: "unit/objects",
     post_install_tool: "post_install.py",
-    post_install_cmd: "${tool} ${out} ARGS...",
+    post_install_cmd: "${tool} ${args} ${out}",
+    post_install_args: ["arg1", "arg2"],
 }
 ```
 

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -277,6 +277,12 @@ are substituted into the command:
 - `${tool}` - the tool specified in `bob_module.post_install_tool`.
 - `${out}` - the output file(s) of the current module.
 - `${bob_config}` - the Bob configuration file.
+- `${args}` - arguments from `post_install_args`
+
+### **bob_module.post_install_args** (optional)
+
+Arguments to insert into `post_install_cmd`. This allows arguments to
+added based on features and defaults.
 
 ----
 ### **bob_module.target_supported** (optional)

--- a/docs/user_guide/build_output.md
+++ b/docs/user_guide/build_output.md
@@ -83,7 +83,8 @@ bob_shared_library {
     install_group: "IG_libraries",
     relative_install_path: "libdrm",
     post_install_tool: "libdrm_post.py",
-    post_install_cmd: "${tool} ${out}",
+    post_install_cmd: "${tool} ${args} ${out}",
+    post_install_args: ["--strip"],
 
     install_deps: ["formats"],
 }
@@ -97,8 +98,12 @@ gets copied to `install/lib/libdrm/libdrm.so`.
 
 If you need to post-process the binary, use `post_install_cmd`. The
 related `post_install_tool` will add a dependency on a script which
-can be referred to in `post_install_cmd` as `${tool}`. An example
-of post-processing is to strip libraries of debug information.
+can be referred to in `post_install_cmd` as `${tool}`. An example of
+post-processing is to strip libraries of debug information. For any
+library it's advised to just run a single script to cover all post
+install actions. If different actions need to be taken in different
+circumstances, use `post_install_args` to pass the necessary arguments
+to the script (based on enabled features).
 
 When installing libraries and binaries, their dependencies are also
 installed. You can specify additional dependencies with


### PR DESCRIPTION
When the post install tool is specified in a default, it should use the module directory of the default as the base directory.

Introduce post_install_args which can be referenced with ${args} in a post_install_cmd. This allows arbitrary arguments to be added to the command via features and defaults.