### PR TITLE
Allow use of generated sources

### DIFF
--- a/tests/bootstrap_soong
+++ b/tests/bootstrap_soong
@@ -44,13 +44,10 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 DISABLE_TEST_DIRS=(
     external_libs
     generate_libs
-    generate_source
     implicit_outs
     match_source
     output
-    shared_libs
     source_encapsulation
-    transform_source
 )
 
 for TEST_DIR in "${DISABLE_TEST_DIRS[@]}"; do

--- a/tests/generate_source/build.bp
+++ b/tests/generate_source/build.bp
@@ -201,6 +201,12 @@ bob_binary {
     generated_headers: ["gen_sources_and_headers"],
     generated_sources: ["gen_sources_and_headers"],
     srcs: ["main.c"],
+
+    // The Soong plugin does not currently support using mixed sources and
+    // headers from the same module.
+    builder_soong: {
+        enabled: false,
+    },
 }
 
 bob_generate_source {
@@ -209,7 +215,7 @@ bob_generate_source {
     out: ["output.txt"],
     depfile: "output.d",
     tool: "gen_with_dep.py",
-    cmd: "${tool} -o ${out} -d ${depfile} ${in}"
+    cmd: "${tool} -o ${out} -d ${depfile} ${in}",
 }
 
 bob_alias {


### PR DESCRIPTION
Use the `generated_sources` field to reference the output of
`bob_generated_source` modules in libraries/binaries.

This is enough to make the `static_libs` tests work. The
`generate_source` tests are also enabled, although the
`bin_gen_sources_and_headers` test is now explicitly disabled, because
there is currently no way to filter between generated sources and
headers, meaning that Soong complains about not knowing how to compile
`.h` files.

Change-Id: I094069e8fc397349c9fa843e85d94f40d98cfb55
Signed-off-by: Chris Diamand <chris.diamand@arm.com>