### PR TITLE
config_system: support '+' and '-' operators

### DIFF
--- a/config_system/config_system/__init__.py
+++ b/config_system/config_system/__init__.py
@@ -27,14 +27,16 @@ if os.path.isfile("build/make/core/envsetup.mk"):
 from config_system.general import \
     can_enable, \
     format_dependency_list, \
-    get_config, \
     get_config_bool, \
     get_config_int, \
-    get_config_list, \
     get_config_string, \
-    get_mconfig_dir, \
     get_options_depending_on, \
     get_options_selecting, \
     init_config, \
     read_config, \
     set_config  # nopep8: E402 module level import not at top of file
+
+from config_system.data import \
+    get_config, \
+    get_config_list, \
+    get_mconfig_dir  # nopep8: E402 module level import not at top of file

--- a/config_system/config_system/__init__.py
+++ b/config_system/config_system/__init__.py
@@ -26,7 +26,6 @@ if os.path.isfile("build/make/core/envsetup.mk"):
 
 from config_system.general import \
     can_enable, \
-    format_dependency_list, \
     get_config_bool, \
     get_config_int, \
     get_config_string, \
@@ -40,3 +39,6 @@ from config_system.data import \
     get_config, \
     get_config_list, \
     get_mconfig_dir  # nopep8: E402 module level import not at top of file
+
+from config_system.expr import \
+    format_dependency_list  # nopep8: E402 module level import not at top of file

--- a/config_system/config_system/config_json.py
+++ b/config_system/config_system/config_json.py
@@ -17,7 +17,7 @@ import json
 import logging
 import os
 
-from config_system import general, utils
+from config_system import data, utils
 
 
 logger = logging.getLogger(__name__)
@@ -26,8 +26,8 @@ logger = logging.getLogger(__name__)
 def config_to_json():
     properties = dict()
 
-    for key in general.get_config_list():
-        c = general.get_config(key)
+    for key in data.get_config_list():
+        c = data.get_config(key)
         key = key.lower()
         datatype = c["datatype"]
         value = c["value"]

--- a/config_system/config_system/data.py
+++ b/config_system/config_system/data.py
@@ -1,0 +1,113 @@
+# Copyright 2018-2019 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+__mconfig_dir = ""
+
+
+def get_mconfig_dir():
+    """
+    Retrieve the path to the input option database.
+    """
+    return __mconfig_dir
+
+
+def init(options_filename, ignore_missing=False):
+    from config_system import lex, lex_wrapper, syntax
+
+    global __mconfig_dir
+    global configuration
+
+    try:
+        lexer = lex_wrapper.LexWrapper(ignore_missing)
+        lexer.source(options_filename)
+        configuration = syntax.parser.parse(None, debug=False, lexer=lexer)
+    except lex.TokenizeError as e:
+        logger.debug("Failed to tokenise input")
+        exit(1)
+    except syntax.ParseError as e:
+        logger.debug("Parse error")
+        exit(1)
+    __mconfig_dir = os.path.dirname(options_filename)
+
+
+def get_config(key):
+    return configuration['config'][key]
+
+
+def get_choice_group(key):
+    return configuration['choice'][key]
+
+
+def is_choice_group(key):
+    return key in configuration['choice']
+
+
+def get_menu(key):
+    return configuration['menu'][key]
+
+
+def get_menu_list():
+    return configuration['menu']
+
+
+def iter_symbols_menuorder():
+    # return tuple of (type, symbol)
+    for i in sorted(configuration['order']):
+        yield configuration['order'][i]
+
+
+def get_menu_depends(type, value):
+    if type in ['config', 'menuconfig']:
+        return configuration['config'][value].get('depends')
+    elif type in ['choice']:
+        return configuration['choice'][value].get('depends')
+    elif type in ['menu']:
+        return configuration['menu'][value].get('depends')
+
+
+def get_menu_visible(type, value):
+    if type in ['config', 'menuconfig']:
+        return configuration['config'][value].get('visible_cond')
+    elif type in ['choice']:
+        return configuration['choice'][value].get('visible_cond')
+    elif type in ['menu']:
+        return configuration['menu'][value].get('visible_cond')
+
+
+def get_config_list():
+    return configuration['config'].keys()
+
+
+def get_menu_title(number):
+    if number in configuration['menu']:
+        if 'title' in configuration['menu'][number]:
+            return configuration['menu'][number]['title']
+    elif number in configuration['choice']:
+        if 'title' in configuration['choice'][number]:
+            return configuration['choice'][number]['title']
+    return "Configuration"
+
+
+def get_title_bar():
+    if 'title_bar' in configuration:
+        return configuration['title_bar']
+    return "Configuration System"

--- a/config_system/config_system/expr.py
+++ b/config_system/config_system/expr.py
@@ -13,6 +13,212 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
+from config_system.data import get_config
+
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
 # Expression tuple for 'y' and 'n'
 YES = ('boolean', 'y')
 NO = ('boolean', 'n')
+
+
+def check_depends(depends, value):
+    """Check if the config identified in value is a simple dependency
+    listed in the depends expression.
+    A simple expression consists of just && and || boolean operators.
+    If the expression uses any other operator, return False.
+
+    This is used by the menu_parse below to indent dependent configs.
+    """
+    if depends is None:
+        return False
+    assert type(depends) == tuple
+    assert len(depends) in [2, 3]
+
+    if depends[0] == 'and':
+        return (check_depends(depends[1], value) or
+                check_depends(depends[2], value))
+    elif depends[0] == 'or':
+        return (check_depends(depends[1], value) and
+                check_depends(depends[2], value))
+    elif depends[0] == 'word':
+        return depends[1] == value
+    return False
+
+
+# Operators where the result is not boolean
+ARITH_SET = {"+", "-"}
+
+
+def _expr_value(e):
+    """Evaluate the value of the input expression.
+    This isn't expected to use conditional operators.
+    """
+    assert type(e) == tuple
+    assert len(e) in [2, 3]
+    if len(e) == 3:
+        left = _expr_value(e[1])
+        right = _expr_value(e[2])
+        if type(left) != type(right):
+            raise TypeError("'{}' operator is not valid with mixed types".format(e[0]))
+        elif left in ['y', 'n'] or right in ['y', 'n']:
+            raise TypeError("'{}' operator is not valid on booleans".format(e[0]))
+        elif e[0] == '+':
+            return left + right
+        elif e[0] == '-':
+            if type(left) is str:
+                raise TypeError("'-' operator is not valid on strings")
+                return left
+            return left - right
+    elif e[0] == 'string':
+        return e[1]
+    elif e[0] == 'number':
+        return e[1]
+    elif e[0] == 'boolean':
+        return e[1]
+    elif e[0] == 'word':
+        return get_config(e[1])['value']
+
+    raise Exception("Unexpected depend list: " + str(e))
+
+
+def expr_value(e):
+    try:
+        result = _expr_value(e)
+    except TypeError as err:
+        logging.error("{} in expression '{}'".format(str(err), format_dependency_list(e)))
+        result = ""
+
+    return result
+
+
+def _condexpr_value(e):
+    """Evaluate the value of the input expression.
+    Note that booleans are propagated as 'y' and 'n'
+    """
+    assert type(e) == tuple
+    assert len(e) in [2, 3]
+
+    if len(e) == 3:
+        if e[0] in ARITH_SET:
+            return _expr_value(e)
+
+        left = _condexpr_value(e[1])
+        right = _condexpr_value(e[2])
+        if type(left) != type(right):
+            # Boolean result expected
+            return 'n'
+        elif e[0] == 'and':
+            if left == 'y' and right == 'y':
+                return 'y'
+            return 'n'
+        elif e[0] == 'or':
+            if left == 'y' or right == 'y':
+                return 'y'
+            return 'n'
+        elif e[0] == '=':
+            if left == right:
+                return 'y'
+            return 'n'
+        elif e[0] == '!=':
+            if left != right:
+                return 'y'
+            return 'n'
+        elif e[0] == '>':
+            if left > right:
+                return 'y'
+            return 'n'
+        elif e[0] == '>=':
+            if left >= right:
+                return 'y'
+            return 'n'
+        elif e[0] == '<':
+            if left < right:
+                return 'y'
+            return 'n'
+        elif e[0] == '<=':
+            if left <= right:
+                return 'y'
+            return 'n'
+    elif e[0] == 'not':
+        if _condexpr_value(e[1]) == 'y':
+            return 'n'
+        return 'y'
+    elif e[0] == 'string':
+        return e[1]
+    elif e[0] == 'number':
+        return e[1]
+    elif e[0] == 'boolean':
+        return e[1]
+    elif e[0] == 'word':
+        return get_config(e[1])['value']
+
+    raise Exception("Unexpected depend list: " + str(e))
+
+
+def condexpr_value(e):
+    if e is None:
+        return 'y'
+    try:
+        result = _condexpr_value(e)
+    except TypeError as err:
+        logging.error("{} in expression '{}'".format(str(err), format_dependency_list(e)))
+        result = 'n'
+
+    return result
+
+
+def dependency_list(e):
+    """
+    Get the set of config identifiers referred to by an expression. A
+    set is returned instead of a list as we don't need duplicates, and
+    order doesn't matter.
+    """
+    if e is None:
+        return set()
+    assert type(e) == tuple
+
+    if e[0] in ['and', 'or', '=', '!=', '<', '<=', '>', '>=', '+', '-']:
+        return dependency_list(e[1]) | dependency_list(e[2])
+    elif e[0] == 'not':
+        return dependency_list(e[1])
+    elif e[0] in ['string', 'number', 'boolean']:
+        # Quoted string, number or boolean
+        return set()
+    elif e[0] == 'word':
+        return {e[1]}
+    raise Exception("Unexpected depend list: " + str(e))
+
+
+OPERATOR_FORMAT_MAP = {
+    "and": "&&",
+    "or": "||",
+}
+
+
+def format_dependency_list(depends, skip_parens=False):
+    assert depends, "Empty dependency list"
+    assert type(depends) == tuple
+
+    if len(depends) == 3:
+        left = format_dependency_list(depends[1])
+        right = format_dependency_list(depends[2])
+
+        operator = OPERATOR_FORMAT_MAP.get(depends[0], depends[0])
+        result = left + " " + operator + " " + right
+        return result if skip_parens else "(" + result + ")"
+    elif depends[0] == 'not':
+        return "!" + format_dependency_list(depends[1])
+    elif depends[0] == 'string':
+        return '"' + depends[1] + '"'
+    elif depends[0] == 'number':
+        return str(depends[1])
+    elif depends[0] == 'boolean':
+        return str(depends[1])
+    elif depends[0] == 'word':
+        return depends[1] + "[=" + str(get_config(depends[1])['value']) + "]"

--- a/config_system/config_system/expr.py
+++ b/config_system/config_system/expr.py
@@ -75,11 +75,7 @@ def _expr_value(e):
                 raise TypeError("'-' operator is not valid on strings")
                 return left
             return left - right
-    elif e[0] == 'string':
-        return e[1]
-    elif e[0] == 'number':
-        return e[1]
-    elif e[0] == 'boolean':
+    elif e[0] in ['string', 'number', 'boolean']:
         return e[1]
     elif e[0] == 'identifier':
         return get_config(e[1])['value']
@@ -149,11 +145,7 @@ def _condexpr_value(e):
         if _condexpr_value(e[1]) == 'y':
             return 'n'
         return 'y'
-    elif e[0] == 'string':
-        return e[1]
-    elif e[0] == 'number':
-        return e[1]
-    elif e[0] == 'boolean':
+    elif e[0] in ['string', 'number', 'boolean']:
         return e[1]
     elif e[0] == 'identifier':
         return get_config(e[1])['value']

--- a/config_system/config_system/expr.py
+++ b/config_system/config_system/expr.py
@@ -1,0 +1,18 @@
+# Copyright 2019 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expression tuple for 'y' and 'n'
+YES = ('boolean', 'y')
+NO = ('boolean', 'n')

--- a/config_system/config_system/expr.py
+++ b/config_system/config_system/expr.py
@@ -46,7 +46,7 @@ def check_depends(depends, value):
     elif depends[0] == 'or':
         return (check_depends(depends[1], value) and
                 check_depends(depends[2], value))
-    elif depends[0] == 'word':
+    elif depends[0] == 'identifier':
         return depends[1] == value
     return False
 
@@ -81,7 +81,7 @@ def _expr_value(e):
         return e[1]
     elif e[0] == 'boolean':
         return e[1]
-    elif e[0] == 'word':
+    elif e[0] == 'identifier':
         return get_config(e[1])['value']
 
     raise Exception("Unexpected depend list: " + str(e))
@@ -155,7 +155,7 @@ def _condexpr_value(e):
         return e[1]
     elif e[0] == 'boolean':
         return e[1]
-    elif e[0] == 'word':
+    elif e[0] == 'identifier':
         return get_config(e[1])['value']
 
     raise Exception("Unexpected depend list: " + str(e))
@@ -190,7 +190,7 @@ def dependency_list(e):
     elif e[0] in ['string', 'number', 'boolean']:
         # Quoted string, number or boolean
         return set()
-    elif e[0] == 'word':
+    elif e[0] == 'identifier':
         return {e[1]}
     raise Exception("Unexpected depend list: " + str(e))
 
@@ -220,5 +220,5 @@ def format_dependency_list(depends, skip_parens=False):
         return str(depends[1])
     elif depends[0] == 'boolean':
         return str(depends[1])
-    elif depends[0] == 'word':
+    elif depends[0] == 'identifier':
         return depends[1] + "[=" + str(get_config(depends[1])['value']) + "]"

--- a/config_system/config_system/general.py
+++ b/config_system/config_system/general.py
@@ -23,215 +23,18 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def check_depends(depends, value):
-    """Check if the config identified in value is a simple dependency
-    listed in the depends expression.
-    A simple expression consists of just && and || boolean operators.
-    If the expression uses any other operator, return False.
-
-    This is used by the menu_parse below to indent dependent configs.
-    """
-    if depends is None:
-        return False
-    assert type(depends) == tuple
-    assert len(depends) in [2, 3]
-
-    if depends[0] == 'and':
-        return (check_depends(depends[1], value) or
-                check_depends(depends[2], value))
-    elif depends[0] == 'or':
-        return (check_depends(depends[1], value) and
-                check_depends(depends[2], value))
-    elif depends[0] == 'word':
-        return depends[1] == value
-    return False
-
-
-# Operators where the result is not boolean
-ARITH_SET = {"+", "-"}
-
-
-def _expr_value(e):
-    """Evaluate the value of the input expression.
-    This isn't expected to use conditional operators.
-    """
-    assert type(e) == tuple
-    assert len(e) in [2, 3]
-    if len(e) == 3:
-        left = _expr_value(e[1])
-        right = _expr_value(e[2])
-        if type(left) != type(right):
-            raise TypeError("'{}' operator is not valid with mixed types".format(e[0]))
-        elif left in ['y', 'n'] or right in ['y', 'n']:
-            raise TypeError("'{}' operator is not valid on booleans".format(e[0]))
-        elif e[0] == '+':
-            return left + right
-        elif e[0] == '-':
-            if type(left) is str:
-                raise TypeError("'-' operator is not valid on strings")
-                return left
-            return left - right
-    elif e[0] == 'string':
-        return e[1]
-    elif e[0] == 'number':
-        return e[1]
-    elif e[0] == 'boolean':
-        return e[1]
-    elif e[0] == 'word':
-        return data.get_config(e[1])['value']
-
-    raise Exception("Unexpected depend list: " + str(e))
-
-
-def expr_value(e):
-    try:
-        result = _expr_value(e)
-    except TypeError as err:
-        logging.error("{} in expression '{}'".format(str(err), format_dependency_list(e)))
-        result = ""
-
-    return result
-
-
-def _condexpr_value(e):
-    """Evaluate the value of the input expression.
-    Note that booleans are propagated as 'y' and 'n'
-    """
-    assert type(e) == tuple
-    assert len(e) in [2, 3]
-
-    if len(e) == 3:
-        if e[0] in ARITH_SET:
-            return _expr_value(e)
-
-        left = _condexpr_value(e[1])
-        right = _condexpr_value(e[2])
-        if type(left) != type(right):
-            # Boolean result expected
-            return 'n'
-        elif e[0] == 'and':
-            if left == 'y' and right == 'y':
-                return 'y'
-            return 'n'
-        elif e[0] == 'or':
-            if left == 'y' or right == 'y':
-                return 'y'
-            return 'n'
-        elif e[0] == '=':
-            if left == right:
-                return 'y'
-            return 'n'
-        elif e[0] == '!=':
-            if left != right:
-                return 'y'
-            return 'n'
-        elif e[0] == '>':
-            if left > right:
-                return 'y'
-            return 'n'
-        elif e[0] == '>=':
-            if left >= right:
-                return 'y'
-            return 'n'
-        elif e[0] == '<':
-            if left < right:
-                return 'y'
-            return 'n'
-        elif e[0] == '<=':
-            if left <= right:
-                return 'y'
-            return 'n'
-    elif e[0] == 'not':
-        if _condexpr_value(e[1]) == 'y':
-            return 'n'
-        return 'y'
-    elif e[0] == 'string':
-        return e[1]
-    elif e[0] == 'number':
-        return e[1]
-    elif e[0] == 'boolean':
-        return e[1]
-    elif e[0] == 'word':
-        return data.get_config(e[1])['value']
-
-    raise Exception("Unexpected depend list: " + str(e))
-
-
-def condexpr_value(e):
-    if e is None:
-        return 'y'
-    try:
-        result = _condexpr_value(e)
-    except TypeError as err:
-        logging.error("{} in expression '{}'".format(str(err), format_dependency_list(e)))
-        result = 'n'
-
-    return result
-
-
 def can_enable(depends):
-    value = condexpr_value(depends)
+    value = expr.condexpr_value(depends)
     if value == 'y':
         return True
     return False
 
 
 def is_visible(cond):
-    value = condexpr_value(cond)
+    value = expr.condexpr_value(cond)
     if value == 'n':
         return False
     return True
-
-
-def dependency_list(e):
-    """
-    Get the set of config identifiers referred to by an expression. A
-    set is returned instead of a list as we don't need duplicates, and
-    order doesn't matter.
-    """
-    if e is None:
-        return set()
-    assert type(e) == tuple
-
-    if e[0] in ['and', 'or', '=', '!=', '<', '<=', '>', '>=', '+', '-']:
-        return dependency_list(e[1]) | dependency_list(e[2])
-    elif e[0] == 'not':
-        return dependency_list(e[1])
-    elif e[0] in ['string', 'number', 'boolean']:
-        # Quoted string, number or boolean
-        return set()
-    elif e[0] == 'word':
-        return {e[1]}
-    raise Exception("Unexpected depend list: " + str(e))
-
-
-OPERATOR_FORMAT_MAP = {
-    "and": "&&",
-    "or": "||",
-}
-
-
-def format_dependency_list(depends, skip_parens=False):
-    assert depends, "Empty dependency list"
-    assert type(depends) == tuple
-
-    if len(depends) == 3:
-        left = format_dependency_list(depends[1])
-        right = format_dependency_list(depends[2])
-
-        operator = OPERATOR_FORMAT_MAP.get(depends[0], depends[0])
-        result = left + " " + operator + " " + right
-        return result if skip_parens else "(" + result + ")"
-    elif depends[0] == 'not':
-        return "!" + format_dependency_list(depends[1])
-    elif depends[0] == 'string':
-        return '"' + depends[1] + '"'
-    elif depends[0] == 'number':
-        return str(depends[1])
-    elif depends[0] == 'boolean':
-        return str(depends[1])
-    elif depends[0] == 'word':
-        return depends[1] + "[=" + str(data.get_config(depends[1])['value']) + "]"
 
 
 def enforce_dependent_values(auto_fix=False):
@@ -398,25 +201,25 @@ def set_initial_values():
         else:
             c['value'] = ''
 
-        for i in dependency_list(c.get("depends")):
+        for i in expr.dependency_list(c.get("depends")):
             data.get_config(i).setdefault('rdepends', []).append(k)
 
         if "default_cond" in c:
             for j in c['default_cond']:
-                for i in dependency_list(j['cond']):
+                for i in expr.dependency_list(j['cond']):
                     data.get_config(i).setdefault('rdefault', []).append(k)
-                value_deps = dependency_list(j['expr'])
+                value_deps = expr.dependency_list(j['expr'])
                 for d in value_deps:
                     data.get_config(d).setdefault('rdefault', []).append(k)
 
         if "default" in c:
-            value_deps = dependency_list(c['default'])
+            value_deps = expr.dependency_list(c['default'])
             for d in value_deps:
                 data.get_config(d).setdefault('rdefault', []).append(k)
 
         if "select_if" in c:
             for j in c['select_if']:
-                for i in dependency_list(j[1]):
+                for i in expr.dependency_list(j[1]):
                     data.get_config(i).setdefault('rselect_if', []).append(k)
 
     # Check for dependency cycles
@@ -457,12 +260,12 @@ def update_choice_default(c):
                 rank = 2
         else:
             for i in config.get("default_cond", []):
-                if can_enable(i['cond']) and expr_value(i['expr']) == 'y':
+                if can_enable(i['cond']) and expr.expr_value(i['expr']) == 'y':
                     rank = 3
                     break
             else:
                 def_expr = config.get("default", expr.NO)
-                if expr_value(def_expr) == "y":
+                if expr.expr_value(def_expr) == "y":
                     rank = 4
 
         return rank, config['position']
@@ -503,12 +306,12 @@ def update_defaults(k):
     if "default_cond" in c:
         for i in c['default_cond']:
             if can_enable(i['cond']):
-                set_config_internal(k, expr_value(i['expr']))
+                set_config_internal(k, expr.expr_value(i['expr']))
                 return
 
     # None of the conditioned defaults match
     if "default" in c:
-        set_config_internal(k, expr_value(c['default']))
+        set_config_internal(k, expr.expr_value(c['default']))
         return
 
     # No default - so set bools to 'n'
@@ -1005,12 +808,12 @@ def menu_parse():
                 continue
 
             while len(depends_stack) > 0:
-                if check_depends(config.get('depends'), depends_stack[-1]):
+                if expr.check_depends(config.get('depends'), depends_stack[-1]):
                     break
                 depends_stack.pop()
 
             while len(menuconfig_stack) > 0:
-                if check_depends(config.get('depends'), menuconfig_stack[-1]):
+                if expr.check_depends(config.get('depends'), menuconfig_stack[-1]):
                     inmenu = menuconfig_stack[-1]
                     break
                 menuconfig_stack.pop()
@@ -1029,7 +832,7 @@ def menu_parse():
             inmenu = config.get('inmenu')
 
             while len(menuconfig_stack) > 0:
-                if check_depends(config.get('depends'), menuconfig_stack[-1]):
+                if expr.check_depends(config.get('depends'), menuconfig_stack[-1]):
                     inmenu = menuconfig_stack[-1]
                     break
                 menuconfig_stack.pop()

--- a/config_system/config_system/lex.py
+++ b/config_system/config_system/lex.py
@@ -42,12 +42,14 @@ tokens = (
     "MENU", "ENDMENU", "MAINMENU",
     "MENUCONFIG",
     "NUMBER",
+    "PLUS", "MINUS",
     "PROMPT",
     "QUOTED_STRING",
     "SELECT",
     "SOURCE",
     "STRING",
     "VISIBLE",
+    "YES", "NO",
     "WORD",
     "COMMENT",
 )
@@ -137,6 +139,8 @@ t_PARAM_LESS = r"<"
 t_PARAM_LESS_EQUAL = r"<="
 t_PARAM_GREATER = r">"
 t_PARAM_GREATER_EQUAL = r">="
+t_PARAM_PLUS = r"\+"
+t_PARAM_MINUS = r"-"
 
 
 def t_PARAM_space(t):
@@ -148,6 +152,10 @@ def t_PARAM_word(t):
     r"[A-Za-z][A-Za-z0-9_]*"
     if t.value in params:
         t.type = t.value.upper()
+    elif t.value == 'y':
+        t.type = "YES"
+    elif t.value == 'n':
+        t.type = "NO"
     else:
         t.type = "WORD"
     return t

--- a/config_system/config_system/lex.py
+++ b/config_system/config_system/lex.py
@@ -36,6 +36,7 @@ tokens = (
     "EOL",
     "EQUAL", "UNEQUAL", "LESS", "LESS_EQUAL", "GREATER", "GREATER_EQUAL",
     "HELP", "HELPTEXT",
+    "IDENTIFIER",
     "IF", "ON",
     "INT",
     "LBRACKET", "RBRACKET",
@@ -50,7 +51,6 @@ tokens = (
     "STRING",
     "VISIBLE",
     "YES", "NO",
-    "WORD",
     "COMMENT",
 )
 
@@ -148,7 +148,7 @@ def t_PARAM_space(t):
     return None
 
 
-def t_PARAM_word(t):
+def t_PARAM_identifier(t):
     r"[A-Za-z][A-Za-z0-9_]*"
     if t.value in params:
         t.type = t.value.upper()
@@ -157,7 +157,7 @@ def t_PARAM_word(t):
     elif t.value == 'n':
         t.type = "NO"
     else:
-        t.type = "WORD"
+        t.type = "IDENTIFIER"
     return t
 
 

--- a/config_system/config_system/syntax.py
+++ b/config_system/config_system/syntax.py
@@ -65,7 +65,7 @@ order_count = 0
 
 
 def p_menuconfig_stmt(p):
-    "menuconfig_stmt : MENUCONFIG WORD EOL config_options"
+    "menuconfig_stmt : MENUCONFIG IDENTIFIER EOL config_options"
 
     global order_count
     order_count += 1
@@ -137,7 +137,7 @@ def p_menu_visible(p):
 
 
 def p_config_stmt(p):
-    "config_stmt : CONFIG WORD EOL config_options"
+    "config_stmt : CONFIG IDENTIFIER EOL config_options"
     global order_count
     order_count += 1
     config_options = merge(p[4], {"type": "config", "position": order_count})
@@ -178,14 +178,14 @@ def p_choice_stmt(p):
                 p[0]["config"][k]["depends"] = config["depends"]
 
     for d in config.get("default_cond", []):
-        assert d["expr"][0] == "word", "Expressions not supported in choice default"
+        assert d["expr"][0] == "identifier", "Expressions not supported in choice default"
         for k in p[0]["config"]:
             if k == d["expr"][1]:
                 p[0]["config"][k] = merge(p[0]["config"][k],
                                           {"default_cond": [{"cond": d["cond"], "expr": expr.YES}]})
 
     if "default" in config:
-        assert config["default"][0] == "word", "Expressions not supported in choice default"
+        assert config["default"][0] == "identifier", "Expressions not supported in choice default"
         for k in p[0]["config"]:
             if k == config["default"][1]:
                 d = {"default": expr.YES}
@@ -291,12 +291,12 @@ def p_config_type(p):
 
 
 def p_config_select(p):
-    "config_select : SELECT WORD EOL"
+    "config_select : SELECT IDENTIFIER EOL"
     p[0] = {"select": [p[2]]}
 
 
 def p_config_select_if(p):
-    "config_select : SELECT WORD IF condexpr EOL"
+    "config_select : SELECT IDENTIFIER IF condexpr EOL"
     p[0] = {"select_if": [(p[2], p[4])]}
 
 
@@ -423,8 +423,8 @@ def p_lit_or_ident_identifier(p):
 
 
 def p_identifier(p):
-    "identifier : WORD"
-    p[0] = ("word", p[1])
+    "identifier : IDENTIFIER"
+    p[0] = ("identifier", p[1])
 
 
 def p_config_help(p):

--- a/config_system/mconfigfmt.py
+++ b/config_system/mconfigfmt.py
@@ -43,9 +43,10 @@ set_config_props = {"BOOL", "INT", "STRING", "PROMPT",
                     "DEFAULT", "DEPENDS", "SELECT",
                     "VISIBLE", "HELP"}
 set_binary_ops = {"ANDAND", "OROR",
-                  "EQUAL", "UNEQUAL", "LESS", "LESS_EQUAL", "GREATER", "GREATER_EQUAL"}
+                  "EQUAL", "UNEQUAL", "LESS", "LESS_EQUAL", "GREATER", "GREATER_EQUAL",
+                  "PLUS", "MINUS"}
 set_unary_ops = {"NOT"}
-set_identifiers = {"NUMBER", "QUOTED_STRING", "WORD"}
+set_identifiers = {"NUMBER", "QUOTED_STRING", "WORD", "YES", "NO"}
 set_keywords = {"IF", "ON"}
 set_lparen = {"LBRACKET"}
 

--- a/config_system/mconfigfmt.py
+++ b/config_system/mconfigfmt.py
@@ -46,7 +46,7 @@ set_binary_ops = {"ANDAND", "OROR",
                   "EQUAL", "UNEQUAL", "LESS", "LESS_EQUAL", "GREATER", "GREATER_EQUAL",
                   "PLUS", "MINUS"}
 set_unary_ops = {"NOT"}
-set_identifiers = {"NUMBER", "QUOTED_STRING", "WORD", "YES", "NO"}
+set_identifiers = {"NUMBER", "QUOTED_STRING", "IDENTIFIER", "YES", "NO"}
 set_keywords = {"IF", "ON"}
 set_lparen = {"LBRACKET"}
 

--- a/config_system/tests/formatter/formatter.expected
+++ b/config_system/tests/formatter/formatter.expected
@@ -66,4 +66,4 @@ endchoice
 
 config FOOBAR
 	bool "Foobar"
-	default y
+	default y if ((4 + 3) - 2) + 8 = 7

--- a/config_system/tests/formatter/formatter.test
+++ b/config_system/tests/formatter/formatter.test
@@ -66,4 +66,4 @@ endchoice
 
 config FOOBAR
 	bool "Foobar"
-	default y
+	default y if  ( ( 4+3 )-2 )+8=7

--- a/config_system/tests/run_tests.py
+++ b/config_system/tests/run_tests.py
@@ -28,7 +28,7 @@ from argparse import ArgumentParser
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 CFG_DIR = os.path.dirname(TEST_DIR)
 sys.path.append(CFG_DIR)
-from config_system import general  # nopep8: E402 module level import not at top of file
+import config_system  # nopep8: E402 module level import not at top of file
 
 
 def runtest(name):
@@ -41,7 +41,7 @@ def runtest(name):
 
     if not os.path.exists(config_file):
         config_file = "empty_file"
-    general.read_config(name, config_file, False)
+    config_system.read_config(name, config_file, False)
 
     with open(name) as f:
         for line_number, line in enumerate(f):
@@ -51,13 +51,13 @@ def runtest(name):
             action, key, value = m.groups()
             if action == "ASSERT":
                 tests_run += 1
-                actual_value = general.get_config(key).get("value")
+                actual_value = config_system.get_config(key).get("value")
                 if actual_value != value:
                     print("ERROR: %s:%d: assertion failed: %s=%s (should be %s)"
                           % (name, line_number, key, actual_value, value))
                     tests_failed += 1
             elif action == "SET":
-                general.set_config(key, value)
+                config_system.set_config(key, value)
             else:
                 raise Exception("Unexpected action %s" % action)
 

--- a/config_system/tests/test_expressions.py
+++ b/config_system/tests/test_expressions.py
@@ -1,0 +1,518 @@
+# Copyright 2019 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from config_system import data, expr, general
+
+
+template_expr_mconfig = """
+config TRUE
+    bool
+    default y
+
+config NUMBER_A
+    int "num"
+    default 7
+
+config NUMBER_B
+    int "num"
+    default 127
+
+config PREFIX
+    string "pre"
+    default "abra"
+
+config SUFFIX
+    string "suffix"
+    default "cadabra"
+
+config OPTION
+    {type} "option"
+    default {expr}
+"""
+
+
+expr_testdata = [
+    (
+        {  # literal addition
+            "type": "int",
+            "expr": "3+4",
+        },
+        7, None
+    ),
+    (
+        {  # addition of identifier and literal
+            "type": "int",
+            "expr": "NUMBER_A+4",
+        },
+        11, None
+    ),
+    (
+        {  # addition of literal and identifier
+            "type": "int",
+            "expr": "5+NUMBER_A",
+        },
+        12, None
+    ),
+    (
+        {  # addition of identifiers
+            "type": "int",
+            "expr": "NUMBER_A+NUMBER_A",
+        },
+        14, None
+    ),
+    (
+        {  # literal subtraction
+            "type": "int",
+            "expr": "10-4",
+        },
+        6, None
+    ),
+    (
+        {  # subtraction of identifier and literal
+            "type": "int",
+            "expr": "NUMBER_A-4",
+        },
+        3, None
+    ),
+    (
+        {  # subtraction of literal and identifier
+            "type": "int",
+            "expr": "20-NUMBER_A",
+        },
+        13, None
+    ),
+    (
+        {  # subtraction of identifiers
+            "type": "int",
+            "expr": "NUMBER_B-NUMBER_A",
+        },
+        120, None
+    ),
+    (
+        {  # parenthesis in expression
+            "type": "int",
+            "expr": "NUMBER_B - (NUMBER_A + 10)",
+        },
+        110, None
+    ),
+    (
+        {  # parenthesis in expression (on LHS)
+            "type": "int",
+            "expr": "(NUMBER_B + NUMBER_A) - 10",
+        },
+        124, None
+    ),
+    (
+        {  # string literal concatenation
+            "type": "string",
+            "expr": '"ban"+"ana"',
+        },
+        "banana", None
+    ),
+    (
+        {  # string and literal concatenation
+            "type": "string",
+            "expr": 'PREFIX+"ana"',
+        },
+        "abraana", None
+    ),
+    (
+        {  # string and literal concatenation
+            "type": "string",
+            "expr": '"ban"+SUFFIX',
+        },
+        "bancadabra", None
+    ),
+    (
+        {  # string concatenation
+            "type": "string",
+            "expr": "PREFIX+SUFFIX",
+        },
+        "abracadabra", None
+    ),
+    (
+        {  # string concatenation with parens (for completeness)
+            "type": "string",
+            "expr": 'PREFIX+(SUFFIX+"boo")',
+        },
+        "abracadabraboo", None
+    ),
+    (
+        {  # string subtraction
+            "type": "string",
+            "expr": "PREFIX-SUFFIX",
+        },
+        "", "'-' operator is not valid on strings"
+    ),
+    (
+        {  # expression with bools (+)
+            "type": "bool",
+            "expr": "y+n",
+        },
+        "", "'+' operator is not valid on booleans"
+    ),
+    (
+        {  # expression with bools (-)
+            "type": "bool",
+            "expr": "TRUE-n",
+        },
+        "", "'-' operator is not valid on booleans"
+    ),
+    (
+        {  # mixed expression '+'
+            "type": "string",
+            "expr": "PREFIX+NUMBER_A",
+        },
+        "", "'+' operator is not valid with mixed types"
+    ),
+    (
+        {  # mixed expression '-'
+            "type": "string",
+            "expr": "PREFIX-NUMBER_A",
+        },
+        "", "'-' operator is not valid with mixed types"
+    ),
+    (
+        {  # mixed expression with boolean. Note we can't detect mixed,
+           # so this complains about boolean
+            "type": "string",
+            "expr": "PREFIX-TRUE",
+        },
+        "", "'-' operator is not valid on booleans"
+    ),
+
+]
+
+
+@pytest.mark.parametrize("inputdata,result,error", expr_testdata)
+def test_expr_evaluation(caplog, tmpdir, inputdata, result, error):
+    mconfig_file = tmpdir.join("Mconfig")
+
+    mconfig = template_expr_mconfig.format(**inputdata)
+    mconfig_file.write(mconfig, "wt")
+
+    data.init(str(mconfig_file), False)
+    c = data.get_config("OPTION")
+    general.set_initial_values()
+
+    val = expr.expr_value(c['default'])
+
+    if error is not None:
+        assert error in caplog.text
+    else:
+        assert val == result
+        assert caplog.text == ""
+
+
+template_condexpr_mconfig = """
+config TRUE
+    bool
+    default y
+
+config FALSE
+    bool
+    default n
+
+config NUMBER_A
+    int "num"
+    default 7
+
+config NUMBER_B
+    int "num"
+    default 127
+
+config PREFIX
+    string "pre"
+    default "abra"
+
+config SUFFIX
+    string "suffix"
+    default "cadabra"
+
+config OPTION
+    bool "option"
+    default y if {expr}
+"""
+
+condexpr_testdata = [
+    (
+        {  # literal AND
+            "expr": "y && y",
+        },
+        "y", None
+    ),
+    (
+        {  # literal AND
+            "expr": "n && y",
+        },
+        "n", None
+    ),
+    (
+        {  # literal AND
+            "expr": "y && n",
+        },
+        "n", None
+    ),
+    (
+        {  # literal AND
+            "expr": "n && n",
+        },
+        "n", None
+    ),
+    (
+        {  # AND
+            "expr": "TRUE && TRUE",
+        },
+        "y", None
+    ),
+    (
+        {  # AND
+            "expr": "FALSE && TRUE",
+        },
+        "n", None
+    ),
+    (
+        {  # AND
+            "expr": "TRUE && FALSE",
+        },
+        "n", None
+    ),
+    (
+        {  # AND
+            "expr": "FALSE && FALSE",
+        },
+        "n", None
+    ),
+    (
+        {  # literal OR
+            "expr": "y || y",
+        },
+        "y", None
+    ),
+    (
+        {  # literal OR
+            "expr": "n || y",
+        },
+        "y", None
+    ),
+    (
+        {  # literal OR
+            "expr": "y || n",
+        },
+        "y", None
+    ),
+    (
+        {  # literal OR
+            "expr": "n || n",
+        },
+        "n", None
+    ),
+    (
+        {  # OR
+            "expr": "TRUE || TRUE",
+        },
+        "y", None
+    ),
+    (
+        {  # OR
+            "expr": "FALSE || TRUE",
+        },
+        "y", None
+    ),
+    (
+        {  # OR
+            "expr": "TRUE || FALSE",
+        },
+        "y", None
+    ),
+    (
+        {  # OR
+            "expr": "FALSE || FALSE",
+        },
+        "n", None
+    ),
+    (
+        {  # NOT
+            "expr": "!TRUE",
+        },
+        "n", None
+    ),
+    (
+        {  # NOT
+            "expr": "!FALSE",
+        },
+        "y", None
+    ),
+    (
+        {  # Greater than
+            "expr": "NUMBER_B > 126",
+        },
+        "y", None
+    ),
+    (
+        {  # Greater than
+            "expr": "NUMBER_B > 127",
+        },
+        "n", None
+    ),
+    (
+        {  # Greater than eq
+            "expr": "NUMBER_B >= 127",
+        },
+        "y", None
+    ),
+    (
+        {  # Greater than eq
+            "expr": "NUMBER_B >= 128",
+        },
+        "n", None
+    ),
+    (
+        {  # Less than
+            "expr": "NUMBER_B < 128",
+        },
+        "y", None
+    ),
+    (
+        {  # Less than
+            "expr": "NUMBER_B < 127",
+        },
+        "n", None
+    ),
+    (
+        {  # Less than eq
+            "expr": "NUMBER_B <= 127",
+        },
+        "y", None
+    ),
+    (
+        {  # Less than eq
+            "expr": "NUMBER_B <= 126",
+        },
+        "n", None
+    ),
+    (
+        {  # Equal
+            "expr": "NUMBER_B = 127",
+        },
+        "y", None
+    ),
+    (
+        {  # Equal
+            "expr": "NUMBER_B = 126",
+        },
+        "n", None
+    ),
+    (
+        {  # Equal
+            "expr": "NUMBER_B = 128",
+        },
+        "n", None
+    ),
+    (
+        {  # Not equal
+            "expr": "NUMBER_B != 127",
+        },
+        "n", None
+    ),
+    (
+        {  # Not equal
+            "expr": "NUMBER_B != 126",
+        },
+        "y", None
+    ),
+    (
+        {  # Not equal
+            "expr": "NUMBER_B != 128",
+        },
+        "y", None
+    ),
+    (
+        {  # Comparison with numeric expression
+            "expr": "NUMBER_B < (121 + NUMBER_A)"
+        },
+        "y", None
+    ),
+    (
+        {  # Comparison with string
+            "expr": '"abracadabra" = PREFIX+SUFFIX'
+        },
+        "y", None
+    ),
+    (
+        {  # Precedence of || vs <
+            "expr": "FALSE || NUMBER_B < 128"
+        },
+        "y", None
+    ),
+    (
+        {  # Precedence of && vs <
+            "expr": "TRUE && NUMBER_B < 128"
+        },
+        "y", None
+    ),
+    (
+        {  # Precedence of && vs < vs +
+            "expr": "TRUE && NUMBER_B < 121 + NUMBER_A"
+        },
+        "y", None
+    ),
+    (
+        {  # Precedence of && vs || - && has higher precedence
+            "expr": "FALSE && TRUE || TRUE"
+        },
+        "y", None
+    ),
+    (
+        {  # Precedence of && vs || - && has higher precedence
+            "expr": "TRUE || FALSE && FALSE"
+        },
+        "y", None
+    ),
+    (
+        {  # Parenthesis to give || precedence
+            "expr": "FALSE && (TRUE || TRUE)"
+        },
+        "n", None
+    ),
+    (
+        {  # Parenthesis to give || precedence
+            "expr": "(TRUE || FALSE) && FALSE"
+        },
+        "n", None
+    ),
+]
+
+
+@pytest.mark.parametrize("inputdata,result,error", condexpr_testdata)
+def test_condexpr_evaluation(caplog, tmpdir, inputdata, result, error):
+    mconfig_file = tmpdir.join("Mconfig")
+
+    mconfig = template_condexpr_mconfig.format(**inputdata)
+    mconfig_file.write(mconfig, "wt")
+
+    data.init(str(mconfig_file), False)
+    c = data.get_config("OPTION")
+    general.set_initial_values()
+
+    val = expr.condexpr_value(c['default_cond'][0]['cond'])
+
+    if error is not None:
+        assert error in caplog.text
+    else:
+        assert val == result
+        assert caplog.text == ""

--- a/config_system/update_config.py
+++ b/config_system/update_config.py
@@ -23,9 +23,10 @@ import re
 import sys
 
 from config_system import log_handlers, config_json
-from config_system.general import enforce_dependent_values, get_config, init_config, \
+from config_system.general import enforce_dependent_values, init_config, \
     read_config, read_profile_file, set_config_if_prompt, write_config, \
     can_enable, format_dependency_list
+from config_system.data import get_config
 
 root_logger = logging.getLogger()
 root_logger.setLevel(logging.WARNING)

--- a/config_system/update_config.py
+++ b/config_system/update_config.py
@@ -25,8 +25,9 @@ import sys
 from config_system import log_handlers, config_json
 from config_system.general import enforce_dependent_values, init_config, \
     read_config, read_profile_file, set_config_if_prompt, write_config, \
-    can_enable, format_dependency_list
+    can_enable
 from config_system.data import get_config
+from config_system.expr import format_dependency_list
 
 root_logger = logging.getLogger()
 root_logger.setLevel(logging.WARNING)


### PR DESCRIPTION
This commit series enables the use of '+' and '-' in expressions in Mconfig. For integers, this results in addition and subtraction. For strings, '+' results in concatenation.

This will simplify some configuration construction, where the default value of an option can be expressed as the combination of other options.

Note that these operators do not apply to booleans, where the 'default if' and 'select if' constructions provide this capability.

The initial commit implements the necessary support. The subsequent commits refactor the code to improve maintainability, and add testing.