### PR TITLE
config_system: use booleans for 'y' and 'n'

### DIFF
--- a/config_system/config_system/config_json.py
+++ b/config_system/config_system/config_json.py
@@ -33,7 +33,6 @@ def config_to_json():
         value = c["value"]
 
         if datatype == "bool":
-            value = True if value == "y" else False
             properties[key] = value
         elif datatype == "int":
             properties[key] = int(value)

--- a/config_system/config_system/syntax.py
+++ b/config_system/config_system/syntax.py
@@ -414,7 +414,10 @@ def p_lit_or_ident_number(p):
 def p_lit_or_ident_boolean(p):
     """literal_or_identifier : YES
                              | NO"""
-    p[0] = ("boolean", p[1])
+    value = False
+    if p[1] == 'y':
+        value = True
+    p[0] = ("boolean", value)
 
 
 def p_lit_or_ident_identifier(p):

--- a/config_system/tests/run_tests.py
+++ b/config_system/tests/run_tests.py
@@ -51,12 +51,19 @@ def runtest(name):
             action, key, value = m.groups()
             if action == "ASSERT":
                 tests_run += 1
-                actual_value = config_system.get_config(key).get("value")
+                config = config_system.get_config(key)
+                actual_value = config.get("value")
+                if config['datatype'] == 'bool':
+                    actual_value = 'y' if actual_value else 'n'
                 if actual_value != value:
                     print("ERROR: %s:%d: assertion failed: %s=%s (should be %s)"
                           % (name, line_number, key, actual_value, value))
                     tests_failed += 1
             elif action == "SET":
+                if value == 'y':
+                    value = True
+                elif value == 'n':
+                    value = False
                 config_system.set_config(key, value)
             else:
                 raise Exception("Unexpected action %s" % action)

--- a/config_system/tests/test_expressions.py
+++ b/config_system/tests/test_expressions.py
@@ -145,6 +145,20 @@ expr_testdata = [
         "abracadabra", None
     ),
     (
+        {  # string concatenation with 'y' (not a bool)
+            "type": "string",
+            "expr": 'PREFIX+"y"',
+        },
+        "abray", None
+    ),
+    (
+        {  # string concatenation with 'n' (not a bool)
+            "type": "string",
+            "expr": '"n"+SUFFIX',
+        },
+        "ncadabra", None
+    ),
+    (
         {  # string concatenation with parens (for completeness)
             "type": "string",
             "expr": 'PREFIX+(SUFFIX+"boo")',
@@ -187,12 +201,11 @@ expr_testdata = [
         "", "'-' operator is not valid with mixed types"
     ),
     (
-        {  # mixed expression with boolean. Note we can't detect mixed,
-           # so this complains about boolean
+        {  # mixed expression with boolean.
             "type": "string",
             "expr": "PREFIX-TRUE",
         },
-        "", "'-' operator is not valid on booleans"
+        "", "'-' operator is not valid with mixed types"
     ),
 
 ]
@@ -253,247 +266,247 @@ condexpr_testdata = [
         {  # literal AND
             "expr": "y && y",
         },
-        "y", None
+        True, None
     ),
     (
         {  # literal AND
             "expr": "n && y",
         },
-        "n", None
+        False, None
     ),
     (
         {  # literal AND
             "expr": "y && n",
         },
-        "n", None
+        False, None
     ),
     (
         {  # literal AND
             "expr": "n && n",
         },
-        "n", None
+        False, None
     ),
     (
         {  # AND
             "expr": "TRUE && TRUE",
         },
-        "y", None
+        True, None
     ),
     (
         {  # AND
             "expr": "FALSE && TRUE",
         },
-        "n", None
+        False, None
     ),
     (
         {  # AND
             "expr": "TRUE && FALSE",
         },
-        "n", None
+        False, None
     ),
     (
         {  # AND
             "expr": "FALSE && FALSE",
         },
-        "n", None
+        False, None
     ),
     (
         {  # literal OR
             "expr": "y || y",
         },
-        "y", None
+        True, None
     ),
     (
         {  # literal OR
             "expr": "n || y",
         },
-        "y", None
+        True, None
     ),
     (
         {  # literal OR
             "expr": "y || n",
         },
-        "y", None
+        True, None
     ),
     (
         {  # literal OR
             "expr": "n || n",
         },
-        "n", None
+        False, None
     ),
     (
         {  # OR
             "expr": "TRUE || TRUE",
         },
-        "y", None
+        True, None
     ),
     (
         {  # OR
             "expr": "FALSE || TRUE",
         },
-        "y", None
+        True, None
     ),
     (
         {  # OR
             "expr": "TRUE || FALSE",
         },
-        "y", None
+        True, None
     ),
     (
         {  # OR
             "expr": "FALSE || FALSE",
         },
-        "n", None
+        False, None
     ),
     (
         {  # NOT
             "expr": "!TRUE",
         },
-        "n", None
+        False, None
     ),
     (
         {  # NOT
             "expr": "!FALSE",
         },
-        "y", None
+        True, None
     ),
     (
         {  # Greater than
             "expr": "NUMBER_B > 126",
         },
-        "y", None
+        True, None
     ),
     (
         {  # Greater than
             "expr": "NUMBER_B > 127",
         },
-        "n", None
+        False, None
     ),
     (
         {  # Greater than eq
             "expr": "NUMBER_B >= 127",
         },
-        "y", None
+        True, None
     ),
     (
         {  # Greater than eq
             "expr": "NUMBER_B >= 128",
         },
-        "n", None
+        False, None
     ),
     (
         {  # Less than
             "expr": "NUMBER_B < 128",
         },
-        "y", None
+        True, None
     ),
     (
         {  # Less than
             "expr": "NUMBER_B < 127",
         },
-        "n", None
+        False, None
     ),
     (
         {  # Less than eq
             "expr": "NUMBER_B <= 127",
         },
-        "y", None
+        True, None
     ),
     (
         {  # Less than eq
             "expr": "NUMBER_B <= 126",
         },
-        "n", None
+        False, None
     ),
     (
         {  # Equal
             "expr": "NUMBER_B = 127",
         },
-        "y", None
+        True, None
     ),
     (
         {  # Equal
             "expr": "NUMBER_B = 126",
         },
-        "n", None
+        False, None
     ),
     (
         {  # Equal
             "expr": "NUMBER_B = 128",
         },
-        "n", None
+        False, None
     ),
     (
         {  # Not equal
             "expr": "NUMBER_B != 127",
         },
-        "n", None
+        False, None
     ),
     (
         {  # Not equal
             "expr": "NUMBER_B != 126",
         },
-        "y", None
+        True, None
     ),
     (
         {  # Not equal
             "expr": "NUMBER_B != 128",
         },
-        "y", None
+        True, None
     ),
     (
         {  # Comparison with numeric expression
             "expr": "NUMBER_B < (121 + NUMBER_A)"
         },
-        "y", None
+        True, None
     ),
     (
         {  # Comparison with string
             "expr": '"abracadabra" = PREFIX+SUFFIX'
         },
-        "y", None
+        True, None
     ),
     (
         {  # Precedence of || vs <
             "expr": "FALSE || NUMBER_B < 128"
         },
-        "y", None
+        True, None
     ),
     (
         {  # Precedence of && vs <
             "expr": "TRUE && NUMBER_B < 128"
         },
-        "y", None
+        True, None
     ),
     (
         {  # Precedence of && vs < vs +
             "expr": "TRUE && NUMBER_B < 121 + NUMBER_A"
         },
-        "y", None
+        True, None
     ),
     (
         {  # Precedence of && vs || - && has higher precedence
             "expr": "FALSE && TRUE || TRUE"
         },
-        "y", None
+        True, None
     ),
     (
         {  # Precedence of && vs || - && has higher precedence
             "expr": "TRUE || FALSE && FALSE"
         },
-        "y", None
+        True, None
     ),
     (
         {  # Parenthesis to give || precedence
             "expr": "FALSE && (TRUE || TRUE)"
         },
-        "n", None
+        False, None
     ),
     (
         {  # Parenthesis to give || precedence
             "expr": "(TRUE || FALSE) && FALSE"
         },
-        "n", None
+        False, None
     ),
 ]
 

--- a/config_system/update_config.py
+++ b/config_system/update_config.py
@@ -71,10 +71,12 @@ def check_value_as_requested(key, requested_value, later_keys, later_values):
         logger.error("unknown configuration option \"%s\"" % key)
         return
 
-    final_value = opt["value"]
+    final_value = opt['value']
 
-    if opt["datatype"] == "int":
+    if opt['datatype'] == 'int':
         final_value = str(final_value)
+    elif opt['datatype'] == 'bool':
+        final_value = 'y' if final_value else 'n'
 
     if final_value == requested_value:
         return

--- a/scripts/minimal_config.py
+++ b/scripts/minimal_config.py
@@ -45,17 +45,14 @@ def config_to_json(database_fname, config_fname, ignore_missing):
     for key in config_list:
         c = config_system.get_config(key)
         key = key.lower()
-        datatype = c["datatype"]
-        value = c["value"]
+        datatype = c['datatype']
+        value = c['value']
 
-        if "title" in c and config_system.can_enable(c.get('depends')):
-            if datatype == "bool":
-                value = True if value == "y" else False
+        if 'title' in c and config_system.can_enable(c.get('depends')):
+            if datatype in ['bool', 'string']:
                 configs[key] = value
-            elif datatype == "int":
+            elif datatype == 'int':
                 configs[key] = int(value)
-            elif datatype == "string":
-                configs[key] = value
             else:
                 msg = "Invalid config type: %s (with value '%s')\n"
                 logger.critical(msg % (datatype, str(value)))


### PR DESCRIPTION
Internally use the appropriate python datatype to handle booleans.
This simplifies type checking, and avoids needing to pass the expected
type around.

Change-Id: I25a3b7c9ee76a38f6bb2697f17e061c7cb3c2f6e
Signed-off-by: David Kilroy <david.kilroy@arm.com>