### PR TITLE
Don't stop build on config warnings

### DIFF
--- a/bob.bash
+++ b/bob.bash
@@ -38,10 +38,18 @@ fi
 # Refresh the configuration. This means that options changed or added since the
 # last build will be chosen from their defaults automatically, so that users
 # don't have to reconfigure manually if the config database changes.
+update_config_status=0
 python "${BOB_DIR}/config_system/update_config.py" \
        --database "${SRCDIR}/Mconfig" --config "${BUILDDIR}/${CONFIGNAME}" \
        --json "${BUILDDIR}/config.json" \
-       ${BOB_CONFIG_OPTS}
+       ${BOB_CONFIG_OPTS} || update_config_status=$?
+
+# If the config generated errors, stop the build. An exit status of 1 indicates
+# only warnings, so allow it to continue in this case.
+if [[ "${update_config_status}" -ge 2 ]]; then
+    echo "Generation of config.json failed" >&2
+    exit 1
+fi
 
 # Get a hash of the environment so we can detect if we need to
 # regenerate the build.ninja


### PR DESCRIPTION
Allow the config system to exit with a status of `1` when running
`buildme`. This only indicates warnings, so the build should be
permitted to continue.

Change-Id: I286c0ddf7065ea05b1d63adf3284a95ed50d1514
Signed-off-by: Chris Diamand <chris.diamand@arm.com>