### PR TITLE
config_system: condexpr_value refactoring

### DIFF
--- a/config_system/config_system/data.py
+++ b/config_system/config_system/data.py
@@ -75,22 +75,13 @@ def iter_symbols_menuorder():
         yield configuration['order'][i]
 
 
-def get_menu_depends(type, value):
+def get_menu_configitem(type, value):
     if type in ['config', 'menuconfig']:
-        return configuration['config'][value].get('depends')
+        return get_config(value)
     elif type in ['choice']:
-        return configuration['choice'][value].get('depends')
+        return get_choice_group(value)
     elif type in ['menu']:
-        return configuration['menu'][value].get('depends')
-
-
-def get_menu_visible(type, value):
-    if type in ['config', 'menuconfig']:
-        return configuration['config'][value].get('visible_cond')
-    elif type in ['choice']:
-        return configuration['choice'][value].get('visible_cond')
-    elif type in ['menu']:
-        return configuration['menu'][value].get('visible_cond')
+        return get_menu(value)
 
 
 def get_config_list():

--- a/config_system/config_system/expr.py
+++ b/config_system/config_system/expr.py
@@ -135,10 +135,13 @@ def _condexpr_value(e):
 
 
 def condexpr_value(e):
-    if e is None:
-        return True
+    assert e is not None
     try:
         result = _condexpr_value(e)
+        if type(result) is not bool:
+            logging.Error("Conditional expression '{}' does not return a boolean '{}'".format(
+                format_dependency_list(e), str(result)))
+            result = False
     except TypeError as err:
         logging.error("{} in expression '{}'".format(str(err), format_dependency_list(e)))
         result = False

--- a/config_system/update_config.py
+++ b/config_system/update_config.py
@@ -88,8 +88,8 @@ def check_value_as_requested(key, requested_value, later_keys, later_values):
                      key, requested_value, key, later_values[last_idx])
         return
 
-    depends = opt.get("depends")
-    if depends and not can_enable(depends):
+    if not can_enable(opt):
+        depends = opt['depends']
         logger.error("%s=%s was ignored; its dependencies were not met: %s",
                      key, requested_value, format_dependency_list(depends, skip_parens=True))
         return

--- a/scripts/minimal_config.py
+++ b/scripts/minimal_config.py
@@ -48,7 +48,7 @@ def config_to_json(database_fname, config_fname, ignore_missing):
         datatype = c['datatype']
         value = c['value']
 
-        if 'title' in c and config_system.can_enable(c.get('depends')):
+        if 'title' in c and config_system.can_enable(c):
             if datatype in ['bool', 'string']:
                 configs[key] = value
             elif datatype == 'int':


### PR DESCRIPTION
condexpr_value must have an input expression, and always return a
bool. Callers need to deal with the case where there is no expression.

Both is_visible() and can_enable() should take a config. Both these
functions should operate on config items rather than an expression.
This means that some current callers of can_enable() need
to call condexpr_value().

can_enable() is exported, so this could impact external scripts.

Change-Id: Ic9ddcb75a802c1b77e546d09a805039bd9a31f37
Signed-off-by: David Kilroy <david.kilroy@arm.com>