### PR TITLE
Don't rewrite config file during build

### DIFF
--- a/bob.bash
+++ b/bob.bash
@@ -38,15 +38,14 @@ fi
 # Refresh the configuration. This means that options changed or added since the
 # last build will be chosen from their defaults automatically, so that users
 # don't have to reconfigure manually if the config database changes.
-update_config_status=0
-python "${BOB_DIR}/config_system/update_config.py" \
-       --database "${SRCDIR}/Mconfig" --config "${BUILDDIR}/${CONFIGNAME}" \
-       --json "${BUILDDIR}/config.json" \
-       ${BOB_CONFIG_OPTS} || update_config_status=$?
+generate_json_status=0
+python "${BOB_DIR}/config_system/generate_config_json.py" \
+       "${BUILDDIR}/${CONFIGNAME}" --database "${SRCDIR}/Mconfig" \
+       --json "${BUILDDIR}/config.json" || generate_json_status=$?
 
 # If the config generated errors, stop the build. An exit status of 1 indicates
 # only warnings, so allow it to continue in this case.
-if [[ "${update_config_status}" -ge 2 ]]; then
+if [[ "${generate_json_status}" -ge 2 ]]; then
     echo "Generation of config.json failed" >&2
     exit 1
 fi

--- a/config_system/generate_config_json.py
+++ b/config_system/generate_config_json.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import sys
+
+import config_system
+import config_system.log_handlers
+import config_system.config_json
+
+root_logger = logging.getLogger()
+root_logger.setLevel(logging.WARNING)
+
+# Add counting Handler
+counter = config_system.log_handlers.ErrorCounterHandler()
+root_logger.addHandler(counter)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('config',
+                        help="Path to the configuration file (*.config)")
+    parser.add_argument('-d', '--database', default="Mconfig",
+                        help='Path to the configuration database (Mconfig)')
+    parser.add_argument('--ignore-missing', action='store_true', default=False,
+                        help="Ignore missing database files included with 'source'")
+    parser.add_argument('-j', '--json', metavar="OUT", required=True,
+                        help="Write JSON configuration file")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    config_system.read_config(args.database, args.config, args.ignore_missing)
+
+    config_system.config_json.write_config(args.json)
+
+    issues = counter.errors() + counter.criticals()
+    warnings = counter.warnings()
+    if issues > 0:
+        return 2
+    elif warnings > 0:
+        return 1
+    else:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Avoid rewriting the `.config` file when generating the JSON when
`buildme` is run. This is achieved by creating another script which only
does JSON generation. Soong will still generate JSON when running the
config, so that functionality is left inside `update_config.py` as well.

Change-Id: I39c359c07ba5b58071d3e59dcdf5d341b2cb1508
Signed-off-by: Chris Diamand <chris.diamand@arm.com>