### PR TITLE
Pass cflags to kernel builds with `=`

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -974,7 +974,7 @@ func (g *androidMkGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.
 		"--sources $(sources) $(kbuild_extra_symbols) " +
 		"--kernel \"$(kernel_dir)\" --cross-compile \"$(kernel_cross_compile)\" " +
 		"$(cc_flag) $(hostcc_flag) $(clang_triple_flag) " +
-		"$(kbuild_options) --extra-cflags \"$(extra_cflags)\" $(make_args)"
+		"$(kbuild_options) --extra-cflags=\"$(extra_cflags)\" $(make_args)"
 
 	sb.WriteString("\techo " + cmd + "\n")
 	sb.WriteString("\t" + cmd + "\n")


### PR DESCRIPTION
Pass extra cflags using `--extra-cflags=`, rather than a space, to avoid
argparse trying to interpret the cflags as arguments.

This was fixed for Linux in `54cfbe5 Fix --extra-cflags argument usage
in kmod_build.py call`.

Change-Id: I03e6ca5cc64e1a000c03fc7176cbac765209864d
Signed-off-by: Chris Diamand <chris.diamand@arm.com>