### PR TITLE
Fix exclude_srcs with relative build dir

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -135,6 +135,9 @@ type SourceProps struct {
 func glob(ctx abstr.ModuleContext, globs []string, excludes []string) []string {
 	var files []string
 
+	// Excludes are relative to the source directory.
+	excludes = utils.PrefixDirs(excludes, srcdir)
+
 	for _, file := range globs {
 		if strings.ContainsAny(file, "*?[") {
 			// Globs need to be calculated relative to the source

--- a/tests/globs/build.bp
+++ b/tests/globs/build.bp
@@ -20,7 +20,16 @@ bob_binary {
     srcs: ["**/*.c"],
 }
 
+bob_binary {
+    name: "glob_test_exclude",
+    srcs: ["src/**/*.cpp"],
+    exclude_srcs: ["src/**/exclude_*.cpp"],
+}
+
 bob_alias {
     name: "bob_test_globs",
-    srcs: ["glob_test"],
+    srcs: [
+        "glob_test",
+        "glob_test_exclude",
+    ],
 }

--- a/tests/globs/src/exclude_this_file.cpp
+++ b/tests/globs/src/exclude_this_file.cpp
@@ -1,0 +1,3 @@
+#include <nonexistent.h>
+
+this (does+not)_ build!;

--- a/tests/globs/src/inside/a/exclude_this_too.cpp
+++ b/tests/globs/src/inside/a/exclude_this_too.cpp
@@ -1,0 +1,3 @@
+#include <nonexistent.h>
+
+this (does+not)_ build!;

--- a/tests/globs/src/inside/a/namespace/main.cpp
+++ b/tests/globs/src/inside/a/namespace/main.cpp
@@ -1,0 +1,3 @@
+int main(void) {
+    return 0;
+}


### PR DESCRIPTION
Commit `14eda8b Run Android.mk generation in ANDROID_BUILD_TOP` added
the source dir to the inputs of the glob function. However, it did not
do the same for the excludes list.

This means that excludes are sometimes missed. Fix it by prepending the
path to the source directory before evaluating the glob.

Change-Id: I8b1557d1f984b690cc519911c18adf1c47fb5b28
Signed-off-by: Chris Diamand <chris.diamand@arm.com>