### PR TITLE
Rename ModuleContext to BaseModuleContext

### DIFF
--- a/abstr/contexts.go
+++ b/abstr/contexts.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Common functions in blueprint.BaseModuleContext and android.BaseModuleContext
-type ModuleContext interface {
+type BaseModuleContext interface {
 	ModuleName() string
 	ModuleDir() string
 
@@ -48,7 +48,7 @@ type ModuleContext interface {
 
 // Common functions in blueprint.TopDownMutatorContext and android.TopDownMutatorContext
 type TopDownMutatorContext interface {
-	ModuleContext
+	BaseModuleContext
 
 	OtherModuleExists(name string) bool
 	Rename(name string)
@@ -67,7 +67,7 @@ type TopDownMutatorContext interface {
 
 // Common functions in blueprint.BottomUpMutatorContext and android.BottomUpMutatorContext
 type BottomUpMutatorContext interface {
-	ModuleContext
+	BaseModuleContext
 	Module() blueprint.Module
 
 	AddDependency(module blueprint.Module, tag blueprint.DependencyTag, name ...string)

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -132,7 +132,7 @@ type SourceProps struct {
 	Specials []string `blueprint:"mutated"`
 }
 
-func glob(ctx abstr.ModuleContext, globs []string, excludes []string) []string {
+func glob(ctx abstr.BaseModuleContext, globs []string, excludes []string) []string {
 	var files []string
 
 	// Excludes are relative to the source directory.
@@ -164,11 +164,11 @@ func glob(ctx abstr.ModuleContext, globs []string, excludes []string) []string {
 // The sources are relative to the project directory (i.e. include
 // the module directory but not the base source directory), and
 // excludes have been handled.
-func (s *SourceProps) getSources(ctx abstr.ModuleContext) []string {
+func (s *SourceProps) getSources(ctx abstr.BaseModuleContext) []string {
 	return glob(ctx, s.Srcs, s.Exclude_srcs)
 }
 
-func (s *SourceProps) processPaths(ctx abstr.ModuleContext, g generatorBackend) {
+func (s *SourceProps) processPaths(ctx abstr.BaseModuleContext, g generatorBackend) {
 	prefix := ctx.ModuleDir()
 	var special = map[string]string{
 		"${bob_config}": filepath.Join(g.buildDir(), configName),
@@ -383,7 +383,7 @@ func targetMutator(mctx abstr.TopDownMutatorContext) {
 }
 
 type pathProcessor interface {
-	processPaths(abstr.ModuleContext, generatorBackend)
+	processPaths(abstr.BaseModuleContext, generatorBackend)
 }
 
 // Adds module paths to appropriate properties.

--- a/core/gen_binary.go
+++ b/core/gen_binary.go
@@ -42,7 +42,7 @@ func (m *generateBinary) outputs(g generatorBackend) []string {
 
 //// Support Installable
 
-func (m *generateBinary) filesToInstall(ctx abstr.ModuleContext, g generatorBackend) []string {
+func (m *generateBinary) filesToInstall(ctx abstr.BaseModuleContext, g generatorBackend) []string {
 	return []string{getLibraryGeneratedPath(m, g)}
 }
 

--- a/core/gen_library.go
+++ b/core/gen_library.go
@@ -49,7 +49,7 @@ type generateLibraryInterface interface {
 	dependentInterface
 
 	libExtension() string
-	getSources(ctx abstr.ModuleContext) []string
+	getSources(ctx abstr.BaseModuleContext) []string
 }
 
 //// Local functions

--- a/core/gen_shared.go
+++ b/core/gen_shared.go
@@ -42,7 +42,7 @@ func (m *generateSharedLibrary) outputs(g generatorBackend) []string {
 
 //// Support Installable
 
-func (m *generateSharedLibrary) filesToInstall(ctx abstr.ModuleContext, g generatorBackend) []string {
+func (m *generateSharedLibrary) filesToInstall(ctx abstr.BaseModuleContext, g generatorBackend) []string {
 	return []string{getLibraryGeneratedPath(m, g)}
 }
 

--- a/core/gen_static.go
+++ b/core/gen_static.go
@@ -42,7 +42,7 @@ func (m *generateStaticLibrary) outputs(g generatorBackend) []string {
 
 //// Support Installable
 
-func (m *generateStaticLibrary) filesToInstall(ctx abstr.ModuleContext, g generatorBackend) []string {
+func (m *generateStaticLibrary) filesToInstall(ctx abstr.BaseModuleContext, g generatorBackend) []string {
 	return []string{getLibraryGeneratedPath(m, g)}
 }
 

--- a/core/generated.go
+++ b/core/generated.go
@@ -389,11 +389,11 @@ func (m *generateCommon) getArgs(ctx blueprint.ModuleContext) (string, map[strin
 	return cmd, args, dependents, hostTarget
 }
 
-func (m *generateCommon) getSources(ctx abstr.ModuleContext) []string {
+func (m *generateCommon) getSources(ctx abstr.BaseModuleContext) []string {
 	return m.Properties.getSources(ctx)
 }
 
-func (m *generateCommon) processPaths(ctx abstr.ModuleContext, g generatorBackend) {
+func (m *generateCommon) processPaths(ctx abstr.BaseModuleContext, g generatorBackend) {
 	m.Properties.SourceProps.processPaths(ctx, g)
 	m.Properties.InstallableProps.processPaths(ctx, g)
 	m.Properties.Export_gen_include_dirs = utils.PrefixDirs(m.Properties.Export_gen_include_dirs, g.sourceOutputDir(m))
@@ -417,7 +417,7 @@ func (m *generateSource) Inouts(ctx blueprint.ModuleContext, g generatorBackend)
 	return []inout{io}
 }
 
-func (m *generateSource) filesToInstall(ctx abstr.ModuleContext, g generatorBackend) []string {
+func (m *generateSource) filesToInstall(ctx abstr.BaseModuleContext, g generatorBackend) []string {
 	// Install everything that we generate
 	return m.outputs(g)
 }
@@ -542,7 +542,7 @@ func (m *transformSource) Inouts(ctx blueprint.ModuleContext, g generatorBackend
 	return inouts
 }
 
-func (m *transformSource) filesToInstall(ctx abstr.ModuleContext, g generatorBackend) []string {
+func (m *transformSource) filesToInstall(ctx abstr.BaseModuleContext, g generatorBackend) []string {
 	// Install everything that we generate
 	return m.outputs(g)
 }

--- a/core/install.go
+++ b/core/install.go
@@ -96,7 +96,7 @@ type InstallableProps struct {
 	Install_path *string `blueprint:"mutated"`
 }
 
-func (props *InstallableProps) processPaths(ctx abstr.ModuleContext, g generatorBackend) {
+func (props *InstallableProps) processPaths(ctx abstr.BaseModuleContext, g generatorBackend) {
 	if props.Post_install_tool != nil {
 		*props.Post_install_tool = filepath.Join(g.sourcePrefix(), ctx.ModuleDir(), *props.Post_install_tool)
 	}
@@ -166,7 +166,7 @@ type symlinkInstaller interface {
 
 // Modules implementing the installable interface can be install their output
 type installable interface {
-	filesToInstall(ctx abstr.ModuleContext, g generatorBackend) []string
+	filesToInstall(ctx abstr.BaseModuleContext, g generatorBackend) []string
 	getInstallableProps() *InstallableProps
 	getInstallDepPhonyNames(ctx blueprint.ModuleContext) []string
 }
@@ -233,7 +233,7 @@ func (m *resource) implicitOutputs(g generatorBackend) []string {
 	return []string{}
 }
 
-func (m *resource) filesToInstall(ctx abstr.ModuleContext, g generatorBackend) []string {
+func (m *resource) filesToInstall(ctx abstr.BaseModuleContext, g generatorBackend) []string {
 	return m.Properties.SourceProps.getSources(ctx)
 }
 
@@ -241,7 +241,7 @@ func (m *resource) getInstallableProps() *InstallableProps {
 	return &m.Properties.InstallableProps
 }
 
-func (m *resource) processPaths(ctx abstr.ModuleContext, g generatorBackend) {
+func (m *resource) processPaths(ctx abstr.BaseModuleContext, g generatorBackend) {
 	m.Properties.SourceProps.processPaths(ctx, g)
 	m.Properties.InstallableProps.processPaths(ctx, g)
 }

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -87,7 +87,7 @@ func (m *kernelModule) implicitOutputs(g generatorBackend) []string {
 	return []string{}
 }
 
-func (m *kernelModule) filesToInstall(ctx abstr.ModuleContext, g generatorBackend) []string {
+func (m *kernelModule) filesToInstall(ctx abstr.BaseModuleContext, g generatorBackend) []string {
 	return m.outputs(g)
 }
 
@@ -99,7 +99,7 @@ func (m *kernelModule) getInstallDepPhonyNames(ctx blueprint.ModuleContext) []st
 	return getShortNamesForDirectDepsWithTags(ctx, installDepTag, kernelModuleDepTag)
 }
 
-func (m *kernelModule) processPaths(ctx abstr.ModuleContext, g generatorBackend) {
+func (m *kernelModule) processPaths(ctx abstr.BaseModuleContext, g generatorBackend) {
 	m.Properties.Build.processPaths(ctx, g)
 }
 

--- a/core/library.go
+++ b/core/library.go
@@ -258,7 +258,7 @@ func (l *Build) getBuildWrapperAndDeps(ctx blueprint.ModuleContext) (string, []s
 
 // Add module paths to srcs, exclude_srcs, local_include_dirs, export_local_include_dirs
 // and post_install_tool
-func (l *Build) processPaths(ctx abstr.ModuleContext, g generatorBackend) {
+func (l *Build) processPaths(ctx abstr.BaseModuleContext, g generatorBackend) {
 	prefix := ctx.ModuleDir()
 	l.SourceProps.processPaths(ctx, g)
 	l.InstallableProps.processPaths(ctx, g)
@@ -440,7 +440,7 @@ func (l *library) GetExportedVariables(ctx blueprint.ModuleContext) (expLocalInc
 	return
 }
 
-func (l *library) processPaths(ctx abstr.ModuleContext, g generatorBackend) {
+func (l *library) processPaths(ctx abstr.BaseModuleContext, g generatorBackend) {
 	l.Properties.Build.processPaths(ctx, g)
 }
 
@@ -462,7 +462,7 @@ func (m *staticLibrary) outputs(g generatorBackend) []string {
 	return []string{filepath.Join(m.outputDir(g), m.outputName()+".a")}
 }
 
-func (m *staticLibrary) filesToInstall(ctx abstr.ModuleContext, g generatorBackend) []string {
+func (m *staticLibrary) filesToInstall(ctx abstr.BaseModuleContext, g generatorBackend) []string {
 	return m.outputs(g)
 }
 
@@ -514,7 +514,7 @@ func (m *sharedLibrary) outputs(g generatorBackend) []string {
 	return []string{filepath.Join(m.outputDir(g), m.getRealName())}
 }
 
-func (m *sharedLibrary) filesToInstall(ctx abstr.ModuleContext, g generatorBackend) []string {
+func (m *sharedLibrary) filesToInstall(ctx abstr.BaseModuleContext, g generatorBackend) []string {
 	return m.outputs(g)
 }
 
@@ -556,7 +556,7 @@ func (m *binary) outputs(g generatorBackend) []string {
 	return []string{filepath.Join(m.outputDir(g), m.outputName())}
 }
 
-func (m *binary) filesToInstall(ctx abstr.ModuleContext, g generatorBackend) []string {
+func (m *binary) filesToInstall(ctx abstr.BaseModuleContext, g generatorBackend) []string {
 	return m.outputs(g)
 }
 

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -41,7 +41,7 @@ type moduleBase struct {
 	blueprint.SimpleName
 }
 
-func getConfig(ctx abstr.ModuleContext) *bobConfig {
+func getConfig(ctx abstr.BaseModuleContext) *bobConfig {
 	return ctx.(blueprint.BaseModuleContext).Config().(*bobConfig)
 }
 


### PR DESCRIPTION
This more closely reflects the structure Blueprint and Soong use, and
will allow a future commit to abstract away _actual_ ModuleContexts.

Change-Id: I515e8124d754ae620f67046a26589524c5c7128f
Signed-off-by: Chris Diamand <chris.diamand@arm.com>