### PR TITLE
Remove special exit code handling

### DIFF
--- a/bob.bash
+++ b/bob.bash
@@ -38,17 +38,9 @@ fi
 # Refresh the configuration. This means that options changed or added since the
 # last build will be chosen from their defaults automatically, so that users
 # don't have to reconfigure manually if the config database changes.
-generate_json_status=0
 python "${BOB_DIR}/config_system/generate_config_json.py" \
        "${BUILDDIR}/${CONFIGNAME}" --database "${SRCDIR}/Mconfig" \
-       --json "${BUILDDIR}/config.json" ${BOB_CONFIG_OPTS} || generate_json_status=$?
-
-# If the config generated errors, stop the build. An exit status of 1 indicates
-# only warnings, so allow it to continue in this case.
-if [[ "${generate_json_status}" -ge 2 ]]; then
-    echo "Generation of config.json failed" >&2
-    exit 1
-fi
+       --json "${BUILDDIR}/config.json" ${BOB_CONFIG_OPTS}
 
 # Get a hash of the environment so we can detect if we need to
 # regenerate the build.ninja

--- a/config.bash
+++ b/config.bash
@@ -45,15 +45,8 @@ done
 
 # Move to the working directory
 cd "${WORKDIR}"
-exit_status=0
 
 "${BOB_DIR}/config_system/update_config.py" --new -d "${SRCDIR}/Mconfig" \
     ${BOB_CONFIG_OPTS} ${BOB_CONFIG_PLUGIN_OPTS} \
     -j "${BUILDDIR}/config.json" \
-    -c "${BUILDDIR}/${CONFIGNAME}" "${ARG_TARGET[@]}" || exit_status=$?
-
-if [ "$exit_status" -eq "1" ]; then # warnings occurred
-    exit 0
-else
-    exit $exit_status
-fi
+    -c "${BUILDDIR}/${CONFIGNAME}" "${ARG_TARGET[@]}"

--- a/config_system/generate_config_json.py
+++ b/config_system/generate_config_json.py
@@ -51,14 +51,7 @@ def main():
 
     config_system.config_json.write_config(args.json)
 
-    issues = counter.errors() + counter.criticals()
-    warnings = counter.warnings()
-    if issues > 0:
-        return 2
-    elif warnings > 0:
-        return 1
-    else:
-        return 0
+    return counter.errors() + counter.criticals()
 
 
 if __name__ == "__main__":

--- a/config_system/menuconfig.py
+++ b/config_system/menuconfig.py
@@ -684,14 +684,7 @@ def main():
     # Flush all log messages on exit
     msgBuffer.close()
 
-    issues = counter.errors() + counter.criticals()
-    warnings = counter.warnings()
-    if issues > 0:
-        return 2
-    elif warnings > 0:
-        return 1
-    else:
-        return 0
+    return counter.errors() + counter.criticals()
 
 
 if __name__ == "__main__":

--- a/config_system/tests/test_update_config.py
+++ b/config_system/tests/test_update_config.py
@@ -136,6 +136,6 @@ def test_ignored_config_option(caplog, mocker, tmpdir, mconfig, args, error):
         if record.levelno == logging.ERROR:
             errors.append(record.message)
 
-    assert returncode == 2
+    assert returncode != 0
     assert len(errors) == 1
     assert errors[0] == error

--- a/config_system/update_config.py
+++ b/config_system/update_config.py
@@ -182,14 +182,7 @@ def main():
     if args.json is not None:
         config_json.write_config(args.json)
 
-    issues = counter.errors() + counter.criticals()
-    warnings = counter.warnings()
-    if issues > 0:
-        return 2
-    elif warnings > 0:
-        return 1
-    else:
-        return 0
+    return counter.errors() + counter.criticals()
 
 
 if __name__ == "__main__":

--- a/menuconfig.bash
+++ b/menuconfig.bash
@@ -25,15 +25,8 @@ source "${BOOTSTRAP}"
 
 # Move to the working directory
 cd "${WORKDIR}"
-exit_status=0
 
 "${BOB_DIR}/config_system/menuconfig.py" -d "${SRCDIR}/Mconfig" \
     ${BOB_CONFIG_OPTS} ${BOB_CONFIG_PLUGIN_OPTS} \
     -j "${BUILDDIR}/config.json" \
-    "${BUILDDIR}/${CONFIGNAME}" || exit_status=$?
-
-if [ "$exit_status" -eq "1" ]; then # warnings occurred
-    exit 0
-else
-    exit $exit_status
-fi
+    "${BUILDDIR}/${CONFIGNAME}"


### PR DESCRIPTION
The config system scripts use an error code of 1 to indicate warnings,
and 2 for errors. When they are invoked, the callers then explicitly
ignore exit codes of 1.

However, this means that:
 - We may as well just return 0 for warnings, since they are being
   ignored anyway
 - Python exceptions also generate an exit status of 1, so if the script
   hits an exception it will currently be ignored...

Fix this by removing the special handling.

Change-Id: Ida2abea3fdfc473579dc25a3a68775f73a3e4719
Signed-off-by: Chris Diamand <chris.diamand@arm.com>