### PR TITLE
Add option to strip libraries and binaries

### DIFF
--- a/Android.bp.in
+++ b/Android.bp.in
@@ -52,6 +52,7 @@ bootstrap_go_package {
         "core/soong_library.go",
         "core/soong_plugin.go",
         "core/splitter.go",
+        "core/strip.go",
         "core/template.go",
         "core/toolchain.go",
         "core/linux.go",

--- a/Blueprints
+++ b/Blueprints
@@ -55,6 +55,7 @@ bootstrap_go_package {
         "core/properties.go",
         "core/splitter.go",
         "core/standalone.go",
+        "core/strip.go",
         "core/template.go",
         "core/toolchain.go",
         "core/linux.go",

--- a/core/android_make.go
+++ b/core/android_make.go
@@ -271,6 +271,9 @@ func (m *library) GenerateBuildAction(sb *strings.Builder, bt binType, ctx bluep
 		sb.WriteString("LOCAL_MODULE_OWNER := " + m.Properties.Owner + "\n")
 		sb.WriteString("LOCAL_PROPRIETARY_MODULE := true\n")
 	}
+	if m.strip() {
+		sb.WriteString("LOCAL_STRIP_MODULE := true\n")
+	}
 
 	// Can't see a way to wrap a particular library in -Wl in link flags on android, so specify
 	// -Wl,--copy-dt-needed-entries across the lot

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -342,6 +342,12 @@ func dependerMutator(mctx abstr.BottomUpMutatorContext) {
 		}
 		parseAndAddVariationDeps(mctx, installDepTag, props.Install_deps...)
 	}
+	if strlib, ok := mctx.Module().(stripable); ok {
+		info := strlib.getDebugInfo()
+		if info != nil {
+			mctx.AddDependency(mctx.Module(), debugInfoTag, *info)
+		}
+	}
 }
 
 // Applies target specific properties within each module. Must be done

--- a/core/library.go
+++ b/core/library.go
@@ -156,6 +156,7 @@ type BuildProps struct {
 	InstallableProps
 	EnableableProps
 	SplittableProps
+	StripProps
 
 	// Linux kernel config options to emulate. These are passed to Kbuild in
 	// the 'make' command-line, and set in the source code via EXTRA_CFLAGS
@@ -355,6 +356,16 @@ func (l *library) outputName() string {
 	return l.Name()
 }
 
+func (l *library) strip() bool {
+	// Only shared libraries and binaries can be stripped.
+	// Implement this on libraries to simplify use in android_make
+	return false
+}
+
+func (m *library) stripOutputDir(g generatorBackend) string {
+	return filepath.Join(g.buildDir(), string(m.Properties.TargetType), "strip")
+}
+
 func (l *library) implicitOutputs(g generatorBackend) []string {
 	return []string{}
 }
@@ -514,6 +525,10 @@ func (m *sharedLibrary) outputs(g generatorBackend) []string {
 	return []string{filepath.Join(m.outputDir(g), m.getRealName())}
 }
 
+func (l *sharedLibrary) strip() bool {
+	return l.Properties.Strip != nil && *l.Properties.Strip
+}
+
 func (m *sharedLibrary) filesToInstall(ctx abstr.BaseModuleContext, g generatorBackend) []string {
 	return m.outputs(g)
 }
@@ -554,6 +569,10 @@ func (m *binary) outputDir(g generatorBackend) string {
 
 func (m *binary) outputs(g generatorBackend) []string {
 	return []string{filepath.Join(m.outputDir(g), m.outputName())}
+}
+
+func (l *binary) strip() bool {
+	return l.Properties.Strip != nil && *l.Properties.Strip
 }
 
 func (m *binary) filesToInstall(ctx abstr.BaseModuleContext, g generatorBackend) []string {

--- a/core/soong_library.go
+++ b/core/soong_library.go
@@ -204,12 +204,18 @@ func (l *sharedLibrary) soongBuildActions(mctx android.TopDownMutatorContext) {
 		// Soong's `export_include_dirs` field is relative to the module dir.
 		Export_include_dirs: l.Properties.Export_local_include_dirs,
 	}
+	stripProps := &cc.StripProperties{}
+	if l.strip() {
+		stripProps.Strip.All = proptools.BoolPtr(true)
+	}
 
 	switch l.Properties.TargetType {
 	case tgtTypeHost:
-		mctx.CreateModule(android.ModuleFactoryAdaptor(cc.LibraryHostSharedFactory), commonProps, libProps)
+		mctx.CreateModule(android.ModuleFactoryAdaptor(cc.LibraryHostSharedFactory),
+			commonProps, libProps, stripProps)
 	case tgtTypeTarget:
-		mctx.CreateModule(android.ModuleFactoryAdaptor(libraryTargetSharedFactory), commonProps, libProps)
+		mctx.CreateModule(android.ModuleFactoryAdaptor(libraryTargetSharedFactory),
+			commonProps, libProps, stripProps)
 	}
 }
 
@@ -231,12 +237,18 @@ func (b *binary) soongBuildActions(mctx android.TopDownMutatorContext) {
 	}
 
 	commonProps := b.setupCcLibraryProps(mctx)
+	stripProps := &cc.StripProperties{}
+	if l.strip() {
+		stripProps.Strip.All = proptools.BoolPtr(true)
+	}
 
 	switch b.Properties.TargetType {
 	case tgtTypeHost:
-		mctx.CreateModule(android.ModuleFactoryAdaptor(binaryHostFactory), commonProps)
+		mctx.CreateModule(android.ModuleFactoryAdaptor(binaryHostFactory),
+			commonProps, stripProps)
 	case tgtTypeTarget:
-		mctx.CreateModule(android.ModuleFactoryAdaptor(binaryTargetFactory), commonProps)
+		mctx.CreateModule(android.ModuleFactoryAdaptor(binaryTargetFactory),
+			commonProps, stripProps)
 	}
 
 }

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -128,6 +128,7 @@ func Main() {
 			abstr.BottomUpAdaptor(applyReexportLibsDependenciesMutator)).Parallel()
 		ctx.RegisterTopDownMutator("encapsulates_mutator", encapsulatesMutator).Parallel()
 		ctx.RegisterTopDownMutator("install_group_mutator", installGroupMutator).Parallel()
+		ctx.RegisterTopDownMutator("debug_info_mutator", debugInfoMutator).Parallel()
 		ctx.RegisterTopDownMutator("match_sources_mutator", matchSourcesMutator).Parallel()
 
 		// Depend on the config file

--- a/core/strip.go
+++ b/core/strip.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"github.com/google/blueprint"
+)
+
+var (
+	debugInfoTag = dependencyTag{name: "debug_info"}
+)
+
+type StripProps struct {
+	// When set, strip symbols and debug information from libraries
+	// and binaries. This is a separate stage that occurs after
+	// linking and before post install.
+	//
+	// On Android, its infrastructure is used to do the stripping. If
+	// not enabled, follow Android's default behaviour.
+	Strip *bool
+
+	// Module specifying a directory for debug information
+	Debug_info *string
+
+	// The path retrieved from debug install group so we don't need to
+	// walk dependencies to get it
+	Debug_path *string `blueprint:"mutated"`
+}
+
+func (props *StripProps) getDebugInfo() *string {
+	return props.Debug_info
+}
+
+func (props *StripProps) getDebugPath() *string {
+	return props.Debug_path
+}
+
+func (props *StripProps) setDebugPath(path *string) {
+	props.Debug_path = path
+}
+
+type stripable interface {
+	strip() bool
+	getTarget() tgtType
+	stripOutputDir(g generatorBackend) string
+
+	getDebugInfo() *string
+	getDebugPath() *string
+	setDebugPath(*string)
+}
+
+func debugInfoMutator(mctx blueprint.TopDownMutatorContext) {
+	if m, ok := mctx.Module().(stripable); ok {
+		path := getInstallPath(mctx, debugInfoTag)
+		m.setDebugPath(path)
+	}
+}

--- a/docs/module_types/bob_binary.md
+++ b/docs/module_types/bob_binary.md
@@ -48,6 +48,7 @@ bob_binary {
 
     tags: ["optional"],
     owner: "company_name",
+    strip: true,
 
     include_dirs: ["include/"],
     local_include_dirs: ["include/"],
@@ -59,6 +60,7 @@ bob_binary {
     install_group: "bob_install_group.name",
     install_deps: ["module_name"],
     relative_install_path: "unit/objects",
+    debug_info: "bob_install_group.name",
     post_install_tool: "post_install.py",
     post_install_cmd: "${tool} ${args} ${out}",
     post_install_args: ["arg1", "arg2"],

--- a/docs/module_types/bob_defaults.md
+++ b/docs/module_types/bob_defaults.md
@@ -64,6 +64,7 @@ bob_defaults {
 
     tags: ["optional"],
     owner: "my_company",
+    strip: true,
 
     include_dirs: ["include/"],
     local_include_dirs: ["include/"],
@@ -87,6 +88,7 @@ bob_defaults {
     install_group: "bob_install_group.name",
     install_deps: ["bob_resource.name"],
     relative_install_path: "unit/objects",
+    debug_info: "bob_install_group.name",
     post_install_tool: "post_install.py",
     post_install_cmd: "${tool} ${args} ${out}",
     post_install_args: ["arg1", "arg2"],

--- a/docs/module_types/bob_shared_library.md
+++ b/docs/module_types/bob_shared_library.md
@@ -54,6 +54,7 @@ bob_shared_library {
 
     tags: ["optional"],
     owner: "{{.android_module_owner}}",
+    strip: true,
 
     include_dirs: ["include/"],
     local_include_dirs: ["include/"],
@@ -68,6 +69,7 @@ bob_shared_library {
     install_group: "bob_install_group.name",
     install_deps: ["bob_resource.name"],
     relative_install_path: "unit/objects",
+    debug_info: "bob_install_group.name",
     post_install_tool: "post_install.py",
     post_install_cmd: "${tool} ${args} ${out}",
     post_install_args: ["arg1", "arg2"],

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -186,6 +186,16 @@ which builds this module is built for.
 Value to use on Android for `LOCAL_MODULE_OWNER`
 
 ----
+### **bob_module.strip** (optional)
+
+When set, strip symbols and debug information from libraries and
+binaries. This is a separate stage that occurs after linking and
+before post install.
+
+On Android, its infrastructure is used to do the stripping. If not
+enabled, follow Android's default behaviour.
+
+----
 ### **bob_module.include_dirs** (optional)
 A list of include directories to use. These are expected to be system
 headers, and will usually be an absolute path. On Android these can be
@@ -253,7 +263,7 @@ location like `/usr/`."
 
 ----
 ### **bob_module.install_group** (optional)
-Module specifying an installation directory.
+Module name of a `bob_install_group` specifying an installation directory.
 
 ----
 ### **bob_module.install_deps** (optional)
@@ -264,6 +274,13 @@ mentioned here, as well as any generated module.
 ----
 ### **bob_module.relative_install_path** (optional)
 Path to install to, relative to the install_group's path.
+
+----
+### **bob_module.debug_info** (optional)
+
+Module name of a `bob_install_group` specifying an installation
+directory for debug information. If supplied, debug information will
+be placed in a separate file (Linux only).
 
 ----
 ### **bob_module.post_install_tool** (optional)

--- a/mconfig/host_toolchain.Mconfig
+++ b/mconfig/host_toolchain.Mconfig
@@ -72,3 +72,12 @@ config HOST_CLANG_USE_GNU_BINUTILS
 	help
 	  Add the configured GNU toolchain's `bin/` directory to Clang's binary
 	  search path, allowing it to use the linker and assembler.
+
+config HOST_OBJCOPY_BINARY
+	string "Host objcopy"
+	default HOST_GNU_PREFIX + "objcopy" if HOST_TOOLCHAIN_GNU || (HOST_TOOLCHAIN_CLANG && HOST_CLANG_USE_GNU_BINUTILS)
+	default "llvm-objcopy" if HOST_TOOLCHAIN_CLANG
+	default "objcopy"
+	help
+	  The objcopy executable that we can use in post install scripts
+	  to manipulate host libraries and executables.

--- a/mconfig/target_toolchain.Mconfig
+++ b/mconfig/target_toolchain.Mconfig
@@ -84,3 +84,12 @@ config TARGET_CLANG_USE_GNU_BINUTILS
 	help
 	  Add the configured GNU toolchain's `bin/` directory to Clang's binary
 	  search path, allowing it to use the linker and assembler.
+
+config TARGET_OBJCOPY_BINARY
+	string "Target objcopy"
+	default TARGET_GNU_PREFIX + "objcopy" if TARGET_TOOLCHAIN_GNU || (TARGET_TOOLCHAIN_CLANG && TARGET_CLANG_USE_GNU_BINUTILS)
+	default "llvm-objcopy" if TARGET_TOOLCHAIN_CLANG
+	default "objcopy"
+	help
+	  The objcopy executable that we can use in post install scripts
+	  to manipulate target libraries and executables.

--- a/scripts/move_debug_files.py
+++ b/scripts/move_debug_files.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Move debug files into the build ID structure that GDB can use.
+
+This script assumes that note.gnu.build-id is available in the debug
+file. You may need to set -Wl,--build-id on the link command line. For
+more information see
+https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
+"""
+
+from __future__ import print_function
+
+import argparse
+import errno
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+
+# Regular expression to pick up Build ID from readelf output
+RE_ID = re.compile(r"Build ID:\s+([a-f0-9]+)")
+
+
+def get_build_id(f):
+    cmd = ["readelf", "-n", f]
+    try:
+        with open(os.devnull, 'w') as devnull:
+            output = subprocess.check_output(cmd, stderr=devnull)
+            output = output.decode(sys.getdefaultencoding())
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write("Error: Command %s failed with exit code %d" %
+                         (str(cmd), e.returncode))
+        sys.exit(e.returncode)
+
+    # Look for Build ID
+    for line in output.splitlines():
+        m = RE_ID.search(line)
+        if m:
+            return m.group(1)
+
+    return None
+
+
+def make_dir(d):
+    try:
+        os.makedirs(d)
+    except OSError as e:
+        # Ignore errors if the dir already exists. Any other error number is
+        # unexpected, so re-raise.
+        if e.errno != errno.EEXIST:
+            raise
+
+
+def process_file(args, f):
+    build_id = get_build_id(f)
+    if build_id is not None:
+        new_filedir = os.path.join(args.output, build_id[0:2])
+        new_filename = os.path.join(new_filedir, build_id[2:]+".debug")
+        if args.dry_run or args.verbose:
+            print("Moving {} => {}".format(f, new_filename))
+        if not(args.dry_run):
+            make_dir(new_filedir)
+            shutil.move(f, new_filename)
+
+    elif args.dry_run or args.verbose:
+        print("Not moving {}".format(f))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(epilog=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument("input", nargs="+",
+                        help="Path to input debug files. Directories will be assumed to "
+                        "only contain debug files. Files will be handled individually.")
+    parser.add_argument("-o", "--output", default="/usr/lib/debug/.build-id",
+                        help="Target debug file directory")
+    parser.add_argument("-n", "--dry-run", action="store_true",
+                        help="Dry run")
+    parser.add_argument("--verbose", action="store_true",
+                        help="List all moves on console")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    for i in args.input:
+        if os.path.isdir(i):
+            for (dirpath, dirnames, filenames) in os.walk(args.input):
+                for f in filenames:
+                    f = os.path.join(dirpath, f)
+                    process_file(args, f)
+        elif os.path.isfile(i):
+            process_file(args, i)
+        else:
+            sys.stderr.write("Error: {}: No such file or directory\n".format(i))
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/strip.py
+++ b/scripts/strip.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import errno
+import os
+import subprocess
+import sys
+
+
+def make_dir(d):
+    try:
+        os.makedirs(d)
+    except OSError as e:
+        # Ignore errors if the dir already exists. Any other error number is
+        # unexpected, so re-raise.
+        if e.errno != errno.EEXIST:
+            raise
+
+
+def run(cmd):
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write("Error: Command %s failed with exit code %d" %
+                         (str(cmd), e.returncode))
+        sys.exit(e.returncode)
+
+
+def create_debug_info(fname, dbg, objcopy):
+    # Retain the build-id in the debug object
+    cmd = [objcopy, "--only-keep-debug", fname, dbg]
+    run(cmd)
+
+
+def write_output(fname, output, dbg, strip, objcopy):
+    cmd = [objcopy]
+    if dbg:
+        cmd.extend(["--strip-debug",
+                    "--add-gnu-debuglink=" + dbg])
+    if strip:
+        cmd.append("--strip-unneeded")
+    cmd.extend([fname, output])
+
+    run(cmd)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("input", help="Library/executable to strip")
+    parser.add_argument("-o", "--output", required=True, help="Stripped file")
+    parser.add_argument("--strip", action="store_true", default=False,
+                        help="Strip library of unnecessary symbols")
+    parser.add_argument("--debug-file", default=None,
+                        help="File to keep debug info in")
+    parser.add_argument("--objcopy", default="objcopy",
+                        help="Objcopy executable")
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main():
+    args = parse_args()
+
+    if args.debug_file:
+        make_dir(os.path.dirname(args.debug_file))
+        create_debug_info(args.input, args.debug_file, args.objcopy)
+
+    write_output(args.input, args.output, args.debug_file, args.strip, args.objcopy)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In Android make, this sets LOCAL_STRIP_MODULE:=true. For soong, set
Strip.All.

On Linux, use a local script to strip between linking and post
install.

Add objcopy into the toolchain logic. Note that we use simpler logic
to calculate its name. The other binaries should follow suit shortly.

Since the stripping is now done by Bob, we need to separate out the
debug information before we strip. Support 3 modes of operation:

* keep the debug information in the library

* output the debug info alongside the library (as currently)

* output the debug info to a specific directory. A separate script
  (move_debug_files.py) can move the output to the build ID layout
  that GDB can use, which doesn't depend on the file heirarchy.

Change-Id: I177026b6a33200a92e4018033c662cad8b5f2e74
Signed-off-by: David Kilroy <david.kilroy@arm.com>