### PR TITLE
Disable match_source test on android

### DIFF
--- a/tests/match_source/build.bp
+++ b/tests/match_source/build.bp
@@ -28,6 +28,9 @@ bob_generate_source {
     ],
     out: ["gen_main.c"],
     cmd: "cat {{match_srcs \"function_def.txt\"}} {{match_srcs \"main.c\"}} > $out",
+    android: {
+        enabled: false,
+    },
 }
 
 // Test that we can refer to specific files in the srcs list of a
@@ -44,6 +47,9 @@ bob_binary {
     ],
     generated_sources: ["match_source_gen"],
     ldflags: ["-Wl,--dynamic-list,{{match_srcs \"*.txt\"}}"],
+    android: {
+        enabled: false,
+    },
 }
 
 bob_alias {


### PR DESCRIPTION
The `match_srcs` template function is broken - it will output
$(LOCAL_SRCS) in the command part of the Make rule, which will result in
the last value being used, rather than the value associated with the
current `Android.mk` file.

Temporarily disable the test, until this is fixed.

Change-Id: I829c474134705a60f8808a4e0abb050b04247387
Signed-off-by: Chris Diamand <chris.diamand@arm.com>