### PR TITLE
Fix un-globbed exclude_srcs

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -135,8 +135,9 @@ type SourceProps struct {
 func glob(ctx abstr.BaseModuleContext, globs []string, excludes []string) []string {
 	var files []string
 
-	// Excludes are relative to the source directory.
-	excludes = utils.PrefixDirs(excludes, srcdir)
+	// If any globs are used, we need to use an exclude list which is
+	// relative to the source directory.
+	excludesFromSrcDir := utils.PrefixDirs(excludes, srcdir)
 
 	for _, file := range globs {
 		if strings.ContainsAny(file, "*?[") {
@@ -144,7 +145,7 @@ func glob(ctx abstr.BaseModuleContext, globs []string, excludes []string) []stri
 			// directory (not the working directory), so add it
 			// here, and remove it afterwards.
 			file = filepath.Join(srcdir, file)
-			matches, _ := ctx.GlobWithDeps(file, excludes)
+			matches, _ := ctx.GlobWithDeps(file, excludesFromSrcDir)
 			for _, match := range matches {
 				rel, err := filepath.Rel(srcdir, match)
 				if err != nil {

--- a/tests/globs/build.bp
+++ b/tests/globs/build.bp
@@ -26,6 +26,17 @@ bob_binary {
     exclude_srcs: ["src/**/exclude_*.cpp"],
 }
 
+bob_binary {
+    name: "test_exclude_srcs",
+    srcs: [
+        "src/inside/a/namespace/main.cpp",
+        "src/inside/a/exclude_this_too.cpp",
+    ],
+    exclude_srcs: [
+        "src/inside/a/exclude_this_too.cpp",
+    ],
+}
+
 bob_alias {
     name: "bob_test_globs",
     srcs: [


### PR DESCRIPTION
Prefixing `exclude_srcs` with `srcdir` broke the non-globbed case,
because that is calculated without referencing the filesystem, and so
doesn't need to be relative to a particular directory.

Update the logic so that the prefixed excludes are only used for globs.

Change-Id: I8986a1b82064ae68cadf51827ebacec89fffe539
Signed-off-by: Chris Diamand <chris.diamand@arm.com>