### PR TITLE
Add test for library stripping

### DIFF
--- a/core/library.go
+++ b/core/library.go
@@ -356,10 +356,16 @@ func (l *library) outputName() string {
 	return l.Name()
 }
 
-func (l *library) strip() bool {
-	// Only shared libraries and binaries can be stripped.
-	// Implement this on libraries to simplify use in android_make
-	return false
+func (l *library) getDebugInfo() *string {
+	return l.Properties.getDebugInfo()
+}
+
+func (l *library) getDebugPath() *string {
+	return l.Properties.getDebugPath()
+}
+
+func (l *library) setDebugPath(path *string) {
+	l.Properties.setDebugPath(path)
 }
 
 func (m *library) stripOutputDir(g generatorBackend) string {

--- a/core/soong_library.go
+++ b/core/soong_library.go
@@ -238,7 +238,7 @@ func (b *binary) soongBuildActions(mctx android.TopDownMutatorContext) {
 
 	commonProps := b.setupCcLibraryProps(mctx)
 	stripProps := &cc.StripProperties{}
-	if l.strip() {
+	if b.strip() {
 		stripProps.Strip.All = proptools.BoolPtr(true)
 	}
 

--- a/tests/shared_libs/build.bp
+++ b/tests/shared_libs/build.bp
@@ -47,12 +47,40 @@ bob_binary {
     generated_sources: ["use_sharedtest_host"],
 }
 
+bob_shared_library {
+    name: "libstripped_library",
+    srcs: ["lib.c"],
+    cflags: ["-DFUNC_NAME=func"],
+    strip: true,
+    host: {
+        install_group: "IG_host_libs",
+    },
+    target: {
+        install_group: "IG_libs",
+    },
+}
+
+bob_binary {
+    name: "stripped_binary",
+    srcs: ["lib.c"],
+    cflags: ["-DFUNC_NAME=main"],
+    shared_libs: ["libstripped_library"],
+    strip: true,
+    host: {
+        install_group: "IG_host_binaries",
+    },
+    target: {
+        install_group: "IG_binaries",
+    },
+}
+
 bob_alias {
     name: "bob_test_shared_libs",
     srcs: [
         "sharedtest:host",
         "sharedtest:target",
         "use_sharedtest_host_gen_source",
+        "stripped_binary",
     ],
 }
 
@@ -62,16 +90,36 @@ bob_install_group {
         install_path: "$(HOST_OUT_SHARED_LIBRARIES)",
     },
     linux: {
-        install_path: "install/hostlib",
+        install_path: "install/host/lib",
     },
 }
 
 bob_install_group {
     name: "IG_libs",
     android: {
-        install_path: "$(TARGET_OUT_VENDOR)/lib",
+        install_path: "$(TARGET_OUT_VENDOR_SHARED_LIBRARIES)",
     },
     linux: {
         install_path: "install/lib",
+    },
+}
+
+bob_install_group {
+    name: "IG_host_binaries",
+    android: {
+        install_path: "$(HOST_OUT_EXECUTABLES)",
+    },
+    linux: {
+        install_path: "install/host/bin",
+    },
+}
+
+bob_install_group {
+    name: "IG_binaries",
+    android: {
+        install_path: "$(TARGET_OUT_VENDOR_EXECUTABLES)",
+    },
+    linux: {
+        install_path: "install/bin",
     },
 }


### PR DESCRIPTION
... and fix the implementation after a last minute refactoring broke
an interface.

The android make implementation also needs fixing. Since
GenerateBuildAction act on the type library, it is always getting the
library implementation of strip() that returns false. Refactor so that
the function takes an interface. Keep the changes in here minimal for
now.

Change-Id: Ice5747bcd4a7919466ee1e47a08d9bc54baadd53
Signed-off-by: David Kilroy <david.kilroy@arm.com>