### PR TITLE
Get BuildDir from command line

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -76,7 +76,7 @@ func writeIfChanged(filename string, sb *strings.Builder) {
 }
 
 func androidMkWriteString(ctx blueprint.ModuleContext, name string, sb *strings.Builder) {
-	filename := filepath.Join(builddir, name+".inc")
+	filename := filepath.Join(getBuildDir(), name+".inc")
 	writeIfChanged(filename, sb)
 }
 
@@ -891,7 +891,7 @@ func (s *androidMkOrderer) GenerateBuildActions(ctx blueprint.SingletonContext) 
 		}
 		order = append(order[:lowindex], order[lowindex+1:]...)
 	}
-	writeIfChanged(filepath.Join(builddir, "Android.inc"), sb)
+	writeIfChanged(filepath.Join(getBuildDir(), "Android.inc"), sb)
 }
 
 func (g *androidMkGenerator) moduleOutputDir(moduleName string) string {

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -32,11 +32,8 @@ import (
 
 var (
 	srcdir     = os.Getenv("SRCDIR")
-	builddir   = os.Getenv("BUILDDIR")
 	configName = os.Getenv("CONFIGNAME")
 	configOpts = os.Getenv("BOB_CONFIG_OPTS")
-	configPath = filepath.Join(builddir, configName)
-	envHash    = filepath.Join(builddir, ".env.hash")
 )
 
 // Types implementing phonyInterface support the creation of phony targets.
@@ -191,17 +188,6 @@ func (s *SourceProps) processPaths(ctx abstr.BaseModuleContext, g generatorBacke
 
 	s.Srcs = utils.PrefixDirs(srcs, prefix)
 	s.Exclude_srcs = utils.PrefixDirs(s.Exclude_srcs, prefix)
-}
-
-type dependencySingleton struct{}
-
-func (m *dependencySingleton) GenerateBuildActions(ctx blueprint.SingletonContext) {
-	ctx.AddNinjaFileDeps(jsonPath)
-	ctx.AddNinjaFileDeps(envHash)
-}
-
-func dependencySingletonFactory() blueprint.Singleton {
-	return &dependencySingleton{}
 }
 
 type tgtType string

--- a/core/linux.go
+++ b/core/linux.go
@@ -33,9 +33,11 @@ import (
 )
 
 var (
-	builddirVar = pctx.StaticVariable("BuildDir", builddir)
-	srcdirVar   = pctx.StaticVariable("SrcDir", srcdir)
 	pctx        = blueprint.NewPackageContext("bob")
+	srcdirVar   = pctx.StaticVariable("SrcDir", srcdir)
+	builddirVar = pctx.VariableFunc("BuildDir", func(interface{}) (string, error) {
+		return getBuildDir(), nil
+	})
 )
 
 type linuxGenerator struct {
@@ -794,7 +796,7 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 		// Expand args immediately
 		cmd = strings.Replace(cmd, "${args}", strings.Join(props.Post_install_args, " "), -1)
 
-		args["bob_config"] = configPath
+		args["bob_config"] = filepath.Join(getBuildDir(), configName)
 		if props.Post_install_tool != nil {
 			args["tool"] = *props.Post_install_tool
 			deps = append(deps, *props.Post_install_tool)

--- a/core/soong_gen.go
+++ b/core/soong_gen.go
@@ -86,8 +86,6 @@ func expandBobVariables(str, tool, hostBin string) (out string, err error) {
 			return "$(depfile)"
 		case "gen_dir":
 			return "$(genDir)"
-		case "bob_config":
-			return configPath
 		case "bob_config_opts":
 			return configOpts
 		default:

--- a/core/soong_plugin.go
+++ b/core/soong_plugin.go
@@ -199,6 +199,9 @@ func init() {
 	// `TopDownMutatorContext.CreateModule` when required.
 
 	android.PreArchMutators(registerMutators)
+
+	// Depend on the configuration
+	apctx.AddNinjaFileDeps(jsonPath)
 }
 
 // Some module types generate other Soong modules. For these, the sources must


### PR DESCRIPTION
Blueprint's `bootstrap` module already gets the build directory when it
parses the command line. This means we can use `bootstrap.BuildDir`,
instead of redundantly reading it from the environment.

However, this approach will not work on Soong. Accordingly, `builddir`
is moved into a helper in `standalone.go`, which will make it obvious,
via a compilation error, if we try and use it uninitialised in Soong.

Note that this requires some tweaks to how jsonPath and envHash are
defined and used. Primarily their main use is in the
dependencySingleton. This is simplified to a single call to
`pctx.AddNinjaFileDeps` from the Main() function, which means those two
globals can be removed.

Add this call in Soong too, which fixes the lack of equivalent
functionality in Soong.

Change-Id: I6eb766904efafed449aad99a3210085be50ed01d
Signed-off-by: Chris Diamand <chris.diamand@arm.com>