### PR TITLE
Don't reference undefined environment variables in Soong

### DIFF
--- a/bootstrap_soong.bash
+++ b/bootstrap_soong.bash
@@ -59,8 +59,11 @@ SOONG_CONFIG_GO="${BUILDDIR}/soong_config.go"
 # do not have access to the Soong context when they are called, even though the
 # config file must be loaded before then.
 TMP_GO_CONFIG=$(mktemp)
-sed -e "s#@@CONFIG_JSON@@#${CONFIG_JSON}#" \
+sed -e "s#@@BOB_CONFIG_OPTS@@#${BOB_CONFIG_OPTS}#" \
     -e "s#@@BOB_DIR@@#${BOB_DIR}#" \
+    -e "s#@@BUILDDIR@@#${BUILDDIR}#" \
+    -e "s#@@CONFIGNAME@@#${CONFIGNAME}#" \
+    -e "s#@@CONFIG_JSON@@#${CONFIG_JSON}#" \
     "${BOB_DIR}/core/soong_config.go.in" > "${TMP_GO_CONFIG}"
 rsync --checksum "${TMP_GO_CONFIG}" "${SOONG_CONFIG_GO}"
 rm -f "${TMP_GO_CONFIG}"

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -18,7 +18,6 @@
 package core
 
 import (
-	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -28,12 +27,6 @@ import (
 
 	"github.com/ARM-software/bob-build/abstr"
 	"github.com/ARM-software/bob-build/utils"
-)
-
-var (
-	srcdir     = os.Getenv("SRCDIR")
-	configName = os.Getenv("CONFIGNAME")
-	configOpts = os.Getenv("BOB_CONFIG_OPTS")
 )
 
 // Types implementing phonyInterface support the creation of phony targets.

--- a/core/linux.go
+++ b/core/linux.go
@@ -796,7 +796,7 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 		// Expand args immediately
 		cmd = strings.Replace(cmd, "${args}", strings.Join(props.Post_install_args, " "), -1)
 
-		args["bob_config"] = filepath.Join(getBuildDir(), configName)
+		args["bob_config"] = filepath.Join(g.buildDir(), configName)
 		if props.Post_install_tool != nil {
 			args["tool"] = *props.Post_install_tool
 			deps = append(deps, *props.Post_install_tool)

--- a/core/soong_config.go.in
+++ b/core/soong_config.go.in
@@ -22,6 +22,21 @@
 package core
 
 var (
-	bobdir   = "@@BOB_DIR@@"
-	jsonPath = "@@CONFIG_JSON@@"
+	bobdir     = "@@BOB_DIR@@"
+	configName = "@@CONFIGNAME@@"
+	configOpts = "@@BOB_CONFIG_OPTS@@"
+	jsonPath   = "@@CONFIG_JSON@@"
+
+	// The working directory is always the root of the Android source tree, but,
+	// unlike the `Android.mk` backend, ModuleDir() will always include the full
+	// path from the Android root (not from the project directory). This means
+	// that joining `${workdir}/${srcdir}/${moduledir}/file.c` would not be a
+	// valid path, if srcdir actually contained the path to the project root,
+	// because that's also included in moduledir. Work around this by leaving
+	// srcdir empty on Soong.
+	srcdir = ""
 )
+
+func getBuildDir() string {
+	return "@@BUILDDIR@@"
+}

--- a/core/soong_gen.go
+++ b/core/soong_gen.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -86,6 +87,8 @@ func expandBobVariables(str, tool, hostBin string) (out string, err error) {
 			return "$(depfile)"
 		case "gen_dir":
 			return "$(genDir)"
+		case "bob_config":
+			return filepath.Join(getBuildDir(), configName)
 		case "bob_config_opts":
 			return configOpts
 		default:

--- a/core/soong_plugin.go
+++ b/core/soong_plugin.go
@@ -105,7 +105,7 @@ func (g *soongGenerator) sharedActions(*sharedLibrary, blueprint.ModuleContext) 
 func (g *soongGenerator) staticActions(*staticLibrary, blueprint.ModuleContext)                     {}
 func (g *soongGenerator) transformSourceActions(*transformSource, blueprint.ModuleContext, []inout) {}
 
-func (g *soongGenerator) buildDir() string                           { return "" }
+func (g *soongGenerator) buildDir() string                           { return getBuildDir() }
 func (g *soongGenerator) sourcePrefix() string                       { return "" }
 func (g *soongGenerator) sharedLibsDir(tgt tgtType) string           { return "" }
 func (g *soongGenerator) sourceOutputDir(m *generateCommon) string   { return "" }

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -35,7 +35,10 @@ import (
 )
 
 var (
-	bobdir = os.Getenv("BOB_DIR")
+	bobdir     = os.Getenv("BOB_DIR")
+	configName = os.Getenv("CONFIGNAME")
+	configOpts = os.Getenv("BOB_CONFIG_OPTS")
+	srcdir     = os.Getenv("SRCDIR")
 )
 
 type moduleBase struct {

--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -39,6 +39,10 @@ type toolchain interface {
 
 func lookPathSecond(toolUnqualified string, firstHit string) (string, error) {
 	firstDir := filepath.Clean(filepath.Dir(firstHit))
+	// In the Soong plugin, this is the only environment variable reference. The Soong plugin
+	// does not hash the environment, so if it were any other variable, there would be a
+	// missing dependency. Fortunately, Soong itself keeps track of PATH, and will
+	// automatically regenerate the Ninja file when it changes, so accessing it here is safe.
 	path := os.Getenv("PATH")
 	foundFirstHit := false
 	for _, dir := range filepath.SplitList(path) {


### PR DESCRIPTION
Remove the `os.Getenv` calls from `build_structs.go`, because these will
fail (returning "") on Soong, where the environment is sanitised before
building.

On "standalone" generators, the environment variables are still used. In
the Soong plugin, add them to `soong_config.go` instead, with the
exception of `srcdir`, which isn't actually needed.

Change-Id: Iacdf77e77ae31e45e0c29be90d70643430931525
Signed-off-by: Chris Diamand <chris.diamand@arm.com>