### PR TITLE
Report missing tools in scripts/strip.py

### DIFF
--- a/scripts/strip.py
+++ b/scripts/strip.py
@@ -39,6 +39,9 @@ def run(cmd):
         sys.stderr.write("Error: Command %s failed with exit code %d" %
                          (str(cmd), e.returncode))
         sys.exit(e.returncode)
+    except OSError as e:
+        sys.stderr.write("Error: Couldn't execute command '%s': %s" % (' '.join(cmd), e.strerror))
+        sys.exit(1)
 
 
 def create_debug_info(fname, dbg, objcopy):


### PR DESCRIPTION
It is possible that tools scripts/strip.py needs does not exist in
host environment at all. In this case error message should be more
telling.

Before:
  ...long stack trace...
  OSError: [Errno 2] No such file or directory
Now:
  Error: Couldn't execute command ['objcopy', '--only-keep-debug',
  'target/executable/test', './install/bin/test.dbg']

Change-Id: I8ffc13d55808499e4a5bf811b7ba3e42ed54714d
Signed-off-by: Ali Utku Selen <ali.utku.selen@arm.com>