### PR TITLE
Do not output config files on errors

### DIFF
--- a/config_system/menuconfig.py
+++ b/config_system/menuconfig.py
@@ -658,7 +658,9 @@ def main():
 
     menustack.append(general.get_root_menu())
 
-    if curses.wrapper(gui_main):
+    should_save = curses.wrapper(gui_main)
+
+    if should_save:
         general.enforce_dependent_values()
         for plugin in args.plugin:
             path, name = os.path.split(plugin)
@@ -684,7 +686,14 @@ def main():
     # Flush all log messages on exit
     msgBuffer.close()
 
-    return counter.errors() + counter.criticals()
+    error_count = counter.errors() + counter.criticals()
+
+    if should_save and error_count > 0:
+        os.remove(args.config)
+        if args.json is not None:
+            os.remove(args.json)
+
+    return error_count
 
 
 if __name__ == "__main__":

--- a/config_system/update_config.py
+++ b/config_system/update_config.py
@@ -182,7 +182,14 @@ def main():
     if args.json is not None:
         config_json.write_config(args.json)
 
-    return counter.errors() + counter.criticals()
+    error_count = counter.errors() + counter.criticals()
+
+    if error_count > 0:
+        os.remove(args.config)
+        if args.json is not None:
+            os.remove(args.json)
+
+    return error_count
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Prevent builds when configuration errors occur in update_config.py and
menuconfig.py by removing configuration files if any errors are found.

Change-Id: Ied41e11e93d31cf34c88bf4a8f76454c979189d0
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>