### PR TITLE
Consistent naming of variables referring to the bootstrap data vs script

### DIFF
--- a/bob.bash
+++ b/bob.bash
@@ -21,8 +21,7 @@ set -e
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 # Read settings written by bootstrap.bash
-BOOTSTRAP=".bob.bootstrap"
-source "${BOOTSTRAP}"
+source ".bob.bootstrap"
 
 # Switch to the working directory
 cd "${WORKDIR}"

--- a/bob_graph.bash
+++ b/bob_graph.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,8 +27,7 @@ set -e
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 # Read settings written by bootstrap.bash
-BOOTSTRAP=".bob.bootstrap"
-source "${BOOTSTRAP}"
+source ".bob.bootstrap"
 
 # Switch to the working directory
 cd "${WORKDIR}"

--- a/config.bash
+++ b/config.bash
@@ -22,8 +22,7 @@ ORIG_PWD="$(pwd)"
 
 # Move to the build directory
 cd $(dirname "${BASH_SOURCE[0]}")
-BOOTSTRAP=".bob.bootstrap"
-source "${BOOTSTRAP}"
+source ".bob.bootstrap"
 
 declare -a ARG_TARGET
 

--- a/example/bootstrap_android.bash
+++ b/example/bootstrap_android.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -107,8 +107,7 @@ rm -f "$TMP_ANDROID_MK"
 
 
 # Pick up some info that bob has worked out
-BOOTSTRAP=".bob.bootstrap"
-source "${BUILDDIR}/${BOOTSTRAP}"
+source "${BUILDDIR}/.bob.bootstrap"
 
 # Setup the buildme script to just run bob
 ln -sf "bob" "${BUILDDIR}/buildme"

--- a/example/bootstrap_linux.bash
+++ b/example/bootstrap_linux.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,8 +59,7 @@ export BUILDDIR
 "${BOB_DIR}/bootstrap_linux.bash"
 
 # Pick up some info that bob has worked out
-BOOTSTRAP=".bob.bootstrap"
-source "${BUILDDIR}/${BOOTSTRAP}"
+source "${BUILDDIR}/.bob.bootstrap"
 
 # Setup the build script
 if [ "${SRCDIR:0:1}" != '/' ]; then

--- a/example/buildme.bash
+++ b/example/buildme.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,8 +26,7 @@ fi
 # Switch to the build directory
 cd $(dirname "${BASH_SOURCE[0]}")
 
-BOOTSTRAP=".bob.bootstrap"
-source "${BOOTSTRAP}"
+source ".bob.bootstrap"
 
 # Check for missing configuration
 if [ ! -f "${CONFIGNAME}" ] ; then

--- a/menuconfig.bash
+++ b/menuconfig.bash
@@ -20,8 +20,7 @@ trap 'echo "*** Unexpected error ***"' ERR
 
 # Move to the build driectory
 cd $(dirname "${BASH_SOURCE[0]}")
-BOOTSTRAP=".bob.bootstrap"
-source "${BOOTSTRAP}"
+source ".bob.bootstrap"
 
 # Move to the working directory
 cd "${WORKDIR}"

--- a/tests/bootstrap
+++ b/tests/bootstrap
@@ -97,8 +97,7 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 "${SCRIPT_DIR}/bob/bootstrap_linux.bash"
 
 # Pick up some info that bob has worked out
-BOOTSTRAP=".bob.bootstrap"
-source "${BUILDDIR}/${BOOTSTRAP}"
+source "${BUILDDIR}/.bob.bootstrap"
 
 # Setup the buildme script to just run bob
 ln -sf "bob" "${BUILDDIR}/buildme"

--- a/tests/bootstrap_android
+++ b/tests/bootstrap_android
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -113,8 +113,7 @@ rm -f "$TMP_ANDROID_MK"
 
 
 # Pick up some info that bob has worked out
-BOOTSTRAP=".bob.bootstrap"
-source "${BUILDDIR}/${BOOTSTRAP}"
+source "${BUILDDIR}/.bob.bootstrap"
 
 # Setup the buildme script to just run bob
 ln -sf "bob" "${BUILDDIR}/buildme"


### PR DESCRIPTION
Replace ${BOOTSTRAP} with .bob.bootstrap to avoid confusion with its usage in bob/bootstrap.bash.

Change-Id: Ie7e57d880337c282bf57b862953b45bf376cba06
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>