### PR TITLE
Prevent build on configuration failure without removing config files

### DIFF
--- a/bob.bash
+++ b/bob.bash
@@ -34,6 +34,12 @@ if [[ "${BOB_BOOTSTRAP_VERSION}" != "${BOB_VERSION}" ]]; then
     exit 1
 fi
 
+# Stop the build if menuconfig.py or update_config.py failed
+if [[ -e "${BUILDDIR}/${CONFIGNAME}.error" ]]; then
+    echo "Configuration errors are present, the build cannot proceed further." >&2
+    exit 1
+fi
+
 # Refresh the configuration. This means that options changed or added since the
 # last build will be chosen from their defaults automatically, so that users
 # don't have to reconfigure manually if the config database changes.

--- a/config_system/menuconfig.py
+++ b/config_system/menuconfig.py
@@ -688,10 +688,21 @@ def main():
 
     error_count = counter.errors() + counter.criticals()
 
-    if should_save and error_count > 0:
-        os.remove(args.config)
-        if args.json is not None:
-            os.remove(args.json)
+    if should_save:
+        error_path = args.config + ".error"
+        if error_count == 0:
+            try:
+                os.remove(error_path)
+            except OSError:
+                pass
+        else:
+            with open(error_path, 'w'):
+                pass
+            if args.json is not None:
+                try:
+                    os.remove(args.json)
+                except OSError:
+                    pass
 
     return error_count
 

--- a/config_system/update_config.py
+++ b/config_system/update_config.py
@@ -184,10 +184,20 @@ def main():
 
     error_count = counter.errors() + counter.criticals()
 
-    if error_count > 0:
-        os.remove(args.config)
+    error_path = args.config + ".error"
+    if error_count == 0:
+        try:
+            os.remove(error_path)
+        except OSError:
+            pass
+    else:
+        with open(error_path, 'w'):
+            pass
         if args.json is not None:
-            os.remove(args.json)
+            try:
+                os.remove(args.json)
+            except OSError:
+                pass
 
     return error_count
 


### PR DESCRIPTION
'bob.config' is no longer removed on configuration failure.
Instead, 'bob.error' is created to signal 'bob.bash' that the build
should not proceed furhter.

Change-Id: Idd2f8c9abd4e06e3615e9f6ad55e83fa556ae44e
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>