### PR TITLE
Fix target cmd LOCAL_PATH usage

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -719,6 +719,9 @@ func (g *androidMkGenerator) generateCommonActions(sb *strings.Builder, m *gener
 		sb.WriteString(outs + ": in := " + ins + "\n")
 		sb.WriteString(outs + ": out := " + strings.Join(inout.out, " ") + "\n")
 		sb.WriteString(outs + ": depfile := " + inout.depfile + "\n")
+		if strings.Contains(cmd, "$(LOCAL_PATH)") {
+			sb.WriteString(outs + ": LOCAL_PATH := $(LOCAL_PATH)" + "\n")
+		}
 		sb.WriteString(outs + ": " + ins + " " + strings.Join(inout.implicitSrcs, " ") + "\n")
 		sb.WriteString("\t" + cmd + "\n")
 		if inout.depfile != "" {


### PR DESCRIPTION
Having LOCAL_PATH in target cmd is not possible since it is re-used.
Instead add a target specific LOCAL_PATH for each out with a cmd that uses
LOCAL_PATH.

Change-Id: Ia3da9461b8aff55d0ff6680f32e4649bf7df6cb4
Signed-off-by: Ali Utku Selen <ali.utku.selen@arm.com>