### PR TITLE
Don't interpret kernel_dir as relative when not set

### DIFF
--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -171,7 +171,7 @@ func (m *kernelModule) generateKbuildArgs(ctx abstr.VisitableModuleContext) kbui
 
 	kmodBuild := filepath.Join(bobdir, "scripts", "kmod_build.py")
 	kdir := m.Properties.Build.Kernel_dir
-	if !filepath.IsAbs(kdir) {
+	if kdir != "" && !filepath.IsAbs(kdir) {
 		kdir = filepath.Join(g.sourcePrefix(), kdir)
 	}
 


### PR DESCRIPTION
Check that `kernel_dir` has actually been set before qualifying it.

Change-Id: I93a1f5b206845a66109fa27604daadf818f72f45
Signed-off-by: Chris Diamand <chris.diamand@arm.com>