### PR TITLE
Support different dynamic library extensions

### DIFF
--- a/core/gen_binary.go
+++ b/core/gen_binary.go
@@ -40,6 +40,12 @@ func (m *generateBinary) outputs(g generatorBackend) []string {
 	return []string{getLibraryGeneratedPath(m, g)}
 }
 
+//// Support singleOutputModule
+
+func (m *generateBinary) outputFileName() string {
+	return m.Name() + m.libExtension()
+}
+
 //// Support Installable
 
 func (m *generateBinary) filesToInstall(ctx abstr.BaseModuleContext, g generatorBackend) []string {

--- a/core/gen_shared.go
+++ b/core/gen_shared.go
@@ -25,12 +25,13 @@ import (
 
 type generateSharedLibrary struct {
 	generateLibrary
+	fileNameExtension string
 }
 
 //// Support GenerateLibraryInterface
 
 func (m *generateSharedLibrary) libExtension() string {
-	return ".so"
+	return m.fileNameExtension
 }
 
 //// Support PhonyInterface, DependentInterface
@@ -56,12 +57,25 @@ func (m *generateSharedLibrary) GenerateBuildActions(ctx blueprint.ModuleContext
 	}
 }
 
+//// Support singleOutputModule
+
+func (m *generateSharedLibrary) outputFileName() string {
+	return m.Name() + m.libExtension()
+}
+
 //// Factory functions
 
 func genSharedLibFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &generateSharedLibrary{}
 	module.generateCommon.Properties.Features.Init(config.Properties, GenerateProps{},
 		GenerateLibraryProps{})
+	switch config.Properties.GetString("os") {
+		case "osx" :
+			module.fileNameExtension = ".dylib"
+			break
+		default:
+			module.fileNameExtension = ".so"
+	}
 	return module, []interface{}{
 		&module.SimpleName.Properties,
 		&module.generateCommon.Properties,

--- a/core/gen_static.go
+++ b/core/gen_static.go
@@ -56,6 +56,12 @@ func (m *generateStaticLibrary) GenerateBuildActions(ctx blueprint.ModuleContext
 	}
 }
 
+//// Support singleOutputModule
+
+func (m *generateStaticLibrary) outputFileName() string {
+	return m.Name() + m.libExtension()
+}
+
 //// Factory functions
 
 func genStaticLibFactory(config *bobConfig) (blueprint.Module, []interface{}) {

--- a/core/linux.go
+++ b/core/linux.go
@@ -93,6 +93,7 @@ var copyRule = pctx.StaticRule("copy",
 type singleOutputModule interface {
 	blueprint.Module
 	outputName() string
+	outputFileName() string
 }
 
 type targetableModule interface {
@@ -103,13 +104,13 @@ type targetableModule interface {
 // Where to put generated shared libraries to simplify linking
 // As long as the module is targetable, we can infer the library path
 func getSharedLibLinkPath(t targetableModule) string {
-	return filepath.Join("${BuildDir}", string(t.getTarget()), "shared", t.outputName()+".so")
+	return filepath.Join("${BuildDir}", string(t.getTarget()), "shared", t.outputFileName())
 }
 
 // Where to put generated binaries in order to make sure generated binaries
 // are available in the same directory as compiled binaries
 func getBinaryPath(t targetableModule) string {
-	return filepath.Join("${BuildDir}", string(t.getTarget()), "executable", t.outputName())
+	return filepath.Join("${BuildDir}", string(t.getTarget()), "executable", t.outputFileName())
 }
 
 // Generate the build actions for a generateSource module and populates the outputs.

--- a/example/Mconfig
+++ b/example/Mconfig
@@ -11,7 +11,16 @@ config LINUX
 config ANDROID
 	bool "Android"
 
+config OSX
+	bool "macOS"
+
 endchoice
+
+config OS
+	string
+	default "android" if ANDROID
+	default "osx" if OSX
+	default "linux"
 
 ## Need to select the BUILDER_ for Bob
 choice

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -25,7 +25,16 @@ config LINUX
 config ANDROID
 	bool "Android"
 
+config OSX
+	bool "macOS"
+
 endchoice
+
+config OS
+	string
+	default "android" if ANDROID
+	default "osx" if OSX
+	default "linux"
 
 ## Need to select the BUILDER_ for Bob
 choice

--- a/tests/build_tests.sh
+++ b/tests/build_tests.sh
@@ -19,6 +19,12 @@ function check_stripped() {
     [ $(nm -a "${FILE}" | wc -l) = "0" ] || { echo "${FILE} not stripped" ; false; }
 }
 
+case "$(uname -s)" in
+    Darwin*) SHARED_LIBRARY_EXTENSION=".dylib";;
+    *)       SHARED_LIBRARY_EXTENSION=".so";;
+esac
+
+
 # Do simple checks on the output of each build
 function check_build_output() {
     local DIR="${1}"
@@ -27,11 +33,11 @@ function check_build_output() {
     echo "Checking build output under ${DIR}"
 
     # Check that installed libraries/binaries are present
-    check_installed "${DIR}/install/lib/libstripped_library.so"
+    check_installed "${DIR}/install/lib/libstripped_library${SHARED_LIBRARY_EXTENSION}"
     check_installed "${DIR}/install/bin/stripped_binary"
 
     # The stripped library must not contain symbols
-    check_stripped "${DIR}/install/lib/libstripped_library.so"
+    check_stripped "${DIR}/install/lib/libstripped_library${SHARED_LIBRARY_EXTENSION}"
     check_stripped "${DIR}/install/bin/stripped_binary"
 }
 


### PR DESCRIPTION
macOS uses 'dylib' as extension for dynamic libraries.

Change-Id: Id732c99650807a52d455435ffac585a6b12fbd35
Signed-off-by: Ali Utku Selen <ali.utku.selen@arm.com>