### PR TITLE
Refactor inout helper

### DIFF
--- a/Android.bp.in
+++ b/Android.bp.in
@@ -36,6 +36,7 @@ bootstrap_go_package {
         "core/defaults.go",
         "core/external_library.go",
         "core/feature.go",
+        "core/filepath.go",
         "core/gen_binary.go",
         "core/gen_library.go",
         "core/gen_shared.go",

--- a/Blueprints
+++ b/Blueprints
@@ -42,6 +42,7 @@ bootstrap_go_package {
         "core/defaults.go",
         "core/external_library.go",
         "core/feature.go",
+        "core/filepath.go",
         "core/gen_binary.go",
         "core/gen_library.go",
         "core/gen_shared.go",

--- a/core/filepath.go
+++ b/core/filepath.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/blueprint"
+)
+
+// filePath encapsulates paths that may need to be used in different
+// ways in source generation modules.
+type filePath interface {
+	// Full path to source used by ninja.
+	// e.g. ${g.bob.SrcDir}/module1/subdir/file1.c
+	//      ${g.bob.BuildDir}/gen/module2/subdir/file2.c
+	//      ${g.bob.BuildDir}/bob.config
+	buildPath() string
+	// Short path used to calculate names of related outputs.
+	// This may include the module directory.
+	// e.g. module1/subdir/file1.c
+	//      module2/subdir/file2.c
+	//      bob.config
+	localPath() string
+	// Module directory associated with this file.
+	// This path is valid from the build output directory.
+	// e.g. ${g.bob.SrcDir}/module1
+	//      ${g.bob.BuildDir}/gen/module2
+	//      ${g.bob.BuildDir}
+	moduleDir() string
+}
+
+// Represents a normal file in the source directory
+type sourceFilePath struct {
+	path      string
+	module    string
+	srcPrefix string
+}
+
+func (file sourceFilePath) buildPath() string {
+	return filepath.Join(file.srcPrefix, file.path)
+}
+
+func (file sourceFilePath) localPath() string {
+	return file.path
+}
+
+func (file sourceFilePath) moduleDir() string {
+	return filepath.Join(file.srcPrefix, file.module)
+}
+
+func newSourceFilePath(path string, ctx blueprint.ModuleContext, g generatorBackend) filePath {
+	return sourceFilePath{path, ctx.ModuleDir(), g.sourcePrefix()}
+}
+
+// Represents a file created in the generated output directory
+type generatedFilePath struct {
+	path    string
+	lclPath string
+	modDir  string
+}
+
+func (file generatedFilePath) buildPath() string {
+	return file.path
+}
+
+func (file generatedFilePath) localPath() string {
+	return file.lclPath
+}
+
+func (file generatedFilePath) moduleDir() string {
+	return file.modDir
+}
+
+func newGeneratedFilePath(path string) filePath {
+	// Identify the parts we need from the full path.
+	//
+	// Ideally we wouldn't need to do this - each module would return
+	// generatedFilePaths.
+	//
+	// For generated paths, the backends set:
+	// ${BuildDir}/gen/m.Name()/file.ext
+	// $(TARGET_OUT_GEN)/STATIC_LIBRARIES/m.Name()/file.ext
+	// $(HOST_OUT_GEN)/STATIC_LIBRARIES/m.Name()/file.ext
+	//
+	// Local path is anything from m.Name() (included)
+	// Module dir is everything upto and including m.Name().
+	pathElems := strings.Split(path, string(os.PathSeparator))
+	if len(pathElems) < 4 {
+		panic(fmt.Errorf("Path doesn't have as many elements as expected. %s", path))
+	}
+	lclPath := filepath.Join(pathElems[2:]...)
+	modDir := filepath.Join(pathElems[:3]...)
+	return generatedFilePath{path, lclPath, modDir}
+}
+
+// Handle special files (i.e. bob.config) in the generated output
+// directory a bit differently.
+func newSpecialFilePath(path string) filePath {
+	// Identify the parts we need from the full path.
+	//
+	// Ideally we wouldn't need to do this - each module would return
+	// filePaths.
+	//
+	// The special path should look like
+	// ${BuildDir}/filename.ext
+	// $(TARGET_OUT_GEN)/STATIC_LIBRARIES/directory/filename.ext
+	//
+	// Local path should just be the basename.
+	// Module dir should be the directory.
+	return generatedFilePath{path, filepath.Base(path), filepath.Dir(path)}
+}

--- a/tests/transform_source/build.bp
+++ b/tests/transform_source/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2019 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,11 +22,16 @@ bob_transform_source {
     ],
     out: {
         match: "(.+)\\.in",
-        replace: ["single/$1.cpp"], // inside extra directory
+        replace: [
+            // inside extra directory
+            "single/$1.cpp",
+            "single/$1.h",
+        ],
     },
+    export_gen_include_dirs: ["single/transform_source"],
 
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${out}",
+    cmd: "python ${tool} --in ${in} --out ${srcs_generated}",
 }
 
 bob_transform_source {
@@ -39,12 +44,16 @@ bob_transform_source {
     },
     always_enabled_feature: {
         out: {
-            replace: ["$1.cpp"],
+            replace: [
+                "$1.cpp",
+                "$1.h",
+            ],
         },
     },
+    export_gen_include_dirs: ["transform_source"],
 
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${out}",
+    cmd: "python ${tool} --in ${in} --out ${srcs_generated}",
 }
 
 bob_transform_source {
@@ -56,16 +65,25 @@ bob_transform_source {
     ],
     out: {
         match: "(.+)\\.in",
-        replace: ["$1.cpp"],
+        replace: [
+            "$1.cpp",
+            "$1.h",
+        ],
     },
+    export_gen_include_dirs: ["transform_source"],
 
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${out}",
+    cmd: "python ${tool} --in ${in} --out ${srcs_generated}",
 }
 
 bob_binary {
     name: "validate_link_transform_source",
     generated_sources: [
+        "transform_source_single_dir",
+        "transform_source_single",
+        "transform_source_multiple_in",
+    ],
+    generated_headers: [
         "transform_source_single_dir",
         "transform_source_single",
         "transform_source_multiple_in",

--- a/tests/transform_source/generator.py
+++ b/tests/transform_source/generator.py
@@ -1,6 +1,6 @@
 #!/bin/python
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2019 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,3 +52,8 @@ if os.path.splitext(output_base_name)[1] != ".cpp":
 without_extension = os.path.splitext(output_base_name)[0]
 with open(args.output, 'w') as outfile:
     outfile.write("void output_%s(){}\n" % without_extension)
+
+# Output a header to go with the cpp file
+header = os.path.splitext(args.output)[0] + ".h"
+with open(header, 'w') as outfile:
+    outfile.write("void output_%s();\n" % without_extension)

--- a/tests/transform_source/main.cpp
+++ b/tests/transform_source/main.cpp
@@ -1,8 +1,8 @@
-void output_f();
-void output_f2();
-void output_f3();
-void output_f4();
-void output_f5();
+#include "f.h"
+#include "f2.h"
+#include "f3.h"
+#include "f4.h"
+#include "f5.h"
 
 void validate_link()
 {


### PR DESCRIPTION
Factor out the inside of transformSource's `Inouts` loops so that it can
be re-used from the Soong plugin.

This commit is modified from the previous attempt to commit this,
b21b028f56, so that ${g.bob.SrcDir} is not added to the output file
path as an infix. In inoutForSrc, the regular expression replace needs
to run on the srcs path before g.sourcePrefix() is added. In addition
we only want that prefix added for non-generated source inputs.

This is achieved by adding a filePath class, which allows us to pass a
single object around from which we can retrieve relevant path portions
for processing in different use cases.

Change-Id: I9ef92900623f7ebe297deeed5ae01a91bbad6bfb
Signed-off-by: David Kilroy <david.kilroy@arm.com>