### PR TITLE
config_system: Add the `source_local` Mconfig keyword

### DIFF
--- a/config_system/config_system/lex.py
+++ b/config_system/config_system/lex.py
@@ -48,6 +48,7 @@ tokens = (
     "QUOTED_STRING",
     "SELECT",
     "SOURCE",
+    "SOURCE_LOCAL",
     "STRING",
     "VISIBLE",
     "YES", "NO",
@@ -74,6 +75,7 @@ commands = (
     "prompt",
     "select",
     "source",
+    "source_local",
     "string",
     "visible",
 )

--- a/config_system/config_system/lex_wrapper.py
+++ b/config_system/config_system/lex_wrapper.py
@@ -25,12 +25,10 @@ class LexWrapper:
         self.ignore_missing = ignore_missing
         self.verbose = verbose
 
-    def source(self, fname):
+    def open(self, fname):
+        """Open the named file."""
         if self.root_dir is None:
             self.root_dir = os.path.dirname(fname)
-        else:
-            # All paths are relative to the dir containing the first Mconfig
-            fname = os.path.join(self.root_dir, fname)
 
         if not os.path.exists(fname) and self.ignore_missing:
             return
@@ -42,6 +40,14 @@ class LexWrapper:
 
         self.push_lexer(lexer)
         self.input(file_contents)
+
+    def source(self, fname):
+        """Handle the source command, ensuring we open the file relative to
+        the directory containing the first Mconfig."""
+        if self.root_dir is not None:
+            fname = os.path.join(self.root_dir, fname)
+
+        self.open(fname)
 
     def current_lexer(self):
         return self.lexers[-1]

--- a/config_system/config_system/syntax.py
+++ b/config_system/config_system/syntax.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os.path
 import ply.yacc as yacc
 
 from config_system import expr
@@ -56,6 +57,7 @@ def p_stmt(p):
             | config_stmt
             | choice_stmt
             | source_stmt
+            | source_local_stmt
             | mainmenu_stmt
     """
     p[0] = p[1]
@@ -222,6 +224,15 @@ def p_source_stmt_first(p):
     p[0] = {}
 
 
+def p_source_local_stmt_first(p):
+    """source_local_stmt_first : SOURCE_LOCAL QUOTED_STRING dummy"""
+    fname = p.lexer.current_lexer().fname
+    dname = os.path.dirname(fname)
+    mname = os.path.join(dname, p[2])
+    p.lexer.open(mname)
+    p[0] = {}
+
+
 def p_mainmenu_stmt_first(p):
     """mainmenu_stmt_first : MAINMENU QUOTED_STRING dummy"""
     p[0] = p[2]
@@ -241,6 +252,11 @@ def p_dummy(p):
 
 def p_source_stmt(p):
     "source_stmt : source_stmt_first EOL"
+    p[0] = {}
+
+
+def p_source_local_stmt(p):
+    'source_local_stmt : source_local_stmt_first EOL'
     p[0] = {}
 
 

--- a/docs/config_system.md
+++ b/docs/config_system.md
@@ -65,10 +65,11 @@ options.
 Configuration options live in a file called `Mconfig` at the root of a project
 directory.
 
-Furthermore, `Mconfig` files can include other ones using the `source`
-statement. The argument to `source` is a directory *relative to the project
-root, not relative to the Mconfig file containing the `source` statement*.
-E.g., for the following layout:
+Furthermore, `Mconfig` files can include other ones using the `source` or
+`source_local` statements. For compatibility with kernel Kconfig files, the
+argument to `source` is a directory *relative to the project root, not relative
+to the Mconfig file containing the `source` statement*. `source_local` takes a
+path relative to the current file. E.g., for the following layout:
 
 ```
 project
@@ -96,6 +97,7 @@ And `subcomponent/Mconfig` would contain:
 ```
 # ...
 source "subcomponent/subsubcomponent/Mconfig"
+# OR: source_local "subsubcomponent/Mconfig"
 # NOT: source "subsubcomponent/Mconfig"
 ```
 


### PR DESCRIPTION
Works the same as `source` just that the path can be local to the
currently parsed `Mconfig` file directory.

Change-Id: If97a5a4b3649f892b43951d8e25859785f8f3e81
Signed-off-by: David Kilroy <david.kilroy@arm.com>