### PR TITLE
macOS support for strip.py

### DIFF
--- a/core/linux.go
+++ b/core/linux.go
@@ -772,9 +772,9 @@ var stripScript = filepath.Join(bobdir, "scripts", "strip.py")
 var stripRule = pctx.StaticRule("strip",
 	blueprint.RuleParams{
 		Command: stripScript +
-			" $args --objcopy $objcopy -o $out $in",
+			" $args --tool $tool -o $out $in",
 		Description: "strip $out",
-	}, "args", "objcopy")
+	}, "args", "tool")
 
 var installRule = pctx.StaticRule("install",
 	blueprint.RuleParams{
@@ -862,8 +862,8 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 					stArgs = append(stArgs, dbgFile)
 				}
 				stripArgs := map[string]string{
-					"args":    strings.Join(stArgs, " "),
-					"objcopy": g.getToolchain(lib.getTarget()).getObjcopy(),
+					"args": strings.Join(stArgs, " "),
+					"tool": g.getToolchain(lib.getTarget()).getStripBinary(),
 				}
 				ctx.Build(pctx,
 					blueprint.BuildParams{

--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -116,7 +116,7 @@ type toolchain interface {
 	getCCompiler() (tool string, flags []string)
 	getCXXCompiler() (tool string, flags []string)
 	getLinker() linker
-	getObjcopy() (tool string)
+	getStripBinary() (tool string)
 }
 
 func lookPathSecond(toolUnqualified string, firstHit string) (string, error) {
@@ -252,7 +252,7 @@ func (tc toolchainGnuCommon) getLinker() linker {
 	return tc.linker
 }
 
-func (tc toolchainGnuCommon) getObjcopy() string {
+func (tc toolchainGnuCommon) getStripBinary() string {
 	return tc.objcopyBinary
 }
 
@@ -431,7 +431,7 @@ func (tc toolchainClangCommon) getLinker() linker {
 	return newDefaultLinker(tc.clangxxBinary, tc.ldflags, tc.ldlibs)
 }
 
-func (tc toolchainClangCommon) getObjcopy() string {
+func (tc toolchainClangCommon) getStripBinary() string {
 	return tc.objcopyBinary
 }
 
@@ -596,7 +596,7 @@ func (tc toolchainArmClang) getLinker() linker {
 	return tc.linker
 }
 
-func (tc toolchainArmClang) getObjcopy() string {
+func (tc toolchainArmClang) getStripBinary() string {
 	return tc.objcopyBinary
 }
 
@@ -724,7 +724,7 @@ func (tc toolchainXcode) getLinker() linker {
 	return tc.linker
 }
 
-func (tc toolchainXcode) getObjcopy() string {
+func (tc toolchainXcode) getStripBinary() string {
 	return tc.objcopyBinary
 }
 

--- a/mconfig/host_toolchain.Mconfig
+++ b/mconfig/host_toolchain.Mconfig
@@ -122,6 +122,7 @@ config HOST_OBJCOPY_BINARY
 	string "Host objcopy"
 	default HOST_GNU_PREFIX + "objcopy" if HOST_TOOLCHAIN_GNU || (HOST_TOOLCHAIN_CLANG && HOST_CLANG_USE_GNU_BINUTILS)
 	default "llvm-objcopy" if HOST_TOOLCHAIN_CLANG
+	default "dsymutil" if OSX
 	default "objcopy"
 	help
 	  The objcopy executable that we can use in post install scripts

--- a/mconfig/target_toolchain.Mconfig
+++ b/mconfig/target_toolchain.Mconfig
@@ -121,6 +121,7 @@ config TARGET_OBJCOPY_BINARY
 	string "Target objcopy"
 	default TARGET_GNU_PREFIX + "objcopy" if TARGET_TOOLCHAIN_GNU || (TARGET_TOOLCHAIN_CLANG && TARGET_CLANG_USE_GNU_BINUTILS)
 	default "llvm-objcopy" if TARGET_TOOLCHAIN_CLANG
+	default "dsymutil" if OSX
 	default "objcopy"
 	help
 	  The objcopy executable that we can use in post install scripts


### PR DESCRIPTION
macOS doesn't have objcopy, equivalent is dsymutil+strip.

Change-Id: I54786d845e7705f0c03938437e4101061565f256
Signed-off-by: Ali Utku Selen <ali.utku.selen@arm.com>