### PR TITLE
whole_static.py fix

### DIFF
--- a/scripts/whole_static.py
+++ b/scripts/whole_static.py
@@ -88,6 +88,16 @@ def main():
     objects = []
     archives = []
 
+    # Always remove the output file to avoid appending to an existing archive.
+    if os.path.isfile(args.out):
+        try:
+            os.remove(args.out)
+        except OSError as e:
+            sys.stderr.write(
+                "Error: Couldn't remove file '%s': %s\n",
+                args.out, e.strerror)
+            sys.exit(1)
+
     for i in args.inputs:
         ext = os.path.splitext(i)[1]
         if ext == ".o":


### PR DESCRIPTION
When creating static archives, start off by deleting any existing
archive. Otherwise `ar` will just keep appending to the archive which
can result in multiply defined symbols.

Change-Id: I67bb0170a874a4911960cafac39e6951d44a4ffd
Signed-off-by: David Kilroy <david.kilroy@arm.com>