### PR TITLE
Verify static libraries created from scratch

### DIFF
--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -243,3 +243,8 @@ config ALWAYS_ENABLED_FEATURE
 config TEMPLATE_TEST_VALUE
 	int
 	default 6
+
+## configuration to toggle for static library creation test
+config STATIC_LIB_TOGGLE
+	bool "Test toggle"
+    default n

--- a/tests/build_tests.sh
+++ b/tests/build_tests.sh
@@ -78,7 +78,13 @@ check_build_output "${build_dir}"
 
 # A re-bootstrapped build directory with a different working directory
 # should still work. Re-use the last directory
+echo Checking rebootstrap
 tests/bootstrap -o ${build_dir}
+${build_dir}/buildme bob_tests
+
+# Check static archives are built from scratch. Re-use the last directory
+echo Reconfiguring to check archives are clean
+${build_dir}/config STATIC_LIB_TOGGLE=y
 ${build_dir}/buildme bob_tests
 
 # Helper function for testing that appropriate files are rebuilt after
@@ -189,7 +195,6 @@ SRC=tests/implicit_outs/input.in
 UPDATE=(${build_dir}/target/executable/build_implicit_out
         ${build_dir}/target/executable/include_implicit_header)
 check_dep_updates "implicit output" "${build_dir}" "${SRC}" "${UPDATE[@]}"
-
 
 # Clean up
 rm -rf "${TEST_DIRS[@]}"

--- a/tests/static_libs/b2.c
+++ b/tests/static_libs/b2.c
@@ -1,0 +1,6 @@
+#include "a.h"
+
+int do_b(int x)
+{
+    return do_a(x + 10);
+}

--- a/tests/static_libs/build.bp
+++ b/tests/static_libs/build.bp
@@ -22,11 +22,19 @@ bob_alias {
         "sl_main_export_static",
         "sl_main_ordered",
         "sl_main_dd",
+        "sl_libb_whole_shared",
+        "sl_libb_shared",
     ],
+}
+
+bob_defaults {
+    name: "shared_code",
+    cflags: ["-fPIC"],
 }
 
 bob_static_library {
     name: "sl_liba",
+    defaults: ["shared_code"],
     srcs: [
         "a/a.c",
         "a.c",
@@ -36,15 +44,53 @@ bob_static_library {
 
 bob_static_library {
     name: "sl_libb_whole_inclusion",
+    defaults: ["shared_code"],
     srcs: ["b.c"],
+
+    // b.c and b2.c contain the same code. Compile different object
+    // based on configuration. After switching configurations the archive
+    // should only ever have one of the objects. This checks archive
+    // creation from archives and objects (calls to whole_static.py).
+    static_lib_toggle: {
+        srcs: ["b2.c"],
+        exclude_srcs: ["b.c"],
+    },
     whole_static_libs: ["sl_liba"],
 }
 
 bob_static_library {
     name: "sl_libb",
+    defaults: ["shared_code"],
     srcs: ["b.c"],
+
+    // b.c and b2.c contain the same code. Compile different object
+    // based on configuration. After switching configurations the archive
+    // should only ever have one of the objects. This checks archive
+    // creation from objects (direct calls to ar).
+    static_lib_toggle: {
+        srcs: ["b2.c"],
+        exclude_srcs: ["b.c"],
+    },
     // Must define FOO for the a.h include
     cflags: ["-DFOO=1"],
+}
+
+bob_shared_library {
+    name: "sl_libb_whole_shared",
+
+    // Include sl_libb_whole_inclusion as a whole archive in this
+    // shared library. If there are duplicate symbols in the static
+    // archive from b.c and b2.c, this link will fail.
+    whole_static_libs: ["sl_libb_whole_inclusion"],
+}
+
+bob_shared_library {
+    name: "sl_libb_shared",
+
+    // Include sl_libb as a whole archive in this shared library. If
+    // there are duplicate symbols in the static archive from b.c and
+    // b2.c, this link will fail.
+    whole_static_libs: ["sl_libb"],
 }
 
 bob_binary {


### PR DESCRIPTION
`ar` appends its input to the existing static library. Add modules
which change the name of the object they are compiling (they will
contain the same code) dependent on the configuration. Then in
build_tests.sh, change the configuration to ensure the static
libraries are created from scratch.

For duplicate symbols to be detected, we need to the static libraries
to be in shared libraries as whole static libraries.

Change-Id: I6ca161849f3abe0925b8882391bb01bcd7d5ee0e
Signed-off-by: David Kilroy <david.kilroy@arm.com>