### PR TITLE
Fix static library test

### DIFF
--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -247,4 +247,4 @@ config TEMPLATE_TEST_VALUE
 ## configuration to toggle for static library creation test
 config STATIC_LIB_TOGGLE
 	bool "Test toggle"
-    default n
+	default n

--- a/tests/static_libs/build.bp
+++ b/tests/static_libs/build.bp
@@ -82,6 +82,7 @@ bob_shared_library {
     // shared library. If there are duplicate symbols in the static
     // archive from b.c and b2.c, this link will fail.
     whole_static_libs: ["sl_libb_whole_inclusion"],
+    ldflags: ["-Wl,--no-undefined"],
 }
 
 bob_shared_library {
@@ -91,6 +92,8 @@ bob_shared_library {
     // there are duplicate symbols in the static archive from b.c and
     // b2.c, this link will fail.
     whole_static_libs: ["sl_libb"],
+    static_libs: ["sl_liba"],
+    ldflags: ["-Wl,--no-undefined"],
 }
 
 bob_binary {


### PR DESCRIPTION
The test added in `77f85ae Verify static libraries created from scratch`
missed a static library dependency, causing it to fail on Soong.

Add the missing dependency, as well as fixing some whitespace from the
same commit.

Add the `--no-undefined` linker option, too; the lack of this is why the
tests were able to pass on Linux.

Change-Id: I62e2e1bd3a75ad94379ca63c00ea6228b86ead6b
Signed-off-by: Chris Diamand <chris.diamand@arm.com>