### PR TITLE
Use getopts instead of getopt in Bob tests

### DIFF
--- a/tests/bootstrap
+++ b/tests/bootstrap
@@ -50,32 +50,22 @@ EOF
 
 source "${SCRIPT_DIR}/bootstrap_utils.sh"
 
-PARAMS=$(getopt -o "o:h" --name ${BASENAME} -- "$@")
-
-eval set -- "$PARAMS"
-unset PARAMS
-
-while true ; do
-    case $1 in
-        -o)
-            BUILDDIR=$2
-            shift 2
+while getopts "o:h" opt ; do
+    case "${opt}" in
+        o)
+            BUILDDIR="${OPTARG}"
             ;;
-        -h)
+        h)
             usage
             exit
             ;;
-        --)
-            shift
-            break
-            ;;
-        *)
-            echo "Unrecognized option $1"
+        [?])
             usage
             exit 1
             ;;
     esac
 done
+shift $((OPTIND - 1))
 
 # Select a BUILDDIR if not provided one
 if [[ -z "$BUILDDIR" ]]; then


### PR DESCRIPTION
When running Bob tests on OSX everything works correctly until
`tests/build_tests.sh` calls `tests/bootstrap.sh -o build-in-src`.

`tests/bootstrap.sh` invokes `getopt` to get the `BUILDDIR` argument
(that is supposed to be `build-in-src`), but this does not work and it defaults
to `BUILDDIR=build`, breaking everything that follows.

This is because `getopt` on OSX 10.13.3 is different from `getopt` on Linux.

This commit fixes this by switching to `getopts` which is dependent on the shell
and not on the OS.

Change-Id: I5035d30cfe8fcf05036bd5716875a732ad995858
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>