### PR TITLE
Fix generated shared library test on macOS

### DIFF
--- a/tests/generate_libs/build.bp
+++ b/tests/generate_libs/build.bp
@@ -49,7 +49,7 @@ bob_generate_shared_library {
      * Note that we make this a host library to avoid having to figure
      * out GCC arguments.
      */
-    cmd: "gcc -fPIC -o ${gen_dir}/libblah_shared.so -shared ${in}; mkdir -p ${gen_dir}/include; cp ${module_dir}/libblah/libblah.h ${module_dir}/libblah/libblah_feature.h ${gen_dir}/include/.",
+    cmd: "gcc -fPIC -o ${out} -shared ${in}; mkdir -p ${gen_dir}/include; cp ${module_dir}/libblah/libblah.h ${module_dir}/libblah/libblah_feature.h ${gen_dir}/include/.",
     target: "host",
 }
 


### PR DESCRIPTION
The file extension being used (.so) was incorrect on macOS -
using ${out} ensures we use the right filename.

Change-Id: I80b1a3e6a63b4cb7e07a8e77e8531cba0ff625de
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>