### PR TITLE
Include implicit outputs in generated sources

### DIFF
--- a/core/generated.go
+++ b/core/generated.go
@@ -424,6 +424,11 @@ func getDepfileName(s string) string {
 	return s + ".d"
 }
 
+func (m *generateSource) processPaths(ctx abstr.BaseModuleContext, g generatorBackend) {
+	m.Properties.Implicit_srcs = utils.PrefixDirs(m.Properties.Implicit_srcs, ctx.ModuleDir())
+	m.generateCommon.processPaths(ctx, g)
+}
+
 func (m *generateSource) Inouts(ctx blueprint.ModuleContext, g generatorBackend) []inout {
 	var io inout
 	io.in = append(append(utils.PrefixDirs(m.getSources(ctx), g.sourcePrefix()),
@@ -433,7 +438,7 @@ func (m *generateSource) Inouts(ctx blueprint.ModuleContext, g generatorBackend)
 	if depfile, ok := m.getDepfile(g); ok {
 		io.depfile = depfile
 	}
-	io.implicitSrcs = utils.PrefixDirs(m.Properties.Implicit_srcs, filepath.Join(g.sourcePrefix(), ctx.ModuleDir()))
+	io.implicitSrcs = utils.PrefixDirs(m.Properties.Implicit_srcs, g.sourcePrefix())
 	io.implicitOuts = m.implicitOutputs(g)
 
 	return []inout{io}

--- a/tests/bootstrap_soong
+++ b/tests/bootstrap_soong
@@ -44,7 +44,6 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 DISABLE_TEST_DIRS=(
     external_libs
     generate_libs
-    implicit_outs
     match_source
     output
     source_encapsulation


### PR DESCRIPTION
Fix and enable the `implicit_outs` test on Soong by including implicit
outputs in the lists of generated sources and headers used by the
SourceFileGenerator interface methods.

Change-Id: Id1ab93d19b21c9a01ef2f1cdb9dbbb7ffed165ea
Signed-off-by: Chris Diamand <chris.diamand@arm.com>