### PR TITLE
Support ${module}_dir and ${module}_out

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -741,7 +741,7 @@ func (g *androidMkGenerator) generateCommonActions(sb *strings.Builder, m *gener
 	for _, inout := range inouts {
 		if _, ok := args["headers_generated"]; ok {
 			headers := utils.Filter(utils.IsHeader, inout.out, inout.implicitOuts)
-			args["header_generated"] = strings.Join(headers, " ")
+			args["headers_generated"] = strings.Join(headers, " ")
 		}
 		if _, ok := args["srcs_generated"]; ok {
 			sources := utils.Filter(utils.IsNotHeader, inout.out, inout.implicitOuts)

--- a/core/generated.go
+++ b/core/generated.go
@@ -335,7 +335,12 @@ func getDependentArgsAndFiles(ctx blueprint.ModuleContext, args map[string]strin
 			}
 
 			depName := ctx.OtherModuleName(m)
-			args[depName+"_dir"] = gen.outputDir(g)
+			// When the dependent module is another Bob generated module, provide
+			// the location of its output dir so the using module can pick and
+			// choose what it uses.
+			if _, ok := getGenerateCommon(m); ok {
+				args[depName+"_dir"] = gen.outputDir(g)
+			}
 			args[depName+"_out"] = strings.Join(gen.outputs(g), " ")
 			depfiles = append(depfiles, gen.outputs(g)...)
 			depfiles = append(depfiles, gen.implicitOutputs(g)...)

--- a/tests/bplist
+++ b/tests/bplist
@@ -2,6 +2,7 @@
 ./bob/Blueprints
 ./bob/blueprint/Blueprints
 ./build.bp
+./command_vars/build.bp
 ./cxx11_simple/build.bp
 ./export_cflags/liba/build.bp
 ./export_cflags/libb/build.bp

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -22,6 +22,7 @@ bob_alias {
     srcs: [
         "bob_test_aliases",
         "bob_test_aliases_all_variants",
+        "bob_test_command_vars",
         "bob_test_cxx11simple",
         "bob_test_export_cflags",
         "bob_test_export_include_dirs",

--- a/tests/command_vars/build.bp
+++ b/tests/command_vars/build.bp
@@ -1,0 +1,41 @@
+bob_generate_source {
+    name: "bob_test_generate_source_single",
+    out: [
+        "dir_and_outs.c",
+        "dir_and_outs.h",
+    ],
+    tool: "generate_trivial_function.py",
+    cmd: "${tool} module_dir_and_outs ${srcs_generated} ${headers_generated}",
+}
+
+bob_generate_source {
+    name: "bob_test_module_dep_dir_and_outs",
+    module_deps: ["bob_test_generate_source_single"],
+    out: [
+        "dir_and_outs.c",
+        "dir_and_outs.h",
+    ],
+    tool: "test_vars.py",
+    cmd: "${tool} --check-in-dir ${bob_test_generate_source_single_dir} ${bob_test_generate_source_single_out} " +
+        "--check-basename ${bob_test_generate_source_single_out} dir_and_outs.c dir_and_outs.h " +
+        "--copy ${bob_test_generate_source_single_out} ${gen_dir}",
+    export_gen_include_dirs: ["."],
+}
+
+// Compile the output of all of the above tests. This ensures that they are
+// actually built on Soong, until we get `mm` to successfully build targets
+// with custom rules.
+bob_binary {
+    name: "bob_test_command_vars",
+    srcs: ["main.c"],
+    cflags: [
+        "-Wall",
+        "-Werror",
+    ],
+    generated_sources: [
+        "bob_test_module_dep_dir_and_outs",
+    ],
+    generated_headers: [
+        "bob_test_module_dep_dir_and_outs",
+    ],
+}

--- a/tests/command_vars/generate_trivial_function.py
+++ b/tests/command_vars/generate_trivial_function.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+
+SOURCE_TEMPLATE = """int {name}(void) {{
+    return 0;
+}}
+"""
+
+HEADER_TEMPLATE = "int {name}(void);\n"
+
+
+def parse_args():
+    ap = argparse.ArgumentParser()
+
+    ap.add_argument("function_name")
+    ap.add_argument("source")
+    ap.add_argument("header")
+
+    return ap.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    for fname, template in [(args.source, SOURCE_TEMPLATE),
+                            (args.header, HEADER_TEMPLATE)]:
+        with open(fname, "wt") as fp:
+            fp.write(template.format(name=args.function_name))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/command_vars/main.c
+++ b/tests/command_vars/main.c
@@ -1,0 +1,5 @@
+#include "dir_and_outs.h"
+
+int main(void) {
+    return module_dir_and_outs();
+}

--- a/tests/command_vars/test_vars.py
+++ b/tests/command_vars/test_vars.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import shutil
+
+
+def parse_args():
+    ap = argparse.ArgumentParser()
+
+    ap.add_argument("--check-basename", nargs="+", action="append", metavar=("PATH ...", "BASE"))
+    ap.add_argument("--check-in-dir", nargs="+", action="append", metavar=("DIR", "PATH"))
+    ap.add_argument("--copy", nargs="+", action="append", metavar=("SRC", "DEST"))
+
+    return ap.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    for check in args.check_in_dir:
+        assert len(check) >= 2, "Path and directory required"
+        check_dir = os.path.normpath(check[0])
+        for path in check[1:]:
+            path = os.path.normpath(path)
+            assert path.startswith(check_dir), \
+                "'%s' is not inside directory '%s'" % (path, check_dir)
+
+    for check in args.check_basename:
+        # The first half of the arguments are paths, the second are basenames
+        paths = check[0:int(len(check)/2)]
+        basenames = check[int(len(check)/2):]
+        assert len(paths) == len(basenames), "All paths must have a corresponding basename"
+        for path, basename in zip(paths, basenames):
+            assert os.path.basename(path) == basename, \
+                   "basename of '%s' is not equal to '%s'" % (path, basename)
+
+    for copy in args.copy:
+        assert len(copy) >= 2, "At least one source and destination required"
+        srcs = copy[:-1]
+        dest = copy[-1]
+        assert len(srcs) == 1 or os.path.isdir(dest), \
+            "Destination must be an existing directory when copying multiple sources"
+
+        for src in srcs:
+            shutil.copy(src, dest)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add support for more of the command variables we need for generated
sources on Soong, in this case ${module}_dir and ${module}_out, and add
a test.

Change-Id: I0e134e52c75dd1ceba6b452e195d04469159f993
Signed-off-by: Chris Diamand <chris.diamand@arm.com>