### PR TITLE
Disable forwarding_libs test on macOS

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -105,3 +105,10 @@ Note that not all Bob features are supported on Android. This includes:
 
 * Aliases
 * Versioned libraries
+
+## macOS support
+
+Building on macOS is supported, however, some features are not available,
+namely:
+
+* Forwarding libraries

--- a/tests/forwarding_libs/forwarding/build.bp
+++ b/tests/forwarding_libs/forwarding/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2019 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,9 +22,12 @@ bob_shared_library {
     forwarding_shlib: true,
     srcs: [],
     build_by_default: true,
-    // Android uses the gold linker, which doesn't support
+    // Android and macOS use linkers which don't support
     // --copy-dt-needed-entries, so forwarding libraries won't work.
     android: {
+        enabled: false,
+    },
+    osx: {
         enabled: false,
     },
 }

--- a/tests/forwarding_libs/forwarding_user/build.bp
+++ b/tests/forwarding_libs/forwarding_user/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2019 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,9 +19,12 @@ bob_binary {
     name: "forwarding_user",
     srcs: ["main.c"],
     shared_libs: ["libforwarding"],
-    // Android uses the gold linker, which doesn't support
+    // Android and macOS use linkers which don't support
     // --copy-dt-needed-entries, so forwarding libraries won't work.
     android: {
+        enabled: false,
+    },
+    osx: {
         enabled: false,
     },
 }


### PR DESCRIPTION
forwarding_libs tests use --copy-dt-needed-entries flags
that are not supported by ld on macOS.

Change-Id: I0d006bae944ce22ebb5bf5565b88a27be4a69c11
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>