### PR TITLE
Fix reexport_libs test on macOS

### DIFF
--- a/tests/reexport_libs/build.bp
+++ b/tests/reexport_libs/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2019 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,7 +54,7 @@ bob_static_library {
 
 bob_static_library {
     name: "lib_reexport_level_2",
-    srcs: ["export.cpp"],
+    srcs: ["export_2.cpp"],
 
     whole_static_libs: ["lib_reexport_level_1"],
 
@@ -64,7 +64,7 @@ bob_static_library {
 
 bob_static_library {
     name: "lib_reexport_level_3",
-    srcs: ["export.cpp"],
+    srcs: ["export_3.cpp"],
 
     whole_static_libs: ["lib_reexport_level_2"],
 

--- a/tests/reexport_libs/export.cpp
+++ b/tests/reexport_libs/export.cpp
@@ -1,11 +1,11 @@
 #include <hidden.h>
 
-static void checkForHiddenAvability()
+static void checkForHiddenAvailibility()
 {
 	hiddenFunction();
 }
 
 void silenceUnusedFunctionError()
 {
-    checkForHiddenAvability();
+	checkForHiddenAvailibility();
 }

--- a/tests/reexport_libs/export_2.cpp
+++ b/tests/reexport_libs/export_2.cpp
@@ -1,0 +1,11 @@
+#include <hidden.h>
+
+static void checkForHiddenAvailibility_2()
+{
+	hiddenFunction();
+}
+
+void silenceUnusedFunctionError_2()
+{
+	checkForHiddenAvailibility_2();
+}

--- a/tests/reexport_libs/export_3.cpp
+++ b/tests/reexport_libs/export_3.cpp
@@ -1,0 +1,11 @@
+#include <hidden.h>
+
+static void checkForHiddenAvailibility_3()
+{
+	hiddenFunction();
+}
+
+void silenceUnusedFunctionError_3()
+{
+	checkForHiddenAvailibility_3();
+}


### PR DESCRIPTION
reexport_libs test was broken on macOS because multiple static
libraries in this test were all compiling export.c and hence `ar`
was being called with option `N` that is unsupported on macOS.

Change-Id: I887c2cdb64bcdec24622751b51dc4bffc444794e
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>