### PR TITLE
Introduce new 'warning' token to the syntax.

### DIFF
--- a/config_system/config_system/__init__.py
+++ b/config_system/config_system/__init__.py
@@ -31,6 +31,7 @@ from config_system.general import \
     get_config_string, \
     get_options_depending_on, \
     get_options_selecting, \
+    get_warning, \
     init_config, \
     read_config, \
     set_config  # nopep8: E402 module level import not at top of file

--- a/config_system/config_system/general.py
+++ b/config_system/config_system/general.py
@@ -185,6 +185,15 @@ def get_options_depending_on(dependent):
     return enabled_options
 
 
+def get_warning(key):
+    """
+    Returns the warning associated with the given config option.
+    Returns None if there isn't an associated warning.
+    """
+    opt = data.get_config(key)
+    return opt.get('warning', None)
+
+
 def set_initial_values():
     "Set all configuration objects to their default value"
 

--- a/config_system/config_system/lex.py
+++ b/config_system/config_system/lex.py
@@ -51,6 +51,7 @@ tokens = (
     "SOURCE_LOCAL",
     "STRING",
     "VISIBLE",
+    "WARNING",
     "YES", "NO",
     "COMMENT",
 )
@@ -78,6 +79,7 @@ commands = (
     "source_local",
     "string",
     "visible",
+    "warning",
 )
 
 params = ("if", "on")

--- a/config_system/config_system/syntax.py
+++ b/config_system/config_system/syntax.py
@@ -288,6 +288,7 @@ def p_config_options(p):
                       | config_options config_depends
                       | config_options config_help
                       | config_options config_prompt
+                      | config_options config_warning
                       """
     p[0] = merge(p[1], p[2])
 
@@ -458,6 +459,11 @@ def p_helptext(p):
         p[0] = ""
     else:
         p[0] = p[1] + "\n" + p[2]
+
+
+def p_config_warning(p):
+    "config_warning : WARNING QUOTED_STRING EOL"
+    p[0] = {"warning": p[2]}
 
 
 def p_error(p):

--- a/config_system/mconfigfmt.py
+++ b/config_system/mconfigfmt.py
@@ -41,7 +41,7 @@ def perform_formatting(file_path, output):
 # Sets grouping tokens into types
 set_config_props = {"BOOL", "INT", "STRING", "PROMPT",
                     "DEFAULT", "DEPENDS", "SELECT",
-                    "VISIBLE", "HELP"}
+                    "VISIBLE", "HELP", "WARNING"}
 set_binary_ops = {"ANDAND", "OROR",
                   "EQUAL", "UNEQUAL", "LESS", "LESS_EQUAL", "GREATER", "GREATER_EQUAL",
                   "PLUS", "MINUS"}

--- a/docs/config_system.md
+++ b/docs/config_system.md
@@ -114,6 +114,7 @@ config OPTION_NAME
 	default n|y|"hello"|1234 if D || E
 	default n
 	select ANOTHER_OPTION
+	warning "warning text when option enabled"
 	help
 		This is a longer, possibly multiline help text
 		describing OPTION_NAME.


### PR DESCRIPTION
This token is used to mark a config option with a
custom warning message. The token must be followed
by a quoted string.

Change-Id: Id058b854cb7a77bc114c2228a62a24f65d107adb
Signed-off-by: Dzanan Bajgoric <dzanan.bajgoric@arm.com>
Signed-off-by: David Kilroy <david.kilroy@arm.com>