### PR TITLE
Enable simple_binary test

### DIFF
--- a/tests/bplist
+++ b/tests/bplist
@@ -1,4 +1,5 @@
 ./aliases/build.bp
+./binary/build.bp
 ./bob/Blueprints
 ./bob/blueprint/Blueprints
 ./build.bp

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -40,6 +40,7 @@ bob_alias {
         "bob_test_reexport_libs",
         "bob_test_resources",
         "bob_test_shared_libs",
+        "bob_test_simple_binary",
         "bob_test_source_encapsulation",
         "bob_test_static_libs",
         "bob_test_templates",


### PR DESCRIPTION
The simple_binary test was missing from `tests/build.bp` and `tests/bplist`.

Change-Id: I97770d8816734930af5bf409bf288ab4ea9aeecc
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>