### PR TITLE
Reduce scope of ModuleDir on Soong

### DIFF
--- a/bootstrap_soong.bash
+++ b/bootstrap_soong.bash
@@ -64,6 +64,7 @@ sed -e "s#@@BOB_CONFIG_OPTS@@#${BOB_CONFIG_OPTS}#" \
     -e "s#@@BUILDDIR@@#${BUILDDIR}#" \
     -e "s#@@CONFIGNAME@@#${CONFIGNAME}#" \
     -e "s#@@CONFIG_JSON@@#${CONFIG_JSON}#" \
+    -e "s#@@SRCDIR@@#${SRCDIR}#" \
     "${BOB_DIR}/core/soong_config.go.in" > "${TMP_GO_CONFIG}"
 rsync --checksum "${TMP_GO_CONFIG}" "${SOONG_CONFIG_GO}"
 rm -f "${TMP_GO_CONFIG}"

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -159,7 +159,7 @@ func (s *SourceProps) getSources(ctx abstr.BaseModuleContext) []string {
 }
 
 func (s *SourceProps) processPaths(ctx abstr.BaseModuleContext, g generatorBackend) {
-	prefix := ctx.ModuleDir()
+	prefix := projectModuleDir(ctx)
 	var special = map[string]string{
 		"${bob_config}": filepath.Join(g.buildDir(), configName),
 	}

--- a/core/filepath.go
+++ b/core/filepath.go
@@ -68,7 +68,7 @@ func (file sourceFilePath) moduleDir() string {
 }
 
 func newSourceFilePath(path string, ctx abstr.BaseModuleContext, g generatorBackend) filePath {
-	return sourceFilePath{path, ctx.ModuleDir(), g.sourcePrefix()}
+	return sourceFilePath{path, projectModuleDir(ctx), g.sourcePrefix()}
 }
 
 // Represents a file created in the generated output directory

--- a/core/generated.go
+++ b/core/generated.go
@@ -430,7 +430,7 @@ func getDepfileName(s string) string {
 }
 
 func (m *generateSource) processPaths(ctx abstr.BaseModuleContext, g generatorBackend) {
-	m.Properties.Implicit_srcs = utils.PrefixDirs(m.Properties.Implicit_srcs, ctx.ModuleDir())
+	m.Properties.Implicit_srcs = utils.PrefixDirs(m.Properties.Implicit_srcs, projectModuleDir(ctx))
 	m.generateCommon.processPaths(ctx, g)
 }
 

--- a/core/install.go
+++ b/core/install.go
@@ -99,7 +99,7 @@ type InstallableProps struct {
 
 func (props *InstallableProps) processPaths(ctx abstr.BaseModuleContext, g generatorBackend) {
 	if props.Post_install_tool != nil {
-		*props.Post_install_tool = filepath.Join(g.sourcePrefix(), ctx.ModuleDir(), *props.Post_install_tool)
+		*props.Post_install_tool = filepath.Join(g.sourcePrefix(), projectModuleDir(ctx), *props.Post_install_tool)
 	}
 }
 

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -209,7 +209,7 @@ func (m *kernelModule) generateKbuildArgs(ctx abstr.VisitableModuleContext) kbui
 		KernelCrossCompile: m.Properties.Build.Kernel_cross_compile,
 		KbuildOptions:      kbuildOptions,
 		MakeArgs:           strings.Join(m.Properties.Build.Make_args, " "),
-		OutputModuleDir:    filepath.Join(m.outputDir(g), ctx.ModuleDir()),
+		OutputModuleDir:    filepath.Join(m.outputDir(g), projectModuleDir(ctx)),
 		CCFlag:             kernelToolchain,
 		HostCCFlag:         hostToolchain,
 		ClangTripleFlag:    clangTriple,

--- a/core/library.go
+++ b/core/library.go
@@ -260,7 +260,7 @@ func (l *Build) getBuildWrapperAndDeps(ctx blueprint.ModuleContext) (string, []s
 // Add module paths to srcs, exclude_srcs, local_include_dirs, export_local_include_dirs
 // and post_install_tool
 func (l *Build) processPaths(ctx abstr.BaseModuleContext, g generatorBackend) {
-	prefix := ctx.ModuleDir()
+	prefix := projectModuleDir(ctx)
 	l.SourceProps.processPaths(ctx, g)
 	l.InstallableProps.processPaths(ctx, g)
 	l.Local_include_dirs = utils.PrefixDirs(l.Local_include_dirs, prefix)

--- a/core/soong_config.go.in
+++ b/core/soong_config.go.in
@@ -26,15 +26,7 @@ var (
 	configName = "@@CONFIGNAME@@"
 	configOpts = "@@BOB_CONFIG_OPTS@@"
 	jsonPath   = "@@CONFIG_JSON@@"
-
-	// The working directory is always the root of the Android source tree, but,
-	// unlike the `Android.mk` backend, ModuleDir() will always include the full
-	// path from the Android root (not from the project directory). This means
-	// that joining `${workdir}/${srcdir}/${moduledir}/file.c` would not be a
-	// valid path, if srcdir actually contained the path to the project root,
-	// because that's also included in moduledir. Work around this by leaving
-	// srcdir empty on Soong.
-	srcdir = ""
+	srcdir     = "@@SRCDIR@@"
 )
 
 func getBuildDir() string {

--- a/core/soong_gen.go
+++ b/core/soong_gen.go
@@ -143,6 +143,8 @@ func (m *genBackend) getHostBin(ctx android.ModuleContext) string {
 }
 
 func (m *genBackend) getArgs(ctx android.ModuleContext) (args map[string]string, dependents []android.Path) {
+	g := getBackend(ctx)
+
 	dependents = android.PathsForSource(ctx, m.Properties.Implicit_srcs)
 	args = map[string]string{
 		"bob_config":      filepath.Join(getBuildDir(), configName),
@@ -155,6 +157,7 @@ func (m *genBackend) getArgs(ctx android.ModuleContext) (args map[string]string,
 		"cxxflags":        utils.Join(m.Properties.Cxxflags),
 		"ldflags":         utils.Join(m.Properties.Ldflags),
 		"ldlibs":          utils.Join(m.Properties.Ldlibs),
+		"src_dir":         g.sourcePrefix(),
 
 		// flag_defaults is primarily used to invoke sub-makes of
 		// different libraries. This shouldn't be needed on Android.
@@ -249,7 +252,7 @@ func (m *genBackend) GenerateAndroidBuildActions(ctx android.ModuleContext) {
 
 	if len(m.Properties.Out) > 0 {
 		sio := soongInout{
-			in:           android.PathsForSource(ctx, m.Properties.Srcs),
+			in:           android.PathsForSource(ctx, utils.PrefixDirs(m.Properties.Srcs, srcdir)),
 			implicitSrcs: implicits,
 			out:          pathsForModuleGen(ctx, m.Properties.Out),
 			implicitOuts: pathsForModuleGen(ctx, m.Properties.Implicit_outs),

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -45,6 +45,10 @@ type moduleBase struct {
 	blueprint.SimpleName
 }
 
+func projectModuleDir(ctx abstr.BaseModuleContext) string {
+	return ctx.ModuleDir()
+}
+
 func getConfig(ctx abstr.BaseModuleContext) *bobConfig {
 	return ctx.(blueprint.BaseModuleContext).Config().(*bobConfig)
 }

--- a/tests/bootstrap_soong
+++ b/tests/bootstrap_soong
@@ -47,7 +47,6 @@ DISABLE_TEST_DIRS=(
     match_source
     output
     source_encapsulation
-    transform_source
 )
 
 for TEST_DIR in "${DISABLE_TEST_DIRS[@]}"; do


### PR DESCRIPTION
In the Soong plugin, unlike the Android.mk backend, calls to
`ModuleDir()` return the whole path from the root of the Android tree up
to the directory containing `Android.bp`. This means that setting srcdir
would be nonsensical, because the project root is included by
`ModuleDir()`.

However, this makes a few things difficult:
 - Transform source regex matching has different behaviour than on the
   other backends, because more of the path is included when matching
   the regular expression.
 - We need to know srcdir for other reasons, for example as a variable
   available to generate_source commands.

Fix the above two issues by wrapping calls to `ctx.ModuleDir()` with a
new helper, `projectModuleDir()`, which returns the location of an
`Android.bp` file relative to the project root, rather than the Android
root.

This fits quite neatly into our current handling of paths:
 - srcdir is now a path relative to the working directory.
 - After the processPaths mutator, source paths are still relative to
   the project dir.
 - Later, we convert everything into "full" paths by prefixing with
   `g.srcPrefix()` or `g.buildDir()`, as appropriate.

Change-Id: Id19163d141fc4e2b4fa9b7f87c39ba2a46ea0af2
Signed-off-by: Chris Diamand <chris.diamand@arm.com>