### PR TITLE
Actually link fake kernel modules together

### DIFF
--- a/scripts/kmod_build.py
+++ b/scripts/kmod_build.py
@@ -184,6 +184,11 @@ if __name__ == "__main__":
     # Add a dependency on copy_with_deps.py, which won't have been set by Bob
     deps.append(os.path.join(os.path.dirname(sys.argv[0]), "copy_with_deps.py"))
 
+    # Add a dependency on the test kernel Makefile. We do not attempt to add
+    # dependencies on every part of the kernel's build system - this is just
+    # enough to ensure that incremental builds of the Bob tests work OK.
+    deps.append(os.path.join(abs_kdir, "Makefile"))
+
     copy_with_deps.write_depfile(args.depfile, args.output, deps)
 
     make_args = args.make_args

--- a/tests/kernel_module/kdir/Makefile
+++ b/tests/kernel_module/kdir/Makefile
@@ -13,11 +13,18 @@ DEPFILES += $(addprefix $(M)/,$(obj-m:.o=.d))
 CPPFLAGS := -Iinclude -MMD -MP
 CFLAGS := -fPIC $(EXTRA_CFLAGS)
 
+# Test that KBUILD_EXTRA_SYMBOLS is correct by actually linking dependent
+# modules together. Each Module.symvers file contains the basename of the
+# module it was generated with, so that we can pass it to `-l`. Use the
+# `:filename` syntax for `-l`, because this allows linking with libraries whose
+# names are not of the form `lib*.so`.
+DEPENDENT_MODULES := $(foreach symvers,$(KBUILD_EXTRA_SYMBOLS),-L $(dir $(symvers)) -l:$(shell cat $(symvers)))
+
 all: $(MODULES)
 
 $(M)/%.ko: $(M)/%.o
-	@$(CROSS_COMPILE)gcc -shared $< -o $@
-	@echo > $(M)/Module.symvers
+	@$(CROSS_COMPILE)gcc -Wl,--no-undefined -shared $< -o $@ $(DEPENDENT_MODULES)
+	@echo $(@F) > $(M)/Module.symvers
 
 %.o: %.c
 	@$(CROSS_COMPILE)gcc -c -o $@ $(CPPFLAGS) $(CFLAGS) $<


### PR DESCRIPTION
Improve the kernel module testing by examining KBUILD_EXTRA_SYMBOLS to
try and actually link to related modules.

Add a dependency on $KDIR/Makefile - we should probably have this
anyway, but in this case it ensures that the kernel module tests will
still pass when doing incremental builds of the Bob tests.

Change-Id: I5b16dfe45f4785368e0f9b52b6d977ab484be1f4
Signed-off-by: Chris Diamand <chris.diamand@arm.com>