### PR TITLE
Fix output test on macOS

### DIFF
--- a/tests/output/build.bp
+++ b/tests/output/build.bp
@@ -45,8 +45,8 @@ bob_generate_source {
     out: ["generated_output"],
     tool: "verify.py",
     cmd: "python ${tool} --out='${binary_output_out}' --expected='bob_output' && " +
-        "python ${tool} --out='${lib_sh_output_out}' --expected='libshared_output.so' && " +
-        "python ${tool} --out='${lib_st_output_out}' --expected='static_output.a' && " +
+        "python ${tool} --out='${lib_sh_output_out}' --expected='libshared_output' --shared && " +
+        "python ${tool} --out='${lib_st_output_out}' --expected='static_output' --static && " +
         "cp ${binary_output_out} ${out}",
 }
 

--- a/tests/output/verify.py
+++ b/tests/output/verify.py
@@ -20,13 +20,29 @@ from __future__ import print_function
 import argparse
 import sys
 import os
+import platform
 
 parser = argparse.ArgumentParser(description='Test generator.')
 parser.add_argument('--out')
 parser.add_argument('--expected')
+group = parser.add_mutually_exclusive_group()
+group.add_argument('--shared', help='use .so or .dylib extension', action='store_true')
+group.add_argument('--static', help='use .a extension', action='store_true')
 
 args = parser.parse_args()
 
-if os.path.basename(args.out) != args.expected:
-    print("Output from generation: {} but expected: {}".format(args.out, args.expected))
+if args.shared:
+    if platform.system() == 'Darwin':
+        extension = '.dylib'
+    else:
+        extension = '.so'
+elif args.static:
+    extension = '.a'
+else:
+    extension = ''
+
+expected = args.expected + extension
+
+if os.path.basename(args.out) != expected:
+    print("Output from generation: {} but expected: {}".format(args.out, expected))
     sys.exit(1)


### PR DESCRIPTION
Use `.dylib` on macOS and `.so` on Linux and Android.

Change-Id: I3844cfb197874b95a15228e3bb468eb29815e35a
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>