### PR TITLE
Fix `scripts/strip.py` on macOS

### DIFF
--- a/scripts/strip.py
+++ b/scripts/strip.py
@@ -55,7 +55,7 @@ def create_debug_info(fname, dbg, tool):
 
 def write_output(fname, output, dbg, strip, tool):
     if os.path.basename(tool) == "dsymutil":
-        run(["strip", "-S", "-o", output, fname])
+        run(["strip", "-o", output, fname])
     else:
         cmd = [tool]
         if dbg:

--- a/tests/build_tests.sh
+++ b/tests/build_tests.sh
@@ -15,8 +15,17 @@ function check_installed() {
 # File must be stripped
 function check_stripped() {
     local FILE="${1}"
+    local OS="${2}"
 
-    [ $(nm -a "${FILE}" | wc -l) = "0" ] || { echo "${FILE} not stripped" ; false; }
+    if [ "$OS" != "OSX" ] ; then
+        [ $(nm -a "${FILE}" | wc -l) = "0" ] || { echo "${FILE} not stripped" ; false; }
+    else
+        # The two symbols below are always expected on macOS
+        [ $(nm -a "${FILE}" | grep -Ev " (dyld_stub_binder|__mh_execute_header)$" | wc -l) = "0" ] || {
+            echo "${FILE} not stripped"
+            false
+        }
+    fi
 }
 
 case "$(uname -s)" in
@@ -44,8 +53,8 @@ function check_build_output() {
     check_installed "${DIR}/install/bin/stripped_binary"
 
     # The stripped library must not contain symbols
-    check_stripped "${DIR}/install/lib/libstripped_library${SHARED_LIBRARY_EXTENSION}"
-    check_stripped "${DIR}/install/bin/stripped_binary"
+    check_stripped "${DIR}/install/lib/libstripped_library${SHARED_LIBRARY_EXTENSION}" "$OS"
+    check_stripped "${DIR}/install/bin/stripped_binary" "$OS"
 }
 
 export TEST_NON_ASCII_IN_ENV_HASH='ó'


### PR DESCRIPTION
This commit updates `scripts/strip.py` to remove the symbols correctly.
The check using `nm` in `tests/build_tests.sh` is updated to ignore
`dyld_stub_binder` and `__mh_execute_header` on macOS.

Change-Id: Ib6322e99ac0b022c3c4ac7888ee63f5b9a5b0f89
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>