### PR TITLE
Fix bootstrap version test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ cache:
   directories:
     - $HOME/ninjabin
 
-jobs:
-  allow_failures:
-    - os: osx
-
 addons:
   apt:
     packages:

--- a/.travis/run_bootstrap_test.sh
+++ b/.travis/run_bootstrap_test.sh
@@ -8,6 +8,17 @@ BOB_ROOT="${SCRIPT_DIR}/.."
 COMMIT=$(git rev-parse HEAD)
 PARENT=$(git merge-base origin/master ${COMMIT})
 
+case "$(uname -s)" in
+    Darwin*)
+        OS=OSX
+        ;;
+    *)
+        OS=LINUX
+        ;;
+esac
+
+OPTIONS="$OS=y"
+
 # Check if version update file was changed and if not verify Bob build
 if git diff --name-only ${PARENT} ${COMMIT} | grep -q "bob.bootstrap.version" ; then
     echo "Bob version file has changed between parent and current commit. Skipping verification step"
@@ -17,7 +28,7 @@ else
     cd "${BOB_ROOT}/tests"
     rm -rf ${build_dir} # Cleanup test directory
     ./bootstrap -o ${build_dir}
-    ${build_dir}/config && ${build_dir}/buildme bob_tests
+    ${build_dir}/config ${OPTIONS} && ${build_dir}/buildme bob_tests
 
     # Wait for filesystems with low timestamp resolution
     sleep 1


### PR DESCRIPTION
Pass `OSX=y` to `${build_dir}/config` on macOS.

Change-Id: I63833f4065b48d05fb346fcc240e46d95f1a377a
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>