### PR TITLE
Soong kernel module fixes

### DIFF
--- a/scripts/kmod_build.py
+++ b/scripts/kmod_build.py
@@ -64,8 +64,15 @@ def build_module(output_dir, module_ko, kdir, module_dir, make_command, make_arg
     # Invoke the kernel build system
     cmd = [make_command, "-C", kdir, "M=" + module_dir, "EXTRA_CFLAGS=" + extra_cflags]
     cmd.extend(make_args)
+
+    # Sanitize the environment - we should only use build options passed in via
+    # the command line.
+    env = dict(os.environ)
+    for var in ["ARCH", "CROSS_COMPILE", "CC", "HOSTCC", "CLANG_TRIPLE", "KBUILD_EXTRA_SYMBOLS"]:
+        env.pop(var, None)
+
     try:
-        subprocess.check_call(cmd)
+        subprocess.check_call(cmd, env=env)
     except subprocess.CalledProcessError as e:
         logger.error("Command failed: %s", str(e.cmd))
         sys.exit(e.returncode)


### PR DESCRIPTION
Correct the source and output directory paths when invoking the kernel
building script, and sanitize the environment so that kernel build
configuration is _only_ controlled by the module properties.

Change-Id: Id508118c7a091106dd4777906d9501bc16f5810d
Signed-off-by: Chris Diamand <chris.diamand@arm.com>