### PR TITLE
Update to support soong aosp branch

### DIFF
--- a/abstr/contexts.go
+++ b/abstr/contexts.go
@@ -67,10 +67,6 @@ type TopDownMutatorContext interface {
 
 	OtherModuleExists(name string) bool
 	Rename(name string)
-	// No `Module()` method in top down contexts, because Soong's version
-	// uses android.Module instead of blueprint.Module.
-
-	CreateModule(blueprint.ModuleFactory, ...interface{})
 
 	GetDirectDepWithTag(name string, tag blueprint.DependencyTag) blueprint.Module
 	GetDirectDep(name string) (blueprint.Module, blueprint.DependencyTag)
@@ -79,12 +75,9 @@ type TopDownMutatorContext interface {
 // Common functions in blueprint.BottomUpMutatorContext and android.BottomUpMutatorContext
 type BottomUpMutatorContext interface {
 	BaseModuleContext
-	Module() blueprint.Module
 
 	AddDependency(module blueprint.Module, tag blueprint.DependencyTag, name ...string)
 	AddReverseDependency(module blueprint.Module, tag blueprint.DependencyTag, name string)
-	CreateVariations(...string) []blueprint.Module
-	CreateLocalVariations(...string) []blueprint.Module
 	SetDependencyVariation(string)
 	AddVariationDependencies([]blueprint.Variation, blueprint.DependencyTag, ...string)
 	AddFarVariationDependencies([]blueprint.Variation, blueprint.DependencyTag, ...string)

--- a/abstr/soong.go
+++ b/abstr/soong.go
@@ -38,20 +38,20 @@ type visitableModuleContext interface {
 	VisitDirectDepsIf(func(android.Module) bool, func(android.Module))
 }
 
-func TopDownAdaptor(f func(TopDownMutatorContext)) android.AndroidTopDownMutator {
+func TopDownAdaptor(f func(TopDownMutatorContext)) android.TopDownMutator {
 	return func(mctx android.TopDownMutatorContext) {
 		f(mctx)
 	}
 }
 
-func BottomUpAdaptor(f func(BottomUpMutatorContext)) android.AndroidBottomUpMutator {
+func BottomUpAdaptor(f func(BottomUpMutatorContext)) android.BottomUpMutator {
 	return func(mctx android.BottomUpMutatorContext) {
 		f(mctx)
 	}
 }
 
-func Module(mctx TopDownMutatorContext) blueprint.Module {
-	return mctx.(android.TopDownMutatorContext).Module()
+func Module(mctx BaseModuleContext) blueprint.Module {
+	return mctx.(android.BaseModuleContext).Module()
 }
 
 func WalkDeps(mctx VisitableModuleContext, f func(blueprint.Module, blueprint.Module) bool) {
@@ -69,4 +69,8 @@ func VisitDirectDepsIf(mctx VisitableModuleContext, pred func(blueprint.Module) 
 		f(dep)
 	}
 	mctx.VisitDirectDepsIf(androidPred, androidFunc)
+}
+
+func CreateVariations(mctx BottomUpMutatorContext, variationNames ...string) []android.Module {
+	return mctx.(android.BottomUpMutatorContext).CreateVariations(variationNames...)
 }

--- a/abstr/standalone.go
+++ b/abstr/standalone.go
@@ -38,8 +38,8 @@ func BottomUpAdaptor(f func(BottomUpMutatorContext)) blueprint.BottomUpMutator {
 	}
 }
 
-func Module(mctx TopDownMutatorContext) blueprint.Module {
-	return mctx.(blueprint.TopDownMutatorContext).Module()
+func Module(mctx BaseModuleContext) blueprint.Module {
+	return mctx.(blueprint.BaseModuleContext).Module()
 }
 
 func WalkDeps(mctx VisitableModuleContext, f func(blueprint.Module, blueprint.Module) bool) {
@@ -48,4 +48,8 @@ func WalkDeps(mctx VisitableModuleContext, f func(blueprint.Module, blueprint.Mo
 
 func VisitDirectDepsIf(mctx VisitableModuleContext, pred func(blueprint.Module) bool, f func(blueprint.Module)) {
 	mctx.VisitDirectDepsIf(pred, f)
+}
+
+func CreateVariations(mctx BottomUpMutatorContext, variationNames ...string) []blueprint.Module {
+	return mctx.(blueprint.BottomUpMutatorContext).CreateVariations(variationNames...)
 }

--- a/core/defaults.go
+++ b/core/defaults.go
@@ -64,17 +64,17 @@ type defaultable interface {
 }
 
 func defaultDepsMutator(mctx abstr.BottomUpMutatorContext) {
-	if l, ok := mctx.Module().(defaultable); ok {
-		mctx.AddDependency(mctx.Module(), defaultDepTag, l.defaults()...)
+	if l, ok := abstr.Module(mctx).(defaultable); ok {
+		mctx.AddDependency(abstr.Module(mctx), defaultDepTag, l.defaults()...)
 	}
-	if gsc, ok := getGenerateCommon(mctx.Module()); ok {
+	if gsc, ok := getGenerateCommon(abstr.Module(mctx)); ok {
 		if len(gsc.Properties.Flag_defaults) > 0 {
 			tgt := gsc.Properties.Target
 			if !(tgt == tgtTypeHost || tgt == tgtTypeTarget) {
 				panic(fmt.Errorf("Module %s uses flag_defaults '%v' but has invalid target type '%s'",
 					mctx.ModuleName(), gsc.Properties.Flag_defaults, tgt))
 			}
-			mctx.AddDependency(mctx.Module(), defaultDepTag, gsc.Properties.Flag_defaults...)
+			mctx.AddDependency(abstr.Module(mctx), defaultDepTag, gsc.Properties.Flag_defaults...)
 		}
 	}
 }

--- a/core/generated.go
+++ b/core/generated.go
@@ -609,7 +609,7 @@ func getGeneratedFiles(ctx blueprint.ModuleContext, g generatorBackend) []string
 }
 
 func generatedDependerMutator(mctx abstr.BottomUpMutatorContext) {
-	if e, ok := mctx.Module().(enableable); ok {
+	if e, ok := abstr.Module(mctx).(enableable); ok {
 		if !isEnabled(e) {
 			// Not enabled, so don't add dependencies
 			return
@@ -617,19 +617,19 @@ func generatedDependerMutator(mctx abstr.BottomUpMutatorContext) {
 	}
 
 	// Things which depend on generated/transformed sources
-	if gd, ok := mctx.Module().(generatedDepender); ok {
-		if _, ok := mctx.Module().(*defaults); ok {
+	if gd, ok := abstr.Module(mctx).(generatedDepender); ok {
+		if _, ok := abstr.Module(mctx).(*defaults); ok {
 			// We do not want to add dependencies for defaults
 			return
 		}
 		b := gd.build()
-		mctx.AddDependency(mctx.Module(), generatedSourceTag, b.Generated_sources...)
-		mctx.AddDependency(mctx.Module(), generatedHeaderTag, b.Generated_headers...)
-		mctx.AddDependency(mctx.Module(), generatedDepTag, b.Generated_deps...)
+		mctx.AddDependency(abstr.Module(mctx), generatedSourceTag, b.Generated_sources...)
+		mctx.AddDependency(abstr.Module(mctx), generatedHeaderTag, b.Generated_headers...)
+		mctx.AddDependency(abstr.Module(mctx), generatedDepTag, b.Generated_deps...)
 	}
 
 	// Things that a generated/transformed source depends on
-	if gsc, ok := getGenerateCommon(mctx.Module()); ok {
+	if gsc, ok := getGenerateCommon(abstr.Module(mctx)); ok {
 		if gsc.Properties.Host_bin != nil {
 			parseAndAddVariationDeps(mctx, hostToolBinTag,
 				proptools.String(gsc.Properties.Host_bin))

--- a/core/library.go
+++ b/core/library.go
@@ -673,7 +673,7 @@ func getLibrary(m blueprint.Module) (*library, bool) {
 }
 
 func checkLibraryFieldsMutator(mctx abstr.BottomUpMutatorContext) {
-	m := mctx.Module()
+	m := abstr.Module(mctx)
 	if b, ok := m.(*binary); ok {
 		props := b.Properties
 		b.checkField(len(props.Export_cflags) == 0, "export_cflags")
@@ -849,7 +849,7 @@ const (
 )
 
 func (handler *graphMutatorHandler) ResolveDependencySortMutator(mctx abstr.BottomUpMutatorContext) {
-	mainModule := mctx.Module()
+	mainModule := abstr.Module(mctx)
 	if e, ok := mainModule.(enableable); ok {
 		if !isEnabled(e) {
 			return // Not enabled, so not needed

--- a/core/soong_kernel_module.go
+++ b/core/soong_kernel_module.go
@@ -86,7 +86,7 @@ func (m *kernelModule) soongBuildActions(mctx android.TopDownMutatorContext) {
 	}
 
 	// create module and fill all its registered properties with data from prepared structs
-	mctx.CreateModule(android.ModuleFactoryAdaptor(kernelModuleBackendFactory), &nameProps, provenanceProps, &props)
+	mctx.CreateModule(kernelModuleBackendFactory, &nameProps, provenanceProps, &props)
 }
 
 func (m *kernelModuleBackend) DepsMutator(mctx android.BottomUpMutatorContext) {

--- a/core/splitter.go
+++ b/core/splitter.go
@@ -116,12 +116,12 @@ func tgtToString(tgts []tgtType) []string {
 
 // Creates all the supported variants of splittable modules, including defaults.
 func splitterMutator(mctx abstr.BottomUpMutatorContext) {
-	if s, ok := mctx.Module().(splittable); ok {
+	if s, ok := abstr.Module(mctx).(splittable); ok {
 		variants := tgtToString(s.supportedVariants())
 		if len(variants) == 0 {
 			s.disable()
 		} else {
-			modules := mctx.CreateVariations(variants...)
+			modules := abstr.CreateVariations(mctx, variants...)
 			for i, v := range variants {
 				newsplit, ok := modules[i].(splittable)
 				if !ok {

--- a/tests/bootstrap_soong
+++ b/tests/bootstrap_soong
@@ -24,6 +24,15 @@ trap 'echo "*** Unexpected error in $0 ***"' ERR
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 BOB_DIR="${SCRIPT_DIR}/.."
 
+source "${SCRIPT_DIR}/bootstrap_utils.sh"
+
+# Add a symlink in the source directory to the parent directory to simulate a
+# project with Bob included in its source dir. On Soong, we don't actually need
+# this, because everything is linked together by Android's build system.
+# However, the tests include some of Bob's Mconfig files, so we need the
+# symlink so that the paths to those files are the same on all test platforms.
+create_link .. "${SCRIPT_DIR}/bob"
+
 source "${BOB_DIR}/pathtools.bash"
 
 export SRCDIR="$(relative_path "${ANDROID_BUILD_TOP}" "${SCRIPT_DIR}")"


### PR DESCRIPTION
* Update the `abstr` contexts - the latest Soong has replaced
  `blueprint.Module` with `android.Module` in more context methods.
* `AndroidTopDownMutator` and `AndroidBottomUpMutator` have lost their
  `Android` prefixes.
* Add a missing dependency between generated modules and their
  `host_bin` binaries.
* Re-implement `ccModuleName` using `VisitDirectDeps()` instead of
  `GetDirectDep()`, as the latter now uses the original module name and
  so we are unable to find the module after it has been renamed.

Change-Id: I47127fbf785344e8264701cf39bd5666865fb060
Signed-off-by: David Kilroy <david.kilroy@arm.com>
Signed-off-by: Chris Diamand <chris.diamand@arm.com>