### PR TITLE
Enable `match_srcs` on Soong

### DIFF
--- a/core/late_template.go
+++ b/core/late_template.go
@@ -23,13 +23,14 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/google/blueprint"
 	"github.com/google/blueprint/pathtools"
+
+	"github.com/ARM-software/bob-build/abstr"
 )
 
 var matchSourcesRegex = regexp.MustCompile(`\{\{match_srcs\s+(.+?)\}\}`)
 
-func (s *SourceProps) matchSources(ctx blueprint.BaseModuleContext, arg string) string {
+func (s *SourceProps) matchSources(ctx abstr.BaseModuleContext, arg string) string {
 	g := getBackend(ctx)
 
 	for _, match := range matchSourcesRegex.FindAllStringSubmatch(arg, -1) {
@@ -66,8 +67,8 @@ func (s *SourceProps) matchSources(ctx blueprint.BaseModuleContext, arg string) 
 // - Generated Common:
 //  - Args
 //  - Cmd
-func matchSourcesMutator(mctx blueprint.TopDownMutatorContext) {
-	module := mctx.Module()
+func matchSourcesMutator(mctx abstr.TopDownMutatorContext) {
+	module := abstr.Module(mctx)
 	matchSrcsString := "{{match_srcs "
 	if e, ok := module.(enableable); ok {
 		if !isEnabled(e) {

--- a/core/soong_plugin.go
+++ b/core/soong_plugin.go
@@ -210,6 +210,7 @@ func registerMutators(ctx android.RegisterMutatorsContext) {
 	ctx.BottomUp("bob_apply_reexport_lib_dependencies",
 		abstr.BottomUpAdaptor(applyReexportLibsDependenciesMutator)).Parallel()
 	ctx.TopDown("bob_install_group", abstr.TopDownAdaptor(soongInstallGroupMutator)).Parallel()
+	ctx.TopDown("match_sources_mutator", abstr.TopDownAdaptor(matchSourcesMutator)).Parallel()
 	ctx.TopDown("bob_rename", renameMutator).Parallel()
 	ctx.TopDown("bob_build_actions", buildActionsMutator).Parallel()
 }

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -151,7 +151,7 @@ func Main() {
 		ctx.RegisterTopDownMutator("encapsulates_mutator", encapsulatesMutator).Parallel()
 		ctx.RegisterTopDownMutator("install_group_mutator", abstr.TopDownAdaptor(installGroupMutator)).Parallel()
 		ctx.RegisterTopDownMutator("debug_info_mutator", abstr.TopDownAdaptor(debugInfoMutator)).Parallel()
-		ctx.RegisterTopDownMutator("match_sources_mutator", matchSourcesMutator).Parallel()
+		ctx.RegisterTopDownMutator("match_sources_mutator", abstr.TopDownAdaptor(matchSourcesMutator)).Parallel()
 	}
 
 	if config.Properties.GetBool("builder_ninja") {

--- a/tests/bootstrap_soong
+++ b/tests/bootstrap_soong
@@ -53,7 +53,6 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 DISABLE_TEST_DIRS=(
     external_libs
     generate_libs
-    match_source
     output
     source_encapsulation
     kernel_module


### PR DESCRIPTION
Register the mutator which handles `match_srcs`, which fixes the feature
and allows the corresponding tests to be run.

Change-Id: Ie5b686796d89222e156e0c5a30ee36b8b46f2b39
Signed-off-by: Chris Diamand <chris.diamand@arm.com>