### PR TITLE
Error on plugin failure

### DIFF
--- a/config_system/menuconfig.py
+++ b/config_system/menuconfig.py
@@ -675,7 +675,7 @@ def main():
             except ImportError as err:
                 logger.error("Could not import %s plugin: %s" % (name, err))
             except Exception as err:
-                logger.warning("Problem encountered in %s plugin: %s" % (name, repr(err)))
+                logger.error("Problem encountered in %s plugin: %s" % (name, repr(err)))
                 import traceback
                 traceback.print_tb(sys.exc_info()[2])
 

--- a/config_system/update_config.py
+++ b/config_system/update_config.py
@@ -174,7 +174,7 @@ def main():
         except ImportError as err:
             logger.error("Could not import %s plugin: %s" % (name, err))
         except Exception as err:
-            logger.warning("Problem encountered in %s plugin: %s" % (name, repr(err)))
+            logger.error("Problem encountered in %s plugin: %s" % (name, repr(err)))
             import traceback
             traceback.print_tb(sys.exc_info()[2])
 


### PR DESCRIPTION
Previously we only output a warning on plugins encountering
exceptions. Make this an error instead, which stops the build
proceeding.

Change-Id: I73fd212a8c6e3282ec0972f5ad0cc3df7273d124
Signed-off-by: David Kilroy <david.kilroy@arm.com>