### PR TITLE
Fix tests on Soong backend

### DIFF
--- a/tests/bootstrap_soong
+++ b/tests/bootstrap_soong
@@ -56,6 +56,8 @@ DISABLE_TEST_DIRS=(
     output
     source_encapsulation
     kernel_module
+    kernel_module/module1
+    kernel_module/module2
 )
 
 for TEST_DIR in "${DISABLE_TEST_DIRS[@]}"; do


### PR DESCRIPTION
Commits `309c14a Run install group mutator for soong` and `b857907
Implement AndroidMkEntries() method on kernel module and generate
backends` combined to break the Bob tests on Soong; kernel modules are
now built via `mm`, but the test modules are now installed with install
group `IG_modules`, which is defined in the excluded
`kernel_module/Android.bp`. file.

Fix this by also excluding the `module1` and `module2` subdirectories.

Change-Id: I2e02e511f744a15485d9c79c3a68a481436185f3
Signed-off-by: Chris Diamand <chris.diamand@arm.com>