### PR TITLE
Use consistent Android make output directories

### DIFF
--- a/tests/shared_libs/build.bp
+++ b/tests/shared_libs/build.bp
@@ -97,7 +97,7 @@ bob_install_group {
 bob_install_group {
     name: "IG_libs",
     builder_android_make: {
-        install_path: "$(TARGET_OUT_VENDOR_SHARED_LIBRARIES)",
+        install_path: "$(TARGET_OUT_SHARED_LIBRARIES)",
     },
     builder_ninja: {
         install_path: "install/lib",
@@ -117,7 +117,7 @@ bob_install_group {
 bob_install_group {
     name: "IG_binaries",
     builder_android_make: {
-        install_path: "$(TARGET_OUT_VENDOR_EXECUTABLES)",
+        install_path: "$(TARGET_OUT_EXECUTABLES)",
     },
     builder_ninja: {
         install_path: "install/bin",


### PR DESCRIPTION
The stripped_binary tests were failing on Android make as the output
directories for shared libraries and binaries are inconsistent. Shared
libraries and binaries are being installed to vendor, but are not
marked as such.

Android Q detects the binaries are vendor as we are setting
LOCAL_MODULE_PATH_32/64 for them. We aren't setting these variables
for shared libraries (as they need to go where android expects them).
Just set the install groups to put these in non-vendor locations.

Change-Id: I3abd447fe34e90333319d8123c1b641c7c6cc813
Signed-off-by: David Kilroy <david.kilroy@arm.com>