### PR TITLE
Android generated library support

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -104,7 +104,12 @@ release and the one before that.
 Note that not all Bob features are supported on Android. This includes:
 
 * Aliases
+
 * Versioned libraries
+
+* Generated library modules only support a single target, so any
+  library/binary that uses them will only build for the main target.
+  i.e. Multilib is disabled on them.
 
 ## macOS support
 


### PR DESCRIPTION
The generated library modules Bob supports only allow the library to
be created for a single architecture. When used on Android, multilib
enabled libraries are not able to use these generated libraries.

Bob libraries are normally setup with multilib enabled. Mark them
non-multilib if they depend on a generated static or generated shared
library.

Update the documentation to note this limitation.

Change-Id: I81938cdda0dbfdb26793446142f43eb76b5540ee
Signed-off-by: David Kilroy <david.kilroy@arm.com>