### PR TITLE
Fix support for export_gen_include_dir property under Soong

### DIFF
--- a/tests/bootstrap_soong
+++ b/tests/bootstrap_soong
@@ -56,7 +56,6 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 DISABLE_TEST_DIRS=(
     external_libs
     generate_libs
-    source_encapsulation
     kernel_module
     kernel_module/module1
     kernel_module/module2


### PR DESCRIPTION
This fixes source_encapsulation test, that are using 'enapsulates'
property, but also fixes all other modules that were using
export_gen_include_dir, just for some reason they didn't report any
error (modules affected: generate source, transform source, generate
static library, generate shared library, generate binary).

Problem was that under Soong, paths to generated include files can be
determined only when inside GenerateAndroidBuildActions(), so after all
mutators have run (processPaths() and encapsulateMutator() do not work
as expected under Soong).

Change-Id: I8815bad57c9b4b959c4edcec1abc8c63da47ec75
Signed-off-by: Michal Przeplata <michal.przeplata@arm.com>