### PR TITLE
Android make test fixes for Android 10

### DIFF
--- a/mconfig/host_toolchain.Mconfig
+++ b/mconfig/host_toolchain.Mconfig
@@ -22,6 +22,7 @@
 
 config HOST_GNU_PREFIX
 	string "Host GNU compiler prefix"
+	default "prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9/bin/x86_64-linux-android-" if ANDROID
 	default ""
 
 config HOST_CLANG_PREFIX

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -257,6 +257,16 @@ config STATIC_LIB_TOGGLE
 	bool "Test toggle"
 	default n
 
+## GEN_ config needed to do compilation for generator modules
+config GEN_CC
+	string "Compiler"
+	default "$(CLANG) -fuse-ld=lld" if BUILDER_ANDROID_MAKE
+	default HOST_GNU_PREFIX + GNU_CC_BINARY
+
+config GEN_AR
+	string "Archiver"
+	default HOST_GNU_PREFIX + AR_BINARY
+
 ## KERNEL_ config needed for testing kernel modules
 config KERNEL_CC
 	string "Kernel compiler"

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -256,3 +256,12 @@ config TEMPLATE_TEST_VALUE
 config STATIC_LIB_TOGGLE
 	bool "Test toggle"
 	default n
+
+## KERNEL_ config needed for testing kernel modules
+config KERNEL_CC
+	string "Kernel compiler"
+	default "$(CLANG)" if BUILDER_ANDROID_MAKE
+
+config KERNEL_CLANG_TRIPLE
+	string "Kernel Clang triple"
+	default "x86_64-linux-gnu" if BUILDER_ANDROID_MAKE

--- a/tests/generate_libs/build.bp
+++ b/tests/generate_libs/build.bp
@@ -55,7 +55,7 @@ bob_generate_shared_library {
      * Note that we make this a host library to avoid having to figure
      * out GCC arguments.
      */
-    cmd: "gcc -fPIC -o ${out} -shared ${in}; mkdir -p ${gen_dir}/include; cp ${module_dir}/libblah/libblah.h ${module_dir}/libblah/libblah_feature.h ${gen_dir}/include/.",
+    cmd: "{{.gen_cc}} -fPIC -o ${out} -shared ${in}; mkdir -p ${gen_dir}/include; cp ${module_dir}/libblah/libblah.h ${module_dir}/libblah/libblah_feature.h ${gen_dir}/include/.",
     target: "host",
 }
 
@@ -82,7 +82,7 @@ bob_generate_static_library {
      * Note that we make this a host library to avoid having to figure
      * out GCC arguments.
      */
-    cmd: "gcc -c -o ${gen_dir}/libblah.o ${in}; ar rcs ${gen_dir}/libblah_static.a ${gen_dir}/libblah.o; mkdir -p ${gen_dir}/include; cp ${module_dir}/libblah/libblah.h ${module_dir}/libblah/libblah_feature.h ${gen_dir}/include/.",
+    cmd: "{{.gen_cc}} -c -o ${gen_dir}/libblah.o ${in}; {{.gen_ar}} rcs ${gen_dir}/libblah_static.a ${gen_dir}/libblah.o; mkdir -p ${gen_dir}/include; cp ${module_dir}/libblah/libblah.h ${module_dir}/libblah/libblah_feature.h ${gen_dir}/include/.",
     target: "host",
 }
 

--- a/tests/kernel_module/kdir/Makefile
+++ b/tests/kernel_module/kdir/Makefile
@@ -11,7 +11,8 @@ include $(M)/Kbuild
 MODULES += $(addprefix $(M)/,$(obj-m:.o=.ko))
 DEPFILES += $(addprefix $(M)/,$(obj-m:.o=.d))
 CPPFLAGS := -Iinclude -MMD -MP
-CFLAGS := -fPIC $(EXTRA_CFLAGS)
+CFLAGS := -fPIC $(EXTRA_CFLAGS) -nostdlib
+LDFLAGS := -Wl,--no-undefined -shared -nostdlib
 
 # Test that KBUILD_EXTRA_SYMBOLS is correct by actually linking dependent
 # modules together. Each Module.symvers file contains the basename of the
@@ -20,13 +21,30 @@ CFLAGS := -fPIC $(EXTRA_CFLAGS)
 # names are not of the form `lib*.so`.
 DEPENDENT_MODULES := $(foreach symvers,$(KBUILD_EXTRA_SYMBOLS),-L $(dir $(symvers)) -l:$(shell cat $(symvers)))
 
+# Attempt to use the compiler requested by CC, CROSS_COMPILE and CLANG_TRIPLE variables.
+#  If CLANG_TRIPLE is set assume we are using clang, otherwise gcc.
+#  If CC is set, that is the gcc or clang binary to use.
+ifndef CC
+ifdef CLANG_TRIPLE
+CC := clang
+else
+CC := $(CROSS_COMPILE)gcc
+endif
+endif
+
+LOCAL_CC := $(CC)
+ifdef CLANG_TRIPLE
+LOCAL_CC += -target $(CLANG_TRIPLE)
+LDFLAGS += -fuse-ld=lld
+endif
+
 all: $(MODULES)
 
 $(M)/%.ko: $(M)/%.o
-	@$(CROSS_COMPILE)gcc -Wl,--no-undefined -shared $< -o $@ $(DEPENDENT_MODULES)
+	@$(LOCAL_CC) $(LDFLAGS) $< -o $@ $(DEPENDENT_MODULES)
 	@echo $(@F) > $(M)/Module.symvers
 
 %.o: %.c
-	@$(CROSS_COMPILE)gcc -c -o $@ $(CPPFLAGS) $(CFLAGS) $<
+	$(LOCAL_CC) -c -o $@ $(CPPFLAGS) $(CFLAGS) $<
 
 -include $(DEPFILES)

--- a/tests/kernel_module/module1/build.bp
+++ b/tests/kernel_module/module1/build.bp
@@ -4,6 +4,8 @@ bob_kernel_module {
      * workaround to use the spoofed kernel build system included with the Bob
      * tests. */
     kernel_dir: "../kdir",
+    kernel_cc: "{{.kernel_cc}}",
+    kernel_clang_triple: "{{.kernel_clang_triple}}",
     srcs: [
         "Kbuild",
         "test_module1.c",

--- a/tests/kernel_module/module2/build.bp
+++ b/tests/kernel_module/module2/build.bp
@@ -4,6 +4,8 @@ bob_kernel_module {
      * workaround to use the spoofed kernel build system included with the Bob
      * tests. */
     kernel_dir: "../kdir",
+    kernel_cc: "{{.kernel_cc}}",
+    kernel_clang_triple: "{{.kernel_clang_triple}}",
     srcs: [
         "Kbuild",
         "test_module2.c",


### PR DESCRIPTION
Address issues with the generator library tests and kernel module tests on Android 10.

Android 10 does not allow us to call gcc in the path. Use the prebuilt clang where we can.