### PR TITLE
Save undefined symbols when stripping on macOS

### DIFF
--- a/scripts/strip.py
+++ b/scripts/strip.py
@@ -55,7 +55,7 @@ def create_debug_info(fname, dbg, tool):
 
 def write_output(fname, output, dbg, strip, tool):
     if os.path.basename(tool) == "dsymutil":
-        run(["strip", "-o", output, fname])
+        run(["strip", "-u", "-o", output, fname])
     else:
         cmd = [tool]
         if dbg:

--- a/tests/build_tests.sh
+++ b/tests/build_tests.sh
@@ -20,8 +20,8 @@ function check_stripped() {
     if [ "$OS" != "OSX" ] ; then
         [ $(nm -a "${FILE}" | wc -l) = "0" ] || { echo "${FILE} not stripped" ; false; }
     else
-        # The two symbols below are always expected on macOS
-        [ $(nm -a "${FILE}" | grep -Ev " (dyld_stub_binder|__mh_execute_header)$" | wc -l) = "0" ] || {
+        # The symbol below is always expected on macOS
+        [ $(nm -a "${FILE}" | grep -Ev " dyld_stub_binder$" | wc -l) = "0" ] || {
             echo "${FILE} not stripped"
             false
         }


### PR DESCRIPTION
In some cases when undefined symbols are present,
macOS `strip` command fails when run with default option values.
Since we do not want to strip undefined symbols,
this commit adds `-u` option that forces undefined symbols
to be saved.

Change-Id: I2f59a0030ed8bdb1cb97be36bc0a5d2932f7d4e6
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>