### PR TITLE
Further soong generate_libs fixups

### DIFF
--- a/mconfig/host_toolchain.Mconfig
+++ b/mconfig/host_toolchain.Mconfig
@@ -27,6 +27,7 @@ config HOST_GNU_PREFIX
 
 config HOST_CLANG_PREFIX
 	string "Host Clang compiler prefix"
+	default "prebuilts/clang/host/linux-x86/clang-r370808/bin/" if ANDROID
 	default ""
 
 config HOST_ARMCLANG_PREFIX

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -261,6 +261,7 @@ config STATIC_LIB_TOGGLE
 config GEN_CC
 	string "Compiler"
 	default "$(CLANG) -fuse-ld=lld" if BUILDER_ANDROID_MAKE
+	default HOST_CLANG_PREFIX + CLANG_CC_BINARY + " -fuse-ld=lld" if BUILDER_SOONG
 	default HOST_GNU_PREFIX + GNU_CC_BINARY
 
 config GEN_AR

--- a/tests/bootstrap_soong
+++ b/tests/bootstrap_soong
@@ -55,7 +55,6 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 # whose tests require unimplemented features.
 DISABLE_TEST_DIRS=(
     external_libs
-    generate_libs
     kernel_module
     kernel_module/module1
     kernel_module/module2


### PR DESCRIPTION
Commit 9513398e6 introduced some issues, as it assumes that you can
cast to the genBackend type. You can't do this if the object is
actually genSharedLibraryBackend (or one of the others). Switch to use
interfaces in a number of cases.

When running on Android also setup the host clang path, and explicitly
use this for GEN_CC on soong.

Re-enable testing for generate_libs.

Change-Id: I0cea69af73d804a8f9645d29a83880761b6d5ab5
Signed-off-by: David Kilroy <david.kilroy@arm.com>