### PR TITLE
Fix kernel_module tests on Soong

### DIFF
--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -272,7 +272,8 @@ config GEN_AR
 config KERNEL_CC
 	string "Kernel compiler"
 	default "$(CLANG)" if BUILDER_ANDROID_MAKE
+	default HOST_CLANG_PREFIX + CLANG_CC_BINARY if BUILDER_SOONG
 
 config KERNEL_CLANG_TRIPLE
 	string "Kernel Clang triple"
-	default "x86_64-linux-gnu" if BUILDER_ANDROID_MAKE
+	default "x86_64-linux-gnu" if ANDROID

--- a/tests/bootstrap_soong
+++ b/tests/bootstrap_soong
@@ -55,9 +55,6 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 # whose tests require unimplemented features.
 DISABLE_TEST_DIRS=(
     external_libs
-    kernel_module
-    kernel_module/module1
-    kernel_module/module2
 )
 
 for TEST_DIR in "${DISABLE_TEST_DIRS[@]}"; do


### PR DESCRIPTION
Setup the kernel build options to use the Clang compiler in the
Android prebuilts.

Change-Id: I2064b8e0bf6cfac939ecd535b8a93b37e913eb35
Signed-off-by: David Kilroy <david.kilroy@arm.com>