### PR TITLE
Fix graph generation

### DIFF
--- a/bob_graph.bash
+++ b/bob_graph.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,4 +63,4 @@ echo "
 #
 "
 
-"${BOB_BUILDER}" -l "${BLUEPRINT_LIST_FILE}" -b "${BUILDDIR}" "$@" "${TOPNAME}"
+"${BOB_BUILDER}" -l "${BLUEPRINT_LIST_FILE}" -b "${BUILDDIR}" "$@" "${SRCDIR}/${TOPNAME}"


### PR DESCRIPTION
The graph generator assumes that the working directory is the source
directory. Fix this by identifying the Blueprint file at the top level
of the source directory when calling the primary builder.

Change-Id: Ideaf049709662f316c9bd4c4fbbf820d705aabd3
Signed-off-by: David Kilroy <david.kilroy@arm.com>