### PR TITLE
Improve consistency of install paths tests

### DIFF
--- a/docs/config_system.md
+++ b/docs/config_system.md
@@ -134,7 +134,7 @@ chosen using defaults, or be overridden by the user if user-visible:
 config INSTALL_PATH
 	string "Location to install the binary"
 	default "/usr/local/bin" if LINUX
-	default "$(TARGET_OUT)/bin if ANDROID
+	default "$(TARGET_OUT)/bin" if ANDROID
 ```
 
 String values can also be compared in expressions (`default if` and `depends

--- a/docs/user_guide/build_output.md
+++ b/docs/user_guide/build_output.md
@@ -66,10 +66,25 @@ bob_install_group {
 }
 ```
 
-Each `install_path` is referring to a directory under the build output
+On Linux each `install_path` is referring to a directory under the build output
 directory. It's recommended to set up a directory containing all the
 files to be installed, so that they can be copied to the target
 filesystem in one command.
+
+On Android `install_path` has to start with an Android make variable defined in
+[envsetup.mk](https://android.googlesource.com/platform/build/+/master/core/envsetup.mk), e.g.
+
+```
+bob_install_group {
+    name: "IG_libs",
+    builder_android_make: {
+        install_path: "$(TARGET_OUT_SHARED_LIBRARIES)",
+    },
+    builder_ninja: {
+        install_path: "install/lib",
+    },
+}
+```
 
 ## Installation properties
 

--- a/docs/user_guide/code_generation.md
+++ b/docs/user_guide/code_generation.md
@@ -204,7 +204,7 @@ One use for these module types is to extract a library from a
 compressed archive with `tar` or a similar command.
 
 ```
-bob_generated_shared_library {
+bob_generate_shared_library {
     name: "libfoo",
     srcs: "libfoo.tar.bz2",
     headers: ["include/libfoo.h"],

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Arm Limited.
+ * Copyright 2018-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,45 @@
  */
 
 subname = "build.bp"
+
+bob_install_group {
+    name: "IG_gensrc",
+    builder_android_make: {
+        install_path: "$(TARGET_OUT)/gen_sh_src",
+    },
+    builder_ninja: {
+        install_path: "gen_sh_src",
+    },
+    builder_soong: {
+        install_path: "gen_sh_src",
+    },
+}
+
+bob_install_group {
+    name: "IG_host_libs",
+    builder_android_make: {
+        install_path: "$(HOST_OUT_SHARED_LIBRARIES)",
+    },
+    builder_ninja: {
+        install_path: "install/host/lib",
+    },
+    builder_soong: {
+        install_path: "install/host/lib",
+    },
+}
+
+bob_install_group {
+    name: "IG_libs",
+    builder_android_make: {
+        install_path: "$(TARGET_OUT_SHARED_LIBRARIES)",
+    },
+    builder_ninja: {
+        install_path: "install/lib",
+    },
+    builder_soong: {
+        install_path: "install/lib",
+    },
+}
 
 bob_alias {
     name: "bob_tests",

--- a/tests/build_tests.sh
+++ b/tests/build_tests.sh
@@ -51,6 +51,17 @@ function check_build_output() {
     # Check that installed libraries/binaries are present
     check_installed "${DIR}/install/lib/libstripped_library${SHARED_LIBRARY_EXTENSION}"
     check_installed "${DIR}/install/bin/stripped_binary"
+    check_installed "${DIR}/gen_sh_lib/libblah_shared${SHARED_LIBRARY_EXTENSION}"
+    check_installed "${DIR}/gen_sh_bin/binary_linked_to_gen_shared"
+    check_installed "${DIR}/gen_sh_bin/binary_linked_to_gen_static"
+    check_installed "${DIR}/gen_sh_src/validate_install_generate_sources.txt"
+    check_installed "${DIR}/gen_sh_src/f3.validate_install_transform_source.txt"
+    check_installed "${DIR}/gen_sh_src/f4.validate_install_transform_source.txt"
+    check_installed "${DIR}/install/tests/linux/y/main.c"
+    if [ "$OS" != "OSX" ] ; then
+        check_installed "${DIR}/lib/modules/test_module1.ko"
+        check_installed "${DIR}/lib/modules/test_module2.ko"
+    fi
 
     # The stripped library must not contain symbols
     check_stripped "${DIR}/install/lib/libstripped_library${SHARED_LIBRARY_EXTENSION}" "$OS"
@@ -193,7 +204,7 @@ check_dep_updates "generate source depfile" "${build_dir}" "${SRC}" "${UPDATE[@]
 
 # resource dependencies
 SRC=tests/resources/main.c
-UPDATE=(${build_dir}/work/bob/linux/y/main.c)
+UPDATE=(${build_dir}/install/tests/linux/y/main.c)
 check_dep_updates "resources" "${build_dir}" "${SRC}" "${UPDATE[@]}"
 
 # implicit output

--- a/tests/generate_libs/build.bp
+++ b/tests/generate_libs/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Arm Limited.
+ * Copyright 2018-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,28 +16,31 @@
  */
 
 bob_install_group {
-    name: "ig_genlib_lib",
+    name: "IG_genlib_lib",
     builder_android_make: {
+        /* On Android make install_path is not respected for generated libraries. */
         install_path: "$(TARGET_OUT)/gen_sh_lib",
     },
     builder_ninja: {
-        install_path: "${BuildDir}/gen_sh_lib",
+        install_path: "gen_sh_lib",
     },
     builder_soong: {
-        install_path: "lib",
+        /* On Soong install_path is not respected for generated libraries. */
+        install_path: "gen_sh_lib",
     },
 }
 
 bob_install_group {
-    name: "ig_genlib_bin",
+    name: "IG_genlib_bin",
     builder_android_make: {
         install_path: "$(TARGET_OUT)/gen_sh_bin",
     },
     builder_ninja: {
-        install_path: "${BuildDir}/gen_sh_bin",
+        install_path: "gen_sh_bin",
     },
     builder_soong: {
-        install_path: "bin",
+        /* On Soong install_path is not respected for binaries. */
+        install_path: "gen_sh_bin",
     },
 }
 
@@ -48,7 +51,7 @@ bob_generate_shared_library {
     always_enabled_feature: {
         headers: ["include/libblah_feature.h"],
     },
-    install_group: "ig_genlib_lib",
+    install_group: "IG_genlib_lib",
     export_gen_include_dirs: ["include"],
 
     /* To avoid checking in a binary, call gcc directly.
@@ -63,7 +66,7 @@ bob_binary {
     name: "binary_linked_to_gen_shared",
     srcs: ["main.c"],
     shared_libs: ["libblah_shared"],
-    install_group: "ig_genlib_bin",
+    install_group: "IG_genlib_bin",
     host_supported: true,
     target_supported: false,
     build_by_default: true,
@@ -82,14 +85,14 @@ bob_generate_static_library {
      * Note that we make this a host library to avoid having to figure
      * out GCC arguments.
      */
-    cmd: "{{.gen_cc}} -c -o ${gen_dir}/libblah.o ${in}; {{.gen_ar}} rcs ${gen_dir}/libblah_static.a ${gen_dir}/libblah.o; mkdir -p ${gen_dir}/include; cp ${module_dir}/libblah/libblah.h ${module_dir}/libblah/libblah_feature.h ${gen_dir}/include/.",
+    cmd: "{{.gen_cc}} -c -o ${gen_dir}/libblah.o ${in}; {{.gen_ar}} rcs ${out} ${gen_dir}/libblah.o; mkdir -p ${gen_dir}/include; cp ${module_dir}/libblah/libblah.h ${module_dir}/libblah/libblah_feature.h ${gen_dir}/include/.",
     target: "host",
 }
 
 bob_binary {
     name: "binary_linked_to_gen_static",
     srcs: ["main.c"],
-    install_group: "ig_genlib_bin",
+    install_group: "IG_genlib_bin",
     static_libs: ["libblah_static"],
     host_supported: true,
     target_supported: false,

--- a/tests/generate_source/build.bp
+++ b/tests/generate_source/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Arm Limited.
+ * Copyright 2018-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -226,10 +226,19 @@ bob_generate_source {
     ],
 }
 
+bob_generate_source {
+    name: "validate_install_generate_sources",
+    out: ["validate_install_generate_sources.txt"],
+    cmd: "touch ${out}",
+    install_group: "IG_gensrc",
+    build_by_default: true,
+}
+
 bob_alias {
     name: "bob_test_generate_source",
     srcs: [
         "validate_link_generate_sources",
+        "validate_install_generate_sources",
         "bin_gen_sources_and_headers",
         "gen_source_depfile",
         "gen_source_depfile_with_implicit_outs",

--- a/tests/resources/build.bp
+++ b/tests/resources/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Arm Limited.
+ * Copyright 2018-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,13 +18,13 @@
 bob_install_group {
     name: "install_group_test",
     builder_android_make: {
-        install_path: "/work/bob/android",
+        install_path: "$(TARGET_OUT)/install/tests/android",
     },
     builder_ninja: {
-        install_path: "/work/bob/linux",
+        install_path: "install/tests/linux",
     },
     builder_soong: {
-        install_path: "resources",
+        install_path: "install/tests/soong",
     },
 }
 

--- a/tests/shared_libs/build.bp
+++ b/tests/shared_libs/build.bp
@@ -85,26 +85,6 @@ bob_alias {
 }
 
 bob_install_group {
-    name: "IG_host_libs",
-    builder_android_make: {
-        install_path: "$(HOST_OUT_SHARED_LIBRARIES)",
-    },
-    builder_ninja: {
-        install_path: "install/host/lib",
-    },
-}
-
-bob_install_group {
-    name: "IG_libs",
-    builder_android_make: {
-        install_path: "$(TARGET_OUT_SHARED_LIBRARIES)",
-    },
-    builder_ninja: {
-        install_path: "install/lib",
-    },
-}
-
-bob_install_group {
     name: "IG_host_binaries",
     builder_android_make: {
         install_path: "$(HOST_OUT_EXECUTABLES)",

--- a/tests/transform_source/build.bp
+++ b/tests/transform_source/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Arm Limited.
+ * Copyright 2018-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,9 +91,25 @@ bob_binary {
     srcs: ["main.cpp"],
 }
 
+bob_transform_source {
+    name: "validate_install_transform_source",
+    srcs: [
+        "f3.in",
+        "f4.in"
+    ],
+    out: {
+        match: "(.+)\\.in",
+        replace: ["$1.validate_install_transform_source.txt"]
+    },
+    cmd: "touch ${out}",
+    install_group: "IG_gensrc",
+    build_by_default: true,
+}
+
 bob_alias {
     name: "bob_test_transform_source",
     srcs: [
         "validate_link_transform_source",
+        "validate_install_transform_source",
     ],
 }


### PR DESCRIPTION
Testing of install paths should be consistent. This commit ensures
that each Bob module type has an instance with an install group,
updates tests/build_tests.sh to check that modules get installed
correctly, and also includes some other miscellaneous improvements
to install paths testing.

Change-Id: I9b8bbc849c9f3b35252a59050698436e49a0e131
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>