### PR TITLE
Kernel module should respect out property

### DIFF
--- a/core/linux.go
+++ b/core/linux.go
@@ -957,7 +957,7 @@ func copyFileIfExists(ctx blueprint.ModuleContext, source string, dest string) {
 }
 
 func (g *linuxGenerator) kernelModOutputDir(m *kernelModule) string {
-	return filepath.Join("${BuildDir}", "target", "kernel_modules", m.Name())
+	return filepath.Join("${BuildDir}", "target", "kernel_modules", m.outputName())
 }
 
 var kbuildRule = pctx.StaticRule("kbuild",
@@ -977,7 +977,7 @@ var kbuildRule = pctx.StaticRule("kbuild",
 	"kbuild_options", "make_args", "output_module_dir", "cc_flag", "hostcc_flag", "clang_triple_flag")
 
 func (g *linuxGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.ModuleContext) {
-	builtModule := filepath.Join(g.kernelModOutputDir(m), m.Name()+".ko")
+	builtModule := filepath.Join(g.kernelModOutputDir(m), m.outputName()+".ko")
 
 	args := m.generateKbuildArgs(ctx).toDict()
 	prefixedSources := utils.PrefixDirs(m.Properties.getSources(ctx), g.sourcePrefix())

--- a/scripts/kmod_build.py
+++ b/scripts/kmod_build.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,7 +86,7 @@ def build_module(output_dir, module_ko, kdir, module_dir, make_command, make_arg
             shutil.copy(built_file, output_dir)
         except (OSError, IOError) as e:
             msg = "Copy file from input path: {}\n" \
-                  "to output path: {}" \
+                  "to output path: {}\n" \
                   "finished with error: {}"
             logger.error(msg.format(built_file, output_dir, e))
             sys.exit(1)

--- a/tests/kernel_module/build.bp
+++ b/tests/kernel_module/build.bp
@@ -1,6 +1,6 @@
 bob_alias {
     name: "bob_test_kernel_module",
-    srcs: ["test_module1", "test_module2"],
+    srcs: ["test_module1_m", "test_module2"],
 }
 
 bob_install_group {

--- a/tests/kernel_module/module1/build.bp
+++ b/tests/kernel_module/module1/build.bp
@@ -1,5 +1,6 @@
 bob_kernel_module {
-    name: "test_module1",
+    name: "test_module1_m",
+    out: "test_module1",
     /* Usually kernel_dir would be an absolute path. For testing use this
      * workaround to use the spoofed kernel build system included with the Bob
      * tests. */

--- a/tests/kernel_module/module2/build.bp
+++ b/tests/kernel_module/module2/build.bp
@@ -11,7 +11,7 @@ bob_kernel_module {
         "test_module2.c",
     ],
     extra_symbols: [
-        "test_module1",
+        "test_module1_m",
     ],
     local_include_dirs: ["../module1"],
     install_group: "IG_modules",


### PR DESCRIPTION
Update kernel module tests to verify `out` behaviour. The module name
is changed to be different, as the `out` property needs to match the
kernel makefile.

Update kmod_build.py so that the output path is separated from the
error message.

Change-Id: I360d013f63bdb7a139988205f4dff7e57455e641
Signed-off-by: David Kilroy <david.kilroy@arm.com>