### PR TITLE
Fix multiple-visit checks

### DIFF
--- a/core/install.go
+++ b/core/install.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Arm Limited.
+ * Copyright 2018-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -131,6 +131,7 @@ func getShortNamesForDirectDepsWithTags(ctx blueprint.ModuleContext,
 			} else {
 				panic("install_dep on non-dependendable module")
 			}
+			visited[m.Name()] = true
 		})
 	return
 }

--- a/core/library.go
+++ b/core/library.go
@@ -425,6 +425,7 @@ func (l *library) GetGeneratedHeaders(ctx blueprint.ModuleContext) (includeDirs 
 				if _, ok := visited[m.Name()]; ok {
 					return
 				}
+				visited[m.Name()] = true
 
 				includeDirs = append(includeDirs, gs.Properties.Export_gen_include_dirs...)
 				// Generated headers are "order-only". That means that a source file does not need to rebuild
@@ -458,6 +459,7 @@ func (l *library) GetExportedVariables(ctx blueprint.ModuleContext) (expLocalInc
 			// dependency. We've already done this module.
 			return
 		}
+		visited[dep.Name()] = true
 
 		if sl, ok := getLibrary(dep); ok {
 			expLocalIncludes = append(expLocalIncludes, sl.Properties.Export_local_include_dirs...)

--- a/core/soong_library.go
+++ b/core/soong_library.go
@@ -109,6 +109,7 @@ func (l *library) getExportedCflags(mctx android.TopDownMutatorContext) []string
 			// dependency. We've already done this module.
 			return
 		}
+		visited[dep.Name()] = true
 
 		if sl, ok := getLibrary(dep); ok {
 			cflags = append(cflags, sl.Properties.Export_cflags...)


### PR DESCRIPTION
Fix a few places in the code where we were checking a `visited` map when
traversing dependencies, but didn't actually update the map after a
module had been visited.

Change-Id: I55a763eeb6791350780041f327aaf03951de032a
Signed-off-by: Chris Diamand <chris.diamand@arm.com>