### PR TITLE
Implement bob_resource on soong

### DIFF
--- a/Android.bp.in
+++ b/Android.bp.in
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Arm Limited.
+ * Copyright 2018-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,6 +52,7 @@ bootstrap_go_package {
         "core/soong_library.go",
         "core/soong_plugin.go",
         "core/soong_kernel_module.go",
+        "core/soong_resource.go",
         "core/splitter.go",
         "core/strip.go",
         "core/template.go",

--- a/core/android_make.go
+++ b/core/android_make.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Arm Limited.
+ * Copyright 2018-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -578,6 +578,10 @@ func (g *androidMkGenerator) resourceActions(m *resource, ctx blueprint.ModuleCo
 		sb.WriteString("LOCAL_MODULE_RELATIVE_PATH := " + proptools.String(m.Properties.Relative_install_path) + "\n")
 		writeListAssignment(sb, "LOCAL_MODULE_TAGS", m.Properties.Tags)
 		sb.WriteString("LOCAL_SRC_FILES := " + file + "\n")
+		if m.Properties.Owner != "" {
+			sb.WriteString("LOCAL_MODULE_OWNER := " + m.Properties.Owner + "\n")
+			sb.WriteString("LOCAL_PROPRIETARY_MODULE := true\n")
+		}
 		sb.WriteString("\ninclude $(BUILD_PREBUILT)\n")
 	}
 

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -121,6 +121,14 @@ type SourceProps struct {
 	Specials []string `blueprint:"mutated"`
 }
 
+// AndroidProps defines module properties used by Android backends
+type AndroidProps struct {
+	// Values to use on Android for LOCAL_MODULE_TAGS, defining which builds this module is built for
+	Tags []string
+	// Value to use on Android for LOCAL_MODULE_OWNER
+	Owner string
+}
+
 func glob(ctx abstr.BaseModuleContext, globs []string, excludes []string) []string {
 	var files []string
 

--- a/core/install.go
+++ b/core/install.go
@@ -179,7 +179,7 @@ type ResourceProps struct {
 	AliasableProps
 	InstallableProps
 	EnableableProps
-	Tags []string
+	AndroidProps
 }
 
 type resource struct {

--- a/core/library.go
+++ b/core/library.go
@@ -113,14 +113,6 @@ type BuildProps struct {
 	// The list of modules that generate output required by the build wrapper
 	Generated_deps []string
 
-	// Values to use on Android for LOCAL_MODULE_TAGS, defining which builds this module is built for
-	// TODO: Hide this in Android-specific properties
-	Tags []string
-
-	// Value to use on Android for LOCAL_MODULE_OWNER
-	// TODO: Hide this in Android-specific properties
-	Owner string
-
 	// The list of include dirs to use that is relative to the source directory
 	Include_dirs []string
 
@@ -157,6 +149,7 @@ type BuildProps struct {
 	EnableableProps
 	SplittableProps
 	StripProps
+	AndroidProps
 
 	// Linux kernel config options to emulate. These are passed to Kbuild in
 	// the 'make' command-line, and set in the source code via EXTRA_CFLAGS

--- a/core/soong_kernel_module.go
+++ b/core/soong_kernel_module.go
@@ -68,7 +68,7 @@ func (m *kernelModule) soongBuildActions(mctx android.TopDownMutatorContext) {
 		proptools.StringPtr(m.buildbpName()),
 	}
 
-	provenanceProps := getProvenanceProps(&m.Properties.Build.BuildProps)
+	provenanceProps := getProvenanceProps(&m.Properties.Build.BuildProps.AndroidProps)
 
 	installProps := m.getInstallableProps()
 	installPath, ok := installProps.getInstallGroupPath()

--- a/core/soong_library.go
+++ b/core/soong_library.go
@@ -157,7 +157,7 @@ func (l *library) setupCcLibraryProps(mctx android.TopDownMutatorContext) (*prov
 	cflags := utils.NewStringSlice(l.Properties.Cflags,
 		l.Properties.Export_cflags, l.getExportedCflags(mctx))
 
-	provenanceProps := getProvenanceProps(&l.Properties.Build.BuildProps)
+	provenanceProps := getProvenanceProps(&l.Properties.Build.BuildProps.AndroidProps)
 
 	sharedLibs := ccModuleNames(mctx, l.Properties.Shared_libs, l.Properties.Export_shared_libs)
 	staticLibs := ccModuleNames(mctx, l.Properties.ResolvedStaticLibs)

--- a/core/soong_plugin.go
+++ b/core/soong_plugin.go
@@ -120,7 +120,7 @@ type provenanceProps struct {
 	Soc_specific *bool
 }
 
-func getProvenanceProps(props *BuildProps) *provenanceProps {
+func getProvenanceProps(props *AndroidProps) *provenanceProps {
 	if props.Owner != "" {
 		return &provenanceProps{
 			Proprietary:  proptools.BoolPtr(true),

--- a/core/soong_resource.go
+++ b/core/soong_resource.go
@@ -1,0 +1,132 @@
+// +build soong
+
+/*
+ * Copyright 2020 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package core
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"android/soong/android"
+
+	"github.com/google/blueprint/proptools"
+)
+
+// Properties we need to set in the embedded PrebuiltEtc struct
+type prebuiltEtcProperties struct {
+	// Source file of this prebuilt.
+	Src *string
+
+	// optional subdirectory under which this file is installed into
+	Sub_dir *string
+
+	// when set to true, and filename property is not set, the name for the installed file
+	// is the same as the file name of the source file.
+	Filename_from_src *bool
+
+	// Whether this module is directly installable to one of the partitions. Default: true.
+	Installable *bool
+}
+
+// Prebuilts going to data partition
+type prebuiltData struct {
+	// pretend to be soong prebuilt module
+	android.PrebuiltEtc
+}
+
+func (m *prebuiltData) AndroidMkEntries() android.AndroidMkEntries {
+	return android.AndroidMkEntries{
+		Class:      "DATA",
+		OutputFile: android.OptionalPathForPath(m.OutputFile()),
+		Include:    "$(BUILD_PREBUILT)",
+		ExtraEntries: []android.AndroidMkExtraEntriesFunc{
+			func(entries *android.AndroidMkEntries) {
+				entries.SetString("LOCAL_MODULE_PATH", m.InstallDirPath().ToMakePath().String())
+				entries.SetString("LOCAL_INSTALLED_MODULE_STEM", m.OutputFile().Base())
+			},
+		},
+	}
+}
+
+func (m *prebuiltData) InstallInData() bool {
+	return true
+}
+
+func prebuiltDataFactory() android.Module {
+	m := &prebuiltData{}
+	// register PrebuiltEtc properties,
+	// install path will be relative to data partition root
+	android.InitPrebuiltEtcModule(&m.PrebuiltEtc, "")
+
+	// init module (including name and common properties) with target-specific variants info
+	android.InitAndroidArchModule(m, android.DeviceSupported, android.MultilibFirst)
+
+	return m
+}
+
+func (m *resource) soongBuildActions(mctx android.TopDownMutatorContext) {
+	if !isEnabled(m) {
+		return
+	}
+
+	provenanceProps := getProvenanceProps(&m.Properties.AndroidProps)
+
+	installProps := m.getInstallableProps()
+	installPath, ok := installProps.getInstallGroupPath()
+	if !ok {
+		installPath = ""
+	} else {
+		if installProps.Relative_install_path != nil {
+			installPath = filepath.Join(installPath, proptools.String(installProps.Relative_install_path))
+		}
+	}
+
+	subdir := ""
+	factory := (func() android.Module)(nil)
+	if strings.HasPrefix(installPath, "data/") {
+		subdir = strings.Replace(installPath, "data/", "", 1)
+		factory = prebuiltDataFactory
+	} else if strings.HasPrefix(installPath, "etc/") {
+		subdir = strings.Replace(installPath, "etc/", "", 1)
+		factory = android.PrebuiltEtcFactory
+	} else {
+		panic(fmt.Errorf("Install path must be prefixed either with 'data' or 'etc' (%s)", installPath))
+	}
+
+	// as prebuilt_etc module supports only single src, we have to split into N modules
+	for _, src := range m.Properties.getSources(mctx) {
+		// prebuilt_etc expects src to not contain a module dir, so we have to strip it here
+		base_src := relativeToModuleDir(mctx, []string{src})[0]
+
+		nameProps := nameProps{
+			// keep module name unique, remove slashes
+			proptools.StringPtr(m.Name() + "__" + strings.Replace(base_src, "/", "_", -1)),
+		}
+
+		props := prebuiltEtcProperties{
+			Src:               proptools.StringPtr(base_src),
+			Sub_dir:           proptools.StringPtr(subdir),
+			Filename_from_src: proptools.BoolPtr(true),
+			Installable:       proptools.BoolPtr(true),
+		}
+
+		// create module and fill all its registered properties with data from prepared structs
+		mctx.CreateModule(factory, &nameProps, provenanceProps, &props)
+	}
+}

--- a/docs/module_types/bob_resource.md
+++ b/docs/module_types/bob_resource.md
@@ -8,6 +8,11 @@ need while executing.
 This will reference an `bob_install_group` so it gets copied to an appropriate location
 relative to the binaries.
 
+For the Soong plugin, the `install_path` set in the `bob_install_group` must be
+prefixed by a known string to select an appropriate Android directory.
+Currently `data/` and `etc/` are supported. The `owner` property also influences
+where the files will be installed.
+
 `bob_resource` supports [features](../features.md)
 
 ## Full specification of `bob_resource` properties
@@ -34,6 +39,7 @@ bob_resource {
     post_install_args: ["arg1", "arg2"],
 
     tags: ["optional"],
+    owner: "company_name",
 
     // features available
 }
@@ -50,3 +56,9 @@ Source files to copy to the installation directory.
 ----
 ### **bob_resource.add_to_alias** (optional)
 Adds this module to an alias.
+
+----
+### **bob_module.owner** (optional)
+Value to use on Android for `LOCAL_MODULE_OWNER`
+If set, then the module is considered proprietary. For the Soong plugin this will
+usually be installed in the vendor partition.

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -184,6 +184,8 @@ which builds this module is built for.
 ----
 ### **bob_module.owner** (optional)
 Value to use on Android for `LOCAL_MODULE_OWNER`
+If set, then the module is considered proprietary. For the Soong plugin this will
+usually be installed in the vendor partition.
 
 ----
 ### **bob_module.strip** (optional)

--- a/tests/resources/build.bp
+++ b/tests/resources/build.bp
@@ -24,7 +24,7 @@ bob_install_group {
         install_path: "install/tests/linux",
     },
     builder_soong: {
-        install_path: "install/tests/soong",
+        install_path: "data/x/y",
     },
 }
 


### PR DESCRIPTION
Extracted AndroidProps and using it for resources to support optional
installing in vendor partition (instead of system partition).

Implementing our custom module to handle installing onto data partition
was necessary as soong's available prebuilt_etc doesn't support that.

Change-Id: I7c229809f1b5c102ead3843043b4e614b3f735fd
Signed-off-by: Michal Przeplata <michal.przeplata@arm.com>