### PR TITLE
config_system: improve type strictness

### DIFF
--- a/config_system/config_system/expr.py
+++ b/config_system/config_system/expr.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Arm Limited.
+# Copyright 2019-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -147,6 +147,37 @@ def condexpr_value(e):
         result = False
 
     return result
+
+
+def expr_type(e):
+    """Return the Mconfig type string for the input expression.
+    This isn't expected to use conditional operators.
+    """
+    assert type(e) == tuple
+    assert len(e) in [2, 3]
+    if len(e) == 3:
+        left = expr_type(e[1])
+        right = expr_type(e[2])
+        if left != right:
+            raise TypeError("'{}' operator is not valid with mixed types".format(e[0]))
+        elif left == 'bool':
+            raise TypeError("'{}' operator is not valid on booleans".format(e[0]))
+        elif e[0] == '+':
+            return left
+        elif e[0] == '-':
+            if left == 'string':
+                raise TypeError("'-' operator is not valid on strings")
+            return left
+    elif e[0] == 'string':
+        return 'string'
+    elif e[0] == 'number':
+        return 'int'
+    elif e[0] == 'boolean':
+        return 'bool'
+    elif e[0] == 'identifier':
+        return get_config(e[1])['datatype']
+
+    raise Exception("Unexpected depend list: " + str(e))
 
 
 def dependency_list(e):

--- a/config_system/tests/test_type_strictness.py
+++ b/config_system/tests/test_type_strictness.py
@@ -1,0 +1,198 @@
+# Copyright 2020 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from config_system import data, expr, general
+
+
+template_type_strictness_default_mconfig = """
+config TRUE
+    bool
+    default y
+
+config TEXT
+    string
+    default "text"
+
+config OPTION
+    bool
+    {expr}
+"""
+
+
+type_strictness_default_testdata = [
+    (
+        {  # default with the wrong type (string)
+            "expr": "default \"string_1\"",
+        },
+        "Type mismatch in config OPTION: expected bool but got string"
+    ),
+    (
+        {  # default with the wrong type (int)
+            "expr": "default 1",
+        },
+        "Type mismatch in config OPTION: expected bool but got int"
+    ),
+    (
+        {  # default with the right type (boolean true)
+            "expr": "default y",
+        },
+        None
+    ),
+    (
+        {  # default with the right type (boolean false)
+            "expr": "default n",
+        },
+        None
+    ),
+    (
+        {  # default with the wrong type (string)
+            "expr": "default TEXT",
+        },
+        "Type mismatch in config OPTION: expected bool but got string"
+    ),
+    (
+        {  # default with the right type (boolean true)
+            "expr": "default TRUE",
+        },
+        None
+    ),
+    (
+        {  # default_cond with with the wrong type (string)
+            "expr": "default \"y\" if y",
+        },
+        "Type mismatch in config OPTION: expected bool but got string"
+    ),
+    (
+        {  # default_cond with the right type
+            "expr": "default y if y",
+        },
+        None
+    ),
+    (
+        {  # two default conds: one with the right type and one with the wrong type
+            "expr": "\n".join(["default n if y", "default \"y\" if n"]),
+        },
+        "Type mismatch in config OPTION: expected bool but got string"
+    ),
+    (
+        {  # two default conds: both with the right types
+            "expr": "\n".join(["default n if y", "default y if n"]),
+        },
+        None
+    ),
+]
+
+
+@pytest.mark.parametrize("inputdata,error", type_strictness_default_testdata)
+def test_type_strictness_default(caplog, tmpdir, inputdata, error):
+    mconfig_file = tmpdir.join("Mconfig")
+
+    mconfig = template_type_strictness_default_mconfig.format(**inputdata)
+    mconfig_file.write(mconfig, "wt")
+
+    general.init_config(str(mconfig_file), False)
+
+    if error is not None:
+        assert error in caplog.text
+    else:
+        assert caplog.text == ""
+
+
+template_type_strictness_select_mconfig = """
+config OPTION_1
+  bool
+  default n
+config OPTION_2
+  string
+  default "text"
+config OPTION_3
+  int
+  default 1
+config OPTION_4
+  bool
+  {expr}
+"""
+
+
+type_strictness_select_testdata = [
+    (
+        {  # select with the wrong type (string)
+            "expr": "select OPTION_2",
+        },
+        "Select option must have type bool but got type string instead"
+    ),
+    (
+        {  # select with the right type (bool)
+            "expr": "select OPTION_1",
+        },
+        None
+    ),
+    (
+        {  # select with the wrong type (string)
+            "expr": "select OPTION_2 if OPTION_1",
+        },
+        "Select option must have type bool but got type string instead"
+    ),
+    (
+        {  # select with the wrong type (int)
+            "expr": "select OPTION_3 if !OPTION_1",
+        },
+        "Select option must have type bool but got type int instead"
+    ),
+    (
+        {  # select with the right type (bool)
+            "expr": "select OPTION_1 if OPTION_3 = 4",
+        },
+        None
+    ),
+    (
+        {  # select with the wrong type (int)
+            "expr": "\n".join(["select OPTION_1 if OPTION_3 = 4", "select OPTION_3 if OPTION_1"]),
+        },
+        "Select option must have type bool but got type int instead"
+    ),
+    (
+        {  # select with the wrong type (int)
+            "expr": "\n".join(["select OPTION_1 if OPTION_3 = 4", "select OPTION_3"]),
+        },
+        "Select option must have type bool but got type int instead"
+    ),
+    (
+        {  # select with the right type (bool)
+            "expr": "\n".join([
+                "select OPTION_1 if OPTION_3 = 4",
+                "select OPTION_1 if OPTION_2 = \"str\""
+            ]),
+        },
+        None
+    ),
+]
+
+
+@pytest.mark.parametrize("inputdata,error", type_strictness_select_testdata)
+def test_type_strictness_select(caplog, tmpdir, inputdata, error):
+    mconfig_file = tmpdir.join("Mconfig")
+
+    mconfig = template_type_strictness_select_mconfig.format(**inputdata)
+    mconfig_file.write(mconfig, "wt")
+
+    general.init_config(str(mconfig_file), False)
+
+    if error is not None:
+        assert error in caplog.text
+    else:
+        assert caplog.text == ""


### PR DESCRIPTION
This commit disallows setting a boolean config with a string value
by ensuring assertion failure when this occurs.

Change-Id: I0fcb3c9155a2168dde12be756fc2050d2361b7bb
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>