### PR TITLE
Don't automatically add `liblog`

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -335,7 +335,7 @@ func androidLibraryBuildAction(sb *strings.Builder, mod blueprint.Module, ctx bl
 	exportHeaderLibs := androidModuleNames(m.Properties.Export_header_libs)
 	headerLibs := append(androidModuleNames(m.Properties.Header_libs), exportHeaderLibs...)
 
-	writeListAssignment(sb, "LOCAL_SHARED_LIBRARIES", append(sharedLibs, "liblog"))
+	writeListAssignment(sb, "LOCAL_SHARED_LIBRARIES", sharedLibs)
 	writeListAssignment(sb, "LOCAL_STATIC_LIBRARIES", staticLibs)
 	writeListAssignment(sb, "LOCAL_WHOLE_STATIC_LIBRARIES", wholeStaticLibs)
 	writeListAssignment(sb, "LOCAL_HEADER_LIBRARIES", headerLibs)


### PR DESCRIPTION
Remove the last implicit dependency on the Android.mk backend, where we
would automatically add `liblog` as a shared library dependency on every
build object.

Modules which need this should now add it explicitly in their
`export_shared_libs` parameter.

Change-Id: I2e7e99f6b79c7d2789b5586e2dc719124bfff761
Signed-off-by: Chris Diamand <chris.diamand@arm.com>