### PR TITLE
Remove Fs() from abstr.BaseModuleContext

### DIFF
--- a/abstr/contexts.go
+++ b/abstr/contexts.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Arm Limited.
+ * Copyright 2019-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,6 @@ import (
 	"text/scanner"
 
 	"github.com/google/blueprint"
-	"github.com/google/blueprint/pathtools"
 )
 
 // Common functions in blueprint.BaseModuleContext and android.BaseModuleContext
@@ -42,7 +41,6 @@ type BaseModuleContext interface {
 
 	GlobWithDeps(pattern string, excludes []string) ([]string, error)
 
-	Fs() pathtools.FileSystem
 	AddNinjaFileDeps(deps ...string)
 }
 


### PR DESCRIPTION
As part of sandboxing the primary builder soong has removed
the Fs() interface.

related soong commits:
988414c2cf6bfb868df7d402e0bf825d6fd44cc8: Sandbox
soong_build by changing to root directory
1184b647d528d9b23c1a16d4a98187208f5a3a65: Add EarlyModuleContext for
LoadHookContext)

Change-Id: I05dd052445d71e904aaa7c7753aacab09483318a
Signed-off-by: Michal Przeplata <michal.przeplata@arm.com>