### PR TITLE
Disable generate_libs test on soong

### DIFF
--- a/tests/generate_libs/build.bp
+++ b/tests/generate_libs/build.bp
@@ -60,6 +60,10 @@ bob_generate_shared_library {
      */
     cmd: "{{.gen_cc}} -fPIC -o ${out} -shared ${in}; mkdir -p ${gen_dir}/include; cp ${module_dir}/libblah/libblah.h ${module_dir}/libblah/libblah_feature.h ${gen_dir}/include/.",
     target: "host",
+    builder_soong: {
+        /* On Soong generated libraries are not supported. */
+        enabled: false,
+    },
 }
 
 bob_binary {
@@ -70,6 +74,10 @@ bob_binary {
     host_supported: true,
     target_supported: false,
     build_by_default: true,
+    builder_soong: {
+        /* On Soong generated binaries are not supported. */
+        enabled: false,
+    },
 }
 
 bob_generate_static_library {
@@ -87,6 +95,10 @@ bob_generate_static_library {
      */
     cmd: "{{.gen_cc}} -c -o ${gen_dir}/libblah.o ${in}; {{.gen_ar}} rcs ${out} ${gen_dir}/libblah.o; mkdir -p ${gen_dir}/include; cp ${module_dir}/libblah/libblah.h ${module_dir}/libblah/libblah_feature.h ${gen_dir}/include/.",
     target: "host",
+    builder_soong: {
+        /* On Soong generated libraries are not supported. */
+        enabled: false,
+    },
 }
 
 bob_binary {
@@ -97,6 +109,10 @@ bob_binary {
     host_supported: true,
     target_supported: false,
     build_by_default: true,
+    builder_soong: {
+        /* On Soong generated binaries are not supported. */
+        enabled: false,
+    },
 }
 
 bob_alias {


### PR DESCRIPTION
First (clean) run of this test fails, for subsequent runs passes ok.
This is because compile step of bob_binary does not have implicit input
set in ninja rules.

Issue is because generated library tries to act as both: generated
source and library, and this is something Soong does not tolerate. Using
'Generated_headers' on Soong cc_binary module property did not work
properly.

On Linux it works because it uses 'headers' property for getting
implitic outs filenames, and then bob_binary uses those with build
inouts struct to create custom ninja rules.

I have proven that it can be fixed by isolating generating headers as a
separate module (bob_generate_source).
However decision was made to remove support completely for generated
libraries/binaries from Soong and disable the appropriate modules
accordingly.

Change-Id: I0046fe6f640b55222938a5fc1963f498170dc44e
Signed-off-by: Michal Przeplata <michal.przeplata@arm.com>