### PR TITLE
Add initial Android.bp backend

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Arm Limited.
+ * Copyright 2018-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,6 +35,7 @@ bootstrap_go_package {
         "bob-utils",
     ],
     srcs: [
+        "core/android_bp.go",
         "core/android_make.go",
         "core/alias.go",
         "core/build_structs.go",

--- a/bootstrap_androidbp.bash
+++ b/bootstrap_androidbp.bash
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright 2020 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source $(dirname "${BASH_SOURCE[0]}")/bootstrap.bash

--- a/core/android_bp.go
+++ b/core/android_bp.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"path/filepath"
+
+	"github.com/google/blueprint"
+)
+
+type androidBpGenerator struct {
+	toolchainSet
+}
+
+/* Compile time checks for interfaces that must be implemented by androidBpGenerator */
+var _ generatorBackend = (*androidBpGenerator)(nil)
+
+func (g *androidBpGenerator) aliasActions(*alias, blueprint.ModuleContext)               {}
+func (g *androidBpGenerator) binaryActions(*binary, blueprint.ModuleContext)             {}
+func (g *androidBpGenerator) kernelModuleActions(*kernelModule, blueprint.ModuleContext) {}
+func (g *androidBpGenerator) resourceActions(*resource, blueprint.ModuleContext)         {}
+func (g *androidBpGenerator) sharedActions(*sharedLibrary, blueprint.ModuleContext)      {}
+func (g *androidBpGenerator) staticActions(*staticLibrary, blueprint.ModuleContext)      {}
+
+func (g *androidBpGenerator) generateSourceActions(*generateSource, blueprint.ModuleContext, []inout) {
+}
+func (g *androidBpGenerator) genBinaryActions(*generateBinary, blueprint.ModuleContext, []inout) {}
+func (g *androidBpGenerator) genSharedActions(*generateSharedLibrary, blueprint.ModuleContext, []inout) {
+}
+func (g *androidBpGenerator) genStaticActions(*generateStaticLibrary, blueprint.ModuleContext, []inout) {
+}
+func (g *androidBpGenerator) transformSourceActions(*transformSource, blueprint.ModuleContext, []inout) {
+}
+
+func (g *androidBpGenerator) buildDir() string                         { return "" }
+func (g *androidBpGenerator) sourcePrefix() string                     { return "" }
+func (g *androidBpGenerator) sharedLibsDir(tgtType) string             { return "" }
+func (g *androidBpGenerator) sourceOutputDir(*generateCommon) string   { return "" }
+func (g *androidBpGenerator) binaryOutputDir(*binary) string           { return "" }
+func (g *androidBpGenerator) staticLibOutputDir(*staticLibrary) string { return "" }
+func (g *androidBpGenerator) sharedLibOutputDir(*sharedLibrary) string { return "" }
+func (g *androidBpGenerator) kernelModOutputDir(*kernelModule) string  { return "" }
+
+type androidBpSingleton struct {
+}
+
+func androidBpSingletonFactory() blueprint.Singleton {
+	return &androidBpSingleton{}
+}
+
+func (s *androidBpSingleton) GenerateBuildActions(ctx blueprint.SingletonContext) {
+	androidbpFile := filepath.Join(srcdir, "Android.bp")
+
+	// Blueprint does not output package context dependencies unless
+	// the package context outputs a variable, pool or rule to the
+	// build.ninja.
+	//
+	// The Android.bp backend does not create variables, pools or
+	// rules since the build logic is actually written in Android.bp files.
+	// Therefore write a dummy ninja target to ensure that the bob
+	// package context dependencies are output.
+	//
+	// We make the target optional, so that it doesn't execute when
+	// ninja runs without a target.
+	ctx.Build(pctx,
+		blueprint.BuildParams{
+			Rule:     dummyRule,
+			Outputs:  []string{androidbpFile},
+			Optional: true,
+		})
+}
+
+func (g *androidBpGenerator) init(ctx *blueprint.Context, config *bobConfig) {
+	ctx.RegisterSingletonType("androidbp_singleton", androidBpSingletonFactory)
+
+	g.toolchainSet.parseConfig(config)
+}

--- a/core/android_make.go
+++ b/core/android_make.go
@@ -55,6 +55,9 @@ type androidMkGenerator struct {
 	toolchainSet
 }
 
+/* Compile time checks for interfaces that must be implemented by androidMkGenerator */
+var _ generatorBackend = (*androidMkGenerator)(nil)
+
 func writeIfChanged(filename string, sb *strings.Builder) {
 	mustWrite := true
 	text := sb.String()

--- a/core/linux.go
+++ b/core/linux.go
@@ -45,6 +45,9 @@ type linuxGenerator struct {
 	toolchainSet
 }
 
+/* Compile time checks for interfaces that must be implemented by linuxGenerator */
+var _ generatorBackend = (*linuxGenerator)(nil)
+
 // Convert a path to a library into a compiler flag.
 // This needs to strip any path, file extension, lib prefix, and prepend -l
 func pathToLibFlag(path string) string {

--- a/core/soong_plugin.go
+++ b/core/soong_plugin.go
@@ -136,6 +136,9 @@ type soongGenerator struct {
 	toolchainSet
 }
 
+/* Compile time checks for interfaces that must be implemented by soongGenerator */
+var _ generatorBackend = (*soongGenerator)(nil)
+
 func (g *soongGenerator) aliasActions(m *alias, ctx blueprint.ModuleContext)                        {}
 func (g *soongGenerator) binaryActions(*binary, blueprint.ModuleContext)                            {}
 func (g *soongGenerator) genBinaryActions(*generateBinary, blueprint.ModuleContext, []inout)        {}

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -172,6 +172,8 @@ func Main() {
 
 	if config.Properties.GetBool("builder_ninja") {
 		config.Generator = &linuxGenerator{}
+	} else if config.Properties.GetBool("builder_android_bp") {
+		config.Generator = &androidBpGenerator{}
 	} else if config.Properties.GetBool("builder_android_make") {
 		config.Generator = &androidMkGenerator{}
 	} else {

--- a/example/bootstrap_android.bash
+++ b/example/bootstrap_android.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,7 +40,7 @@ Usage:
   profiles and explicit options (like DEBUG=y)
 
 Options
-  -m, --menuconfig  Open graphical configuration editor
+  -m, --menuconfig  Open configuration editor
   -h, --help        Help text
 
 Examples:

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 Arm Limited.
+# Copyright 2016-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,6 +60,12 @@ config BUILDER_ANDROID_MAKE
 	depends on ANDROID
 	help
 	  Generate Android.mk fragments for use with Android make.
+
+config BUILDER_ANDROID_BP
+	bool "Android.bp (EXPERIMENTAL)"
+	depends on ANDROID
+	help
+	  Integrate into Android's build system by writing Android.bp files.
 
 config BUILDER_SOONG
 	bool "Soong plugin (EXPERIMENTAL)"

--- a/tests/bootstrap_androidbp
+++ b/tests/bootstrap_androidbp
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,22 +17,22 @@
 
 # This script sets up the source tree to use Bob Blueprint under Android.
 
-# Copy the Blueprint version of the Android makefile into place, bootstrap
-# Bob with a BUILDDIR in the Android output directory, and generate an initial
-# config based on the args passed to this script.
+# Bootstrap Bob with a BUILDDIR in the Android output directory, and
+# generate an initial config based on the args passed to this script.
+# Finally run Bob to generate the Android.bp for the configuration.
 
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 BOB_DIR=bob
 PROJ_NAME="bob_tests"
 
-source "$SCRIPT_DIR/bootstrap_utils.sh"
+source "${SCRIPT_DIR}/bootstrap_utils.sh"
 
 BASENAME=$(basename $0)
 function usage {
     cat <<EOF
 $BASENAME
 
-Sets up the Bob tests to build for Android.
+Sets up the Bob tests to build for Android using Android.bp files.
 
 Usage:
  $BASENAME CONFIG_OPTIONS...
@@ -91,41 +91,31 @@ create_link external_lib.bp "${SCRIPT_DIR}/external_libs/external/Android.bp"
 # Change to the working directory
 cd "${ANDROID_BUILD_TOP}"
 
-### Variables required for Bob and Android.mk bootstrap ###
+### Variables required for Bob and Android.bp bootstrap ###
 
-# This must match the path derived from LOCAL_MODULE and LOCAL_MODULE_CLASS
-# in Android.mk.blueprint.
-ANDROIDMK_DIR="${OUT}/gen/STATIC_LIBRARIES/${PROJ_NAME}_intermediates"
-export BUILDDIR="${ANDROIDMK_DIR}"
+BPBUILD_DIR="${OUT}/gen/STATIC_LIBRARIES/bobbp_${PROJ_NAME}_intermediates"
+export BUILDDIR="${BPBUILD_DIR}"
 export TOPNAME="build.bp"
 export CONFIGNAME="bob.config"
 export SRCDIR="${PROJ_DIR}"
 export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 
-# Write the Android.mk
-TMP_ANDROID_MK="$(mktemp)"
-sed -e "s#@@BOB_PROJ_NAME@@#$PROJ_NAME#" \
-    -e "s#@@BOB_DIR@@#$BOB_DIR#" \
-    -e "s#@@CONFIGNAME@@#$CONFIGNAME#" \
-    "${PROJ_DIR}/Android.mk.blueprint" > "$TMP_ANDROID_MK"
-rsync --checksum "$TMP_ANDROID_MK" "${PROJ_DIR}/Android.mk"
-rm -f "$TMP_ANDROID_MK"
-
 # Bootstrap Bob
-"${PROJ_DIR}/${BOB_DIR}/bootstrap_androidmk.bash"
+"${PROJ_DIR}/${BOB_DIR}/bootstrap_androidbp.bash"
 
 
 # Pick up some info that bob has worked out
 source "${BUILDDIR}/.bob.bootstrap"
 
-# Setup the buildme script to just run bob
-ln -sf "bob" "${BUILDDIR}/buildme"
-
-if [ ! -z "$*" ] || [ ! -f "$ANDROIDMK_DIR/$CONFIGNAME" ] ; then
+if [ ! -z "$*" ] || [ ! -f "${BPBUILD_DIR}/${CONFIGNAME}" ] ; then
     # Have arguments or missing bob.config. Run config.
-    "$ANDROIDMK_DIR/config" ANDROID=y "$@"
+    "${BPBUILD_DIR}/config" ANDROID=y BUILDER_ANDROID_BP=y "$@"
 fi
 
 if [ $MENU -eq 1 ] ; then
-    "$ANDROIDMK_DIR/menuconfig"
+    "${BPBUILD_DIR}/menuconfig"
 fi
+
+# Once configured, generate the Android.bp by running Bob
+# There is a symlink in the build directory.
+"${BPBUILD_DIR}/bob"

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -22,6 +22,9 @@ bob_install_group {
     builder_android_make: {
         install_path: "$(TARGET_OUT)/gen_sh_src",
     },
+    builder_android_bp: {
+        install_path: "gen_sh_src",
+    },
     builder_ninja: {
         install_path: "gen_sh_src",
     },
@@ -35,6 +38,9 @@ bob_install_group {
     builder_android_make: {
         install_path: "$(HOST_OUT_SHARED_LIBRARIES)",
     },
+    builder_android_bp: {
+        install_path: "lib",
+    },
     builder_ninja: {
         install_path: "install/host/lib",
     },
@@ -47,6 +53,9 @@ bob_install_group {
     name: "IG_libs",
     builder_android_make: {
         install_path: "$(TARGET_OUT_SHARED_LIBRARIES)",
+    },
+    builder_android_bp: {
+        install_path: "lib",
     },
     builder_ninja: {
         install_path: "install/lib",

--- a/tests/generate_libs/build.bp
+++ b/tests/generate_libs/build.bp
@@ -21,6 +21,9 @@ bob_install_group {
         /* On Android make install_path is not respected for generated libraries. */
         install_path: "$(TARGET_OUT)/gen_sh_lib",
     },
+    builder_android_bp: {
+        install_path: "gen_sh_lib",
+    },
     builder_ninja: {
         install_path: "gen_sh_lib",
     },
@@ -34,6 +37,9 @@ bob_install_group {
     name: "IG_genlib_bin",
     builder_android_make: {
         install_path: "$(TARGET_OUT)/gen_sh_bin",
+    },
+    builder_android_bp: {
+        install_path: "gen_sh_lib",
     },
     builder_ninja: {
         install_path: "gen_sh_bin",

--- a/tests/kernel_module/build.bp
+++ b/tests/kernel_module/build.bp
@@ -8,6 +8,9 @@ bob_install_group {
     builder_android_make: {
         install_path: "$(TARGET_OUT)/lib/modules",
     },
+    builder_android_bp: {
+        install_path: "lib/modules",
+    },
     builder_ninja: {
         install_path: "lib/modules",
     },

--- a/tests/resources/build.bp
+++ b/tests/resources/build.bp
@@ -20,6 +20,9 @@ bob_install_group {
     builder_android_make: {
         install_path: "$(TARGET_OUT)/install/tests/android",
     },
+    builder_android_bp: {
+        install_path: "data/x/y",
+    },
     builder_ninja: {
         install_path: "install/tests/linux",
     },

--- a/tests/shared_libs/build.bp
+++ b/tests/shared_libs/build.bp
@@ -89,6 +89,9 @@ bob_install_group {
     builder_android_make: {
         install_path: "$(HOST_OUT_EXECUTABLES)",
     },
+    builder_android_bp: {
+        install_path: "bin",
+    },
     builder_ninja: {
         install_path: "install/host/bin",
     },
@@ -98,6 +101,9 @@ bob_install_group {
     name: "IG_binaries",
     builder_android_make: {
         install_path: "$(TARGET_OUT_EXECUTABLES)",
+    },
+    builder_android_bp: {
+        install_path: "bin",
     },
     builder_ninja: {
         install_path: "install/bin",


### PR DESCRIPTION
Add bootstrap infrastructure for a new backend that will write
Android.bp files.

The test bootstrap script will bootstrap, configure and execute Bob
(to write the Android.bp file).

In the test project, define an install_path for all bob_install_groups
for the new backend. These are nominal paths at the moment, to prevent
the standard mutator from panicking.

Add compile time checks in the implementation of each generatorBackend
to ensure the appropriate functions are implemented. This avoids
relying on how the generators are used to idenitfy errors.

Also do a minor text cleanup in the test and example bootstrap scripts
that was noticed during review.

Change-Id: I06dfed5249d5196d6e5e668d15f0ab14a066686e
Signed-off-by: David Kilroy <david.kilroy@arm.com>