### PR TITLE
Define OS and BUILDER in a common file

### DIFF
--- a/core/gen_shared.go
+++ b/core/gen_shared.go
@@ -69,11 +69,9 @@ func genSharedLibFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &generateSharedLibrary{}
 	module.generateCommon.Properties.Features.Init(&config.Properties, GenerateProps{},
 		GenerateLibraryProps{})
-	switch config.Properties.GetString("os") {
-	case "osx":
+	if config.Properties.GetBool("osx") {
 		module.fileNameExtension = ".dylib"
-		break
-	default:
+	} else {
 		module.fileNameExtension = ".so"
 	}
 	return module, []interface{}{

--- a/core/library.go
+++ b/core/library.go
@@ -632,11 +632,9 @@ func staticLibraryFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 
 func sharedLibraryFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &sharedLibrary{}
-	switch config.Properties.GetString("os") {
-	case "osx":
+	if config.Properties.GetBool("osx") {
 		module.fileNameExtension = ".dylib"
-		break
-	default:
+	} else {
 		module.fileNameExtension = ".so"
 	}
 	return module.LibraryFactory(config, module)

--- a/example/Mconfig
+++ b/example/Mconfig
@@ -1,49 +1,8 @@
 # This is an example configuration database containing the minimal set
 # of configuration options required by Bob.
 
-choice
-	prompt "Operating System"
-	default LINUX
-
-config LINUX
-	bool "Linux"
-
-config ANDROID
-	bool "Android"
-
-config OSX
-	bool "macOS"
-
-endchoice
-
-config OS
-	string
-	default "android" if ANDROID
-	default "osx" if OSX
-	default "linux"
-
-## Need to select the BUILDER_ for Bob
-choice
-	prompt "Builder"
-	default BUILDER_ANDROID_MAKE if ANDROID
-	default BUILDER_NINJA
-	help
-	  Bob supports generating output for different build systems.
-
-	  Select the desired build system.
-
-config BUILDER_NINJA
-	bool "Ninja"
-	help
-	  Generate build.ninja output to use with ninja.
-
-config BUILDER_ANDROID_MAKE
-	bool "Android make"
-	depends on ANDROID
-	help
-	  Generate Android.mk fragments for use with Android make.
-
-endchoice
+# Update this to reflect the path to Bob within the superproject
+source "bob-build/mconfig/basics.Mconfig"
 
 menu "Toolchain Options"
 
@@ -86,8 +45,6 @@ config TARGET_TOOLCHAIN_XCODE
 	  Toolchain for macOS.
 
 	  Support is still experimental.
-
-
 
 endchoice
 

--- a/mconfig/basics.Mconfig
+++ b/mconfig/basics.Mconfig
@@ -1,0 +1,69 @@
+# Copyright 2020 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### Common configuration settings
+
+choice
+	prompt "Operating System"
+	default LINUX
+
+config ANDROID
+	bool "Android"
+
+config LINUX
+	bool "Linux"
+
+config OSX
+	bool "OSX"
+
+config WINDOWS
+	bool "Windows"
+
+endchoice
+
+
+choice
+	prompt "Builder"
+	default BUILDER_ANDROID_MAKE if ANDROID
+	default BUILDER_NINJA
+	help
+	  Bob supports generating output for different build systems.
+
+	  Select the desired build system.
+
+config BUILDER_ANDROID_MAKE
+	bool "Android make"
+	depends on ANDROID
+	help
+	  Generate Android.mk fragments for use with Android make.
+
+config BUILDER_ANDROID_BP
+	bool "Android.bp (EXPERIMENTAL)"
+	depends on ANDROID
+	help
+	  Generate Android.bp fragments for use with Android.
+
+config BUILDER_NINJA
+	bool "Ninja"
+	help
+	  Generate build.ninja output to use with ninja.
+
+config BUILDER_SOONG
+	bool "Soong (EXPERIMENTAL)"
+	depends on ANDROID
+	help
+	  Use the experimental Soong plugin.
+
+endchoice

--- a/mconfig/host_toolchain.Mconfig
+++ b/mconfig/host_toolchain.Mconfig
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 Arm Limited.
+# Copyright 2016-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -124,7 +124,7 @@ config HOST_OBJCOPY_BINARY
 	string "Host objcopy"
 	default HOST_GNU_PREFIX + "objcopy" if HOST_TOOLCHAIN_GNU || (HOST_TOOLCHAIN_CLANG && HOST_CLANG_USE_GNU_BINUTILS)
 	default "llvm-objcopy" if HOST_TOOLCHAIN_CLANG
-	default "dsymutil" if OSX
+	default "dsymutil" if HOST_TOOLCHAIN_XCODE
 	default "objcopy"
 	help
 	  The objcopy executable that we can use in post install scripts

--- a/mconfig/target_toolchain.Mconfig
+++ b/mconfig/target_toolchain.Mconfig
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 Arm Limited.
+# Copyright 2016-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -121,7 +121,7 @@ config TARGET_OBJCOPY_BINARY
 	string "Target objcopy"
 	default TARGET_GNU_PREFIX + "objcopy" if TARGET_TOOLCHAIN_GNU || (TARGET_TOOLCHAIN_CLANG && TARGET_CLANG_USE_GNU_BINUTILS)
 	default "llvm-objcopy" if TARGET_TOOLCHAIN_CLANG
-	default "dsymutil" if OSX
+	default "dsymutil" if TARGET_TOOLCHAIN_XCODE
 	default "objcopy"
 	help
 	  The objcopy executable that we can use in post install scripts

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -13,67 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-## Operating system determines available builders, and used in
-## resource testing
-choice
-	prompt "Operating System"
-	default LINUX
-
-config LINUX
-	bool "Linux"
-
-config ANDROID
-	bool "Android"
-
-config OSX
-	bool "macOS"
-
-endchoice
+source "bob/mconfig/basics.Mconfig"
 
 config NOT_OSX
 	bool
 	default y if !OSX
-
-config OS
-	string
-	default "android" if ANDROID
-	default "osx" if OSX
-	default "linux"
-
-## Need to select the BUILDER_ for Bob
-choice
-	prompt "Builder"
-	default BUILDER_ANDROID_MAKE if ANDROID
-	default BUILDER_NINJA
-	help
-	  Bob supports generating output for different build systems.
-
-	  Select the desired build system.
-
-config BUILDER_NINJA
-	bool "Ninja"
-	help
-	  Generate build.ninja output to use with ninja.
-
-config BUILDER_ANDROID_MAKE
-	bool "Android make"
-	depends on ANDROID
-	help
-	  Generate Android.mk fragments for use with Android make.
-
-config BUILDER_ANDROID_BP
-	bool "Android.bp (EXPERIMENTAL)"
-	depends on ANDROID
-	help
-	  Integrate into Android's build system by writing Android.bp files.
-
-config BUILDER_SOONG
-	bool "Soong plugin (EXPERIMENTAL)"
-	depends on ANDROID
-	help
-	  Integrate into Android's build system by operating as a Soong plugin.
-
-endchoice
 
 config NOT_BUILDER_SOONG
 	bool


### PR DESCRIPTION
The BUILDER_* configs need to be available in all projects, so we want
these to be picked up from a single file defined by Bob.

The default builder may depend on OS, so we include the OS definitions
as well. Only define the choice in Bob, and modify the Go code to
avoid checking the string config.

Fixup objcopy binary definitions to default based on toolchain rather
than OS.

Change-Id: Ied1e450b1c8078694f33cb542ce9065672cc0afd
Signed-off-by: David Kilroy <david.kilroy@arm.com>