### PR TITLE
Implement Android.bp backend cc static library

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -31,12 +31,14 @@ bootstrap_go_package {
         "blueprint-bootstrap",
         "blueprint-pathtools",
         "bob-abstr",
+        "bob-bpwriter",
         "bob-graph",
         "bob-utils",
     ],
     srcs: [
-        "core/android_bp.go",
         "core/android_make.go",
+        "core/androidbp_backend.go",
+        "core/androidbp_cclibs.go",
         "core/alias.go",
         "core/build_structs.go",
         "core/config_props.go",
@@ -79,6 +81,14 @@ bootstrap_go_package {
         "abstr/standalone.go",
     ],
     pkgPath: "github.com/ARM-software/bob-build/abstr",
+}
+
+bootstrap_go_package {
+    name: "bob-bpwriter",
+    srcs: [
+        "internal/bpwriter/bpwriter.go",
+    ],
+    pkgPath: "github.com/ARM-software/bob-build/internal/bpwriter",
 }
 
 bootstrap_go_package {

--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2020 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package core
+
+// Support for building libraries and binaries via soong's cc_library
+// modules.
+
+import (
+	"fmt"
+
+	"github.com/google/blueprint"
+	"github.com/google/blueprint/proptools"
+
+	"github.com/ARM-software/bob-build/internal/bpwriter"
+	"github.com/ARM-software/bob-build/utils"
+)
+
+// Convert between Bob module names, and the name we will give the generated
+// cc_library module. This is required when a module supports being built on
+// host and target; we cannot create two modules with the same name, so
+// instead, we use the `shortName()` (which may include a `__host` or
+// `__target` suffix) to disambiguate, and use the `stem` property to fix up
+// the output filename.
+func ccModuleName(mctx blueprint.BaseModuleContext, buildbpName string) string {
+	var dep blueprint.Module
+
+	bobModuleName := bobName(buildbpName)
+
+	mctx.VisitDirectDeps(func(m blueprint.Module) {
+		if m.Name() == bobModuleName {
+			dep = m
+		}
+	})
+
+	if dep == nil {
+		panic(fmt.Errorf("%s has no dependency '%s'", mctx.ModuleName(), buildbpName))
+	}
+
+	if l, ok := getLibrary(dep); ok {
+		return l.shortName()
+	}
+
+	// Most cases should match the getLibrary() check above, but generated libraries,
+	// etc, do not, and they also do not require using shortName() (because of not
+	// being target-specific), so just use the original build.bp name.
+	return buildbpName
+}
+
+func ccModuleNames(mctx blueprint.BaseModuleContext, buildbpNameLists ...[]string) []string {
+	ccModules := []string{}
+	for _, buildbpNameList := range buildbpNameLists {
+		for _, buildbpName := range buildbpNameList {
+			ccModules = append(ccModules, ccModuleName(mctx, buildbpName))
+		}
+	}
+	return ccModules
+}
+
+func (l *library) getGeneratedSourceModules(mctx blueprint.BaseModuleContext) (srcs []string) {
+	mctx.VisitDirectDepsIf(
+		func(dep blueprint.Module) bool {
+			return mctx.OtherModuleDependencyTag(dep) == generatedSourceTag
+		},
+		func(dep blueprint.Module) {
+			switch dep.(type) {
+			case *generateSource:
+			case *transformSource:
+			default:
+				panic(fmt.Errorf("Dependency %s of %s is not a generated source",
+					dep.Name(), l.Name()))
+			}
+
+			srcs = append(srcs, buildbpName(dep.Name()))
+		})
+	return
+}
+
+func (l *library) getGeneratedHeaderModules(mctx blueprint.BaseModuleContext) (headers []string) {
+	mctx.VisitDirectDepsIf(
+		func(dep blueprint.Module) bool {
+			return mctx.OtherModuleDependencyTag(dep) == generatedHeaderTag
+		},
+		func(dep blueprint.Module) {
+			switch dep.(type) {
+			case *generateSource:
+			case *transformSource:
+			default:
+				panic(fmt.Errorf("Dependency %s of %s is not a generated source",
+					dep.Name(), l.Name()))
+			}
+
+			headers = append(headers, buildbpName(dep.Name()))
+		})
+	return
+}
+
+func addProvenanceProps(m bpwriter.Module, props AndroidProps) {
+	if props.Owner != "" {
+		m.AddString("owner", props.Owner)
+		m.AddBool("vendor", true)
+		m.AddBool("proprietary", true)
+		m.AddBool("soc_specific", true)
+	}
+}
+
+func addCcLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContext) {
+	if len(l.Properties.Export_include_dirs) > 0 {
+		panic(fmt.Errorf("Module %s exports non-local include dirs %v - this is not supported",
+			mctx.ModuleName(), l.Properties.Export_include_dirs))
+	}
+
+	// Soong deals with exported include directories between library
+	// modules, but it doesn't export cflags.
+	_, _, exported_cflags := l.GetExportedVariables(mctx)
+
+	cflags := utils.NewStringSlice(l.Properties.Cflags,
+		l.Properties.Export_cflags, exported_cflags)
+
+	sharedLibs := ccModuleNames(mctx, l.Properties.Shared_libs, l.Properties.Export_shared_libs)
+	staticLibs := ccModuleNames(mctx, l.Properties.ResolvedStaticLibs)
+	// Exported header libraries must be mentioned in both header_libs
+	// *and* export_header_lib_headers - i.e., we can't export a header
+	// library which isn't actually being used.
+	headerLibs := ccModuleNames(mctx, l.Properties.Header_libs, l.Properties.Export_header_libs)
+
+	reexportShared := []string{}
+	reexportStatic := []string{}
+	reexportHeaders := ccModuleNames(mctx, l.Properties.Export_header_libs)
+	for _, lib := range ccModuleNames(mctx, l.Properties.Reexport_libs) {
+		if utils.Contains(sharedLibs, lib) {
+			reexportShared = append(reexportShared, lib)
+		} else if utils.Contains(staticLibs, lib) {
+			reexportStatic = append(reexportStatic, lib)
+		} else if utils.Contains(headerLibs, lib) {
+			reexportHeaders = append(reexportHeaders, lib)
+		}
+	}
+
+	if l.shortName() != l.outputName() {
+		m.AddString("stem", l.outputName())
+	}
+	m.AddStringList("srcs", utils.Filter(utils.IsCompilableSource, l.Properties.Srcs))
+	m.AddStringList("generated_sources", l.getGeneratedSourceModules(mctx))
+	m.AddStringList("generated_headers", l.getGeneratedHeaderModules(mctx))
+	m.AddStringList("exclude_srcs", l.Properties.Exclude_srcs)
+	m.AddStringList("cflags", cflags)
+	m.AddStringList("include_dirs", l.Properties.Include_dirs)
+	m.AddStringList("local_include_dirs", l.Properties.Local_include_dirs)
+	m.AddStringList("shared_libs", ccModuleNames(mctx, l.Properties.Shared_libs, l.Properties.Export_shared_libs))
+	m.AddStringList("static_libs", staticLibs)
+	m.AddStringList("whole_static_libs", ccModuleNames(mctx, l.Properties.Whole_static_libs))
+	m.AddStringList("header_libs", headerLibs)
+	m.AddStringList("export_shared_lib_headers", reexportShared)
+	m.AddStringList("export_static_lib_headers", reexportStatic)
+	m.AddStringList("export_header_lib_headers", reexportHeaders)
+	m.AddStringList("ldflags", l.Properties.Ldflags)
+	if l.getInstallableProps().Relative_install_path != nil {
+		m.AddString("relative_install_path", proptools.String(l.getInstallableProps().Relative_install_path))
+	}
+
+	addProvenanceProps(m, l.Properties.Build.AndroidProps)
+}
+
+func addStaticOrSharedLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContext) {
+	// Soong's `export_include_dirs` field is relative to the module
+	// dir. The Android.bp backend writes the file into the project
+	// root, so we can use the Export_local_include_dirs property
+	// unchanged.
+	m.AddStringList("export_include_dirs", l.Properties.Export_local_include_dirs)
+}
+
+func addStripProp(m bpwriter.Module) {
+	g := m.NewGroup("strip")
+	g.AddBool("all", true)
+}
+
+func (g *androidBpGenerator) binaryActions(l *binary, mctx blueprint.ModuleContext) {
+	var modType string
+	switch l.Properties.TargetType {
+	case tgtTypeHost:
+		modType = "cc_binary_host"
+	case tgtTypeTarget:
+		modType = "cc_binary"
+	}
+
+	m, err := AndroidBpFile().NewModule(modType, l.shortName())
+	if err != nil {
+		panic(err.Error())
+	}
+
+	addCcLibraryProps(m, l.library, mctx)
+	if l.strip() {
+		addStripProp(m)
+	}
+}
+
+func (g *androidBpGenerator) sharedActions(l *sharedLibrary, mctx blueprint.ModuleContext) {
+	var modType string
+	switch l.Properties.TargetType {
+	case tgtTypeHost:
+		modType = "cc_library_host_shared"
+	case tgtTypeTarget:
+		modType = "cc_library_shared"
+	}
+
+	m, err := AndroidBpFile().NewModule(modType, l.shortName())
+	if err != nil {
+		panic(err.Error())
+	}
+
+	addCcLibraryProps(m, l.library, mctx)
+	addStaticOrSharedLibraryProps(m, l.library, mctx)
+	if l.strip() {
+		addStripProp(m)
+	}
+}
+
+func (g *androidBpGenerator) staticActions(l *staticLibrary, mctx blueprint.ModuleContext) {
+	var modType string
+	switch l.Properties.TargetType {
+	case tgtTypeHost:
+		modType = "cc_library_host_static"
+	case tgtTypeTarget:
+		modType = "cc_library_static"
+	}
+
+	m, err := AndroidBpFile().NewModule(modType, l.shortName())
+	if err != nil {
+		panic(err.Error())
+	}
+
+	addCcLibraryProps(m, l.library, mctx)
+	addStaticOrSharedLibraryProps(m, l.library, mctx)
+}

--- a/internal/bpwriter/bpwriter.go
+++ b/internal/bpwriter/bpwriter.go
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2020 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bpwriter
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Implement types and helpers to record all the modules that we want
+// to write into an Android.bp file.
+//
+// This is a really basic implementation that allows us to add key
+// value pairs to a module, and store string, bools and string lists.
+// Only a single level of nesting for properties is supported.
+
+func indentString(depth int) string {
+	return strings.Repeat(" ", depth*4)
+}
+
+var bpEscaper = strings.NewReplacer("\"", "\\\"")
+
+func Escape(s string) string {
+	return bpEscaper.Replace(s)
+}
+
+func EscapeList(slice []string) []string {
+	slice = append([]string(nil), slice...)
+	for i, s := range slice {
+		slice[i] = Escape(s)
+	}
+	return slice
+}
+
+// Key-value pair for a property
+type property struct {
+	// Property key
+	key string
+	// Property value represented as a string
+	value string
+}
+
+// Adjacent properties within an Android.bp file
+type Group interface {
+	AddString(name, value string)
+	AddBool(name string, value bool)
+	AddStringList(name string, list []string)
+}
+
+type group struct {
+	// The name of this group. "" for the top level group.
+	// This is necessary as we want to store group as an array
+	// rather than a map, to maintain ordering.
+	name string
+	// Depth
+	depth int
+	// Properties in the group.
+	// This is a list rather than a map to maintain ordering.
+	props []property
+}
+
+var _ Group = (*group)(nil)
+
+func (g *group) addProp(key, value string) {
+	p := property{
+		key:   key,
+		value: value,
+	}
+	g.props = append(g.props, p)
+}
+
+// Add a string property to the property group
+func (g *group) AddString(name, value string) {
+	g.addProp(name, "\""+Escape(value)+"\"")
+}
+
+// Add a boolean property to the property group
+func (g *group) AddBool(name string, value bool) {
+	if value {
+		g.addProp(name, "true")
+	} else {
+		g.addProp(name, "false")
+	}
+}
+
+// Add a string list property to the property group
+func (g *group) AddStringList(name string, list []string) {
+	if len(list) == 0 {
+		return
+	}
+
+	s := ""
+
+	if len(list) > 1 {
+		// Put each entry on a new line, indented
+		s += "[\n"
+		indent := indentString(g.depth + 1)
+		for _, v := range list {
+			s += indent + "\"" + Escape(v) + "\",\n"
+		}
+		// The list close is back-indented one tab
+		s += indentString(g.depth) + "]"
+	} else {
+		// One entry. Put on a single line.
+		s += "[\"" + Escape(list[0]) + "\"]"
+	}
+	g.addProp(name, s)
+}
+
+// Render the property group into a string
+func (g *group) render(b *strings.Builder) {
+	indent := indentString(g.depth)
+	for _, p := range g.props {
+		b.WriteString(indent + p.key + ": " + p.value + ",\n")
+	}
+}
+
+// Arbitrary Android.bp module
+//
+// No locking for modules, as the creation of each module is done
+// in a single thread.
+type Module interface {
+	Group
+	NewGroup(name string) Group
+}
+
+type module struct {
+	// Module type
+	modType string
+
+	// Module name
+	name string
+
+	// Top level properties of module
+	group
+
+	// Nested properties (1 level deep only)
+	groups []group
+}
+
+var _ Module = (*module)(nil)
+
+// Add a string property as a top level module property
+func (m *module) AddString(name, value string) {
+	m.group.AddString(name, value)
+}
+
+// Add a boolean property as a top level module property
+func (m *module) AddBool(name string, value bool) {
+	m.group.AddBool(name, value)
+}
+
+// Add a string list property as a top level module property
+func (m *module) AddStringList(name string, list []string) {
+	m.group.AddStringList(name, list)
+}
+
+// Create a property group in the module
+func (m *module) NewGroup(name string) Group {
+	g := group{}
+	g.name = name
+	g.depth = 2
+	m.groups = append(m.groups, g)
+	return &g
+}
+
+// Render the module into a string
+func (m *module) render(b *strings.Builder) {
+	indent := indentString(1)
+	b.WriteString(m.modType + " {\n" + indent + "name: \"" + m.name + "\",\n")
+	m.group.render(b)
+	for _, group := range m.groups {
+		b.WriteString(indent + group.name + ": {\n")
+		group.render(b)
+		b.WriteString(indent + "},\n")
+	}
+	b.WriteString("}\n\n")
+}
+
+func moduleFactory(modType, name string) *module {
+	m := module{}
+	m.modType = modType
+	m.name = name
+	m.group.name = ""
+	m.group.depth = 1
+	return &m
+}
+
+// Content for an Android.bp file
+type File interface {
+	NewModule(modType, name string) (Module, error)
+	Render(b *strings.Builder)
+}
+
+type file struct {
+	sync.Mutex
+	modules map[string]*module
+}
+
+var _ File = (*file)(nil)
+
+// Create a module
+func (f *file) NewModule(modType, name string) (Module, error) {
+	m := moduleFactory(modType, name)
+
+	// Lock the addition to ensure parallel build actions can add
+	// modules to the file.
+	f.Lock()
+	defer f.Unlock()
+
+	if _, dup := f.modules[name]; !dup {
+		f.modules[name] = m
+	} else {
+		err := fmt.Errorf("Duplicate module name (%s)", name)
+		return nil, err
+	}
+
+	return m, nil
+}
+
+// Render all the modules in the file
+func (f *file) Render(b *strings.Builder) {
+	modNames := make([]string, len(f.modules))
+	i := 0
+	for name, _ := range f.modules {
+		modNames[i] = name
+		i = i + 1
+	}
+	sort.Strings(modNames)
+	for _, name := range modNames {
+		f.modules[name].render(b)
+	}
+}
+
+func FileFactory() File {
+	f := file{}
+	f.modules = make(map[string]*module)
+	return &f
+}

--- a/tests/export_include_dirs/liba/build.bp
+++ b/tests/export_include_dirs/liba/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Arm Limited.
+ * Copyright 2018-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +37,12 @@ bob_static_library {
         ],
     },
     builder_soong: {
+        // Soong does not support exporting absolute include dirs.
+        export_local_include_dirs: [
+            "include2",
+        ],
+    },
+    builder_android_bp: {
         // Soong does not support exporting absolute include dirs.
         export_local_include_dirs: [
             "include2",


### PR DESCRIPTION
Add basic infrastructure to write out modules. Make writer an internal
package.

Move the Android.bp backend into a subdirectory, so we can implement
each support for each module in separate files.

Change-Id: I25b67876740fb61d14b549bc184260f21636ef14
Signed-off-by: David Kilroy <david.kilroy@arm.com>