### PR TITLE
Support globbing in implicit source lists

### DIFF
--- a/core/generated.go
+++ b/core/generated.go
@@ -267,11 +267,18 @@ func (m *generateCommon) getDepfile(g generatorBackend) (name string, depfile bo
 type GenerateSourceProps struct {
 	// The list of files that will be output.
 	Out []string
-	// List of implicit sources. Implicit sources are input files that do not get mentioned on the command line,
-	// and are not specified in the explicit sources.
+	// List of implicit sources. Implicit sources are input files that do not get
+	// mentioned on the command line, and are not specified in the explicit sources.
 	Implicit_srcs []string
-	// List of implicit outputs. Implicit outputs are output files that do not get mentioned on the command line.
+	// Implicit source files that should not be included. Use with care.
+	Exclude_implicit_srcs []string
+	// List of implicit outputs. Implicit outputs are output files that do not get
+	// mentioned on the command line.
 	Implicit_outs []string
+}
+
+func (g *GenerateSourceProps) getImplicitSources(ctx abstr.BaseModuleContext) []string {
+	return glob(ctx, g.Implicit_srcs, g.Exclude_implicit_srcs)
 }
 
 type generateSource struct {
@@ -449,7 +456,7 @@ func (m *generateSource) Inouts(ctx blueprint.ModuleContext, g generatorBackend)
 	if depfile, ok := m.getDepfile(g); ok {
 		io.depfile = depfile
 	}
-	io.implicitSrcs = utils.PrefixDirs(m.Properties.Implicit_srcs, g.sourcePrefix())
+	io.implicitSrcs = utils.PrefixDirs(m.Properties.getImplicitSources(ctx), g.sourcePrefix())
 	io.implicitOuts = m.implicitOutputs(g)
 
 	if m.generateCommon.Properties.Rsp_content != nil {

--- a/core/linux.go
+++ b/core/linux.go
@@ -177,13 +177,11 @@ func (g *linuxGenerator) generateCommonActions(m *generateCommon, ctx blueprint.
 			args["srcs_generated"] = strings.Join(sources, " ")
 		}
 
-		implicits = append(implicits, inout.implicitSrcs...)
-
 		buildparams := blueprint.BuildParams{
 			Rule:      rule,
 			Inputs:    inout.in,
 			Outputs:   inout.out,
-			Implicits: implicits,
+			Implicits: append(inout.implicitSrcs, implicits...),
 			Args:      args,
 			Optional:  true,
 		}

--- a/core/soong_gen.go
+++ b/core/soong_gen.go
@@ -167,7 +167,7 @@ func (m *genBackend) getHostBin(ctx android.ModuleContext) android.OptionalPath 
 func (m *genBackend) getArgs(ctx android.ModuleContext) (args map[string]string, dependents []android.Path) {
 	g := getBackend(ctx)
 
-	dependents = android.PathsForSource(ctx, m.Properties.Implicit_srcs)
+	dependents = android.PathsForSource(ctx, utils.PrefixDirs(m.Properties.Implicit_srcs, srcdir))
 	args = map[string]string{
 		"bob_config":      configFile,
 		"bob_config_opts": configOpts,
@@ -433,7 +433,9 @@ func (gc *generateCommon) createGenrule(mctx android.TopDownMutatorContext,
 }
 
 func (gs *generateSource) soongBuildActions(mctx android.TopDownMutatorContext) {
-	gs.createGenrule(mctx, gs.Properties.Out, gs.Properties.Implicit_srcs, gs.Properties.Implicit_outs, proptools.Bool(gs.generateCommon.Properties.Depfile), genBackendFactory)
+	gs.createGenrule(mctx, gs.Properties.Out, gs.Properties.getImplicitSources(mctx),
+		gs.Properties.Implicit_outs, proptools.Bool(gs.generateCommon.Properties.Depfile),
+		genBackendFactory)
 }
 
 func (gs *generateStaticLibrary) soongBuildActions(mctx android.TopDownMutatorContext) {

--- a/tests/build_tests.sh
+++ b/tests/build_tests.sh
@@ -202,6 +202,10 @@ SRC=tests/generate_source/depgen2.in
 UPDATE=(${build_dir}/gen/gen_source_depfile/output.txt)
 check_dep_updates "generate source depfile" "${build_dir}" "${SRC}" "${UPDATE[@]}"
 
+SRC=tests/generate_source/an.implicit.src
+UPDATE=(${build_dir}/gen/gen_source_globbed_implicit_sources/validate_globbed_implicit_dependency.c)
+check_dep_updates "generate source implicit source" "${build_dir}" "${SRC}" "${UPDATE[@]}"
+
 # resource dependencies
 SRC=tests/resources/main.c
 UPDATE=(${build_dir}/install/tests/linux/y/main.c)

--- a/tests/generate_source/build.bp
+++ b/tests/generate_source/build.bp
@@ -232,6 +232,21 @@ bob_generate_source {
     build_by_default: true,
 }
 
+bob_generate_source {
+    name: "gen_source_globbed_implicit_sources",
+    implicit_srcs: ["*.implicit.src"],
+    out: ["validate_globbed_implicit_dependency.c"],
+    cmd: "echo 'int main(void) { return 0; }' > ${out}",
+    build_by_default: true,
+}
+
+bob_binary {
+    name: "use_miscellaneous_generated_source_tests",
+    generated_sources: [
+        "gen_source_globbed_implicit_sources",
+    ],
+}
+
 bob_alias {
     name: "bob_test_generate_source",
     srcs: [
@@ -240,5 +255,6 @@ bob_alias {
         "bin_gen_sources_and_headers",
         "gen_source_depfile",
         "gen_source_depfile_with_implicit_outs",
+        "use_miscellaneous_generated_source_tests",
     ],
 }


### PR DESCRIPTION
Also fix a related bug found by inspection, where we were inadvertently
combining the implicit source list of every `inout` in transform source
module.

Change-Id: I0e65163ebb151a030e672e2a70e0a84eb233b4b2
Signed-off-by: Chris Diamand <chris.diamand@arm.com>