### PR TITLE
Support inclusion of ldlibs in output of bob_graphs

### DIFF
--- a/bob_graph.bash
+++ b/bob_graph.bash
@@ -53,6 +53,7 @@ echo "
 # green           - static library
 # orange          - shared library
 # gray            - binary
+# blue            - ldlib flag
 # yellow          - defaults module
 # white           - external library (not defined in Bob)
 
@@ -63,6 +64,7 @@ echo "
 # orange edge     - linked by shared_libs
 # green edge      - linked by static_libs
 # red edge        - linked by whole_static
+# blue edge       - linked by ldlibs
 # yellow edge     - uses defaults
 # dashed edge     - linked using an export_ property
 "

--- a/bob_graph.bash
+++ b/bob_graph.bash
@@ -18,10 +18,10 @@
 set -e
 
 # Example usage
-# ./bob_graph -graph_out=libMy -graph_who_uses=libMy,libOther -graph_dependencies=libMy,libOther
+# ./bob_graph --graph-start-nodes=libMy,libOther
 #
-# To view dependencies of libOther
-# ./bob_graph -graph_out=libOther_deps -graph_dependencies=libOther
+# To view users of libOther
+# ./bob_graph --graph-start-nodes=libOther --graph-rev-deps
 
 # Switch to the build directory
 cd "$(dirname "${BASH_SOURCE[0]}")"

--- a/bob_graph.bash
+++ b/bob_graph.bash
@@ -47,25 +47,24 @@ ninja -f "${BOB_BUILDER_NINJA}" "${BOB_BUILDER_TARGET}"
 
 echo "
 #
-# Legend description
+# Legend
 #
 # Nodes
-# green node            - static library
-# orange node           - shared library
-# gray node             - binary
-# yellow node           - default
+# green           - static library
+# orange          - shared library
+# gray            - binary
+# yellow          - defaults module
+# white           - external library (not defined in Bob)
 
 # Marked node
-# double circle         - marked node
+# double circle   -  marked node
 
 # Edges
-# orange edges          - content of shared_libs
-# orange-dashed edges   - content of export_shared_libs
-# green edges           - content of static_libs
-# green-dashed edges    - content of export_static_libs
-# red edges             - content of whole_static
-# yellow edges          - content of defaults
-#
+# orange edge     - linked by shared_libs
+# green edge      - linked by static_libs
+# red edge        - linked by whole_static
+# yellow edge     - uses defaults
+# dashed edge     - linked using an export_ property
 "
 
 "${BOB_BUILDER}" -l "${BLUEPRINT_LIST_FILE}" -b "${BUILDDIR}" "$@" "${SRCDIR}/${TOPNAME}"

--- a/bob_graph.bash
+++ b/bob_graph.bash
@@ -32,13 +32,18 @@ source ".bob.bootstrap"
 # Switch to the working directory
 cd "${WORKDIR}"
 
-BOB_BUILDER="${BUILDDIR}/.bootstrap/bin/bob"
+BOB_BUILDER_TARGET=".bootstrap/bin/bob"
+BOB_BUILDER="${BUILDDIR}/${BOB_BUILDER_TARGET}"
+BOB_BUILDER_NINJA="${BUILDDIR}/.bootstrap/build.ninja"
 
-if [ ! -f "${BOB_BUILDER}" ]; then
-	echo "Please first run buildme"
-	echo "Missing bob_builder: ${BOB_BUILDER}"
+if [ ! -f "${BOB_BUILDER_NINJA}" ]; then
+	echo "Missing ${BOB_BUILDER_NINJA}"
+	echo "Please build your project first"
 	exit 1
 fi
+
+# Make sure Bob is built
+ninja -f "${BOB_BUILDER_NINJA}" "${BOB_BUILDER_TARGET}"
 
 echo "
 #


### PR DESCRIPTION
bob_graphs produces a graph of the libraries bob is aware of that are used in a build. ldlibs is a mechanism via which we reference system libraries in the build. However ldlibs are not currently included in bob_graph output.

This commit adds support for including libraries that we link via ldlibs. While we're there, tidy up the command line and legend, and ensure that Bob is rebuilt if needed (which simplifies making updates to the graph).