### PR TITLE
Update Android.bp ccLibrary support to filter cflags

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -70,6 +70,7 @@ bootstrap_go_package {
     testSrcs: [
         "core/feature_test.go",
         "core/template_test.go",
+        "core/androidbp_test.go",
     ],
     pkgPath: "github.com/ARM-software/bob-build/core",
 }
@@ -96,6 +97,9 @@ bootstrap_go_package {
 
 bootstrap_go_package {
     name: "bob-ccflags",
+    deps: [
+        "bob-utils",
+    ],
     srcs: [
         "internal/ccflags/ccflags.go",
     ],

--- a/core/androidbp_test.go
+++ b/core/androidbp_test.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"testing"
+
+	"github.com/ARM-software/bob-build/internal/bpwriter"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockModule struct {
+	mock.Mock
+	bpwriter.Module
+}
+
+func (m *MockModule) AddString(name, value string) {
+	m.Called(name, value)
+}
+
+func Test_filterCFlags(t *testing.T) {
+	m := new(MockModule)
+
+	m.On("AddString", "c_std", "c11")
+	m.On("AddString", "cpp_std", "c++11")
+	m.On("AddString", "instruction_set", "arm")
+
+	cflags := []string{"-marm", "-mx32", "-cl-no-signed-zeros"}
+	conlyFlags := []string{"-std=c11"}
+	cxxFlags := []string{"-std=c++11"}
+
+	assert.Equal(t, []string{"-cl-no-signed-zeros"}, filterCFlags(m, cflags, conlyFlags, cxxFlags))
+
+	m.AssertExpectations(t)
+}
+
+func Test_filterCFlags2(t *testing.T) {
+	m := new(MockModule)
+
+	m.On("AddString", "c_std", "c17")
+	m.On("AddString", "cpp_std", "c++17")
+	m.On("AddString", "instruction_set", "thumb")
+
+	cflags := []string{"-mthumb", "-mx32"}
+	conlyFlags := []string{"-std=c17"}
+	cxxFlags := []string{"-std=c++17"}
+
+	assert.Equal(t, []string(nil), filterCFlags(m, cflags, conlyFlags, cxxFlags))
+
+	m.AssertExpectations(t)
+}
+
+func Test_filterCFlags3(t *testing.T) {
+	m := new(MockModule)
+
+	m.On("AddString", "cpp_std", "c++17")
+
+	cflags := []string{"-mx32"}
+	conlyFlags := []string{}
+	cxxFlags := []string{"-std=c++17"}
+
+	assert.Equal(t, []string(nil), filterCFlags(m, cflags, conlyFlags, cxxFlags))
+
+	m.AssertExpectations(t)
+}

--- a/internal/ccflags/ccflags.go
+++ b/internal/ccflags/ccflags.go
@@ -21,6 +21,8 @@ package ccflags
 
 import (
 	"strings"
+
+	"github.com/ARM-software/bob-build/internal/utils"
 )
 
 // This flag is a machine specific option
@@ -57,4 +59,28 @@ func AndroidCompileFlags(s string) bool {
 // properties.
 func AndroidLinkFlags(s string) bool {
 	return !machineSpecificFlag(s)
+}
+
+func GetCompilerStandard(flags ...[]string) (std string) {
+	// Look for the flag setting compiler standard
+	stdList := utils.Filter(CompilerStandard, flags...)
+	if len(stdList) > 0 {
+		// Use last definition only
+		std = strings.TrimPrefix(stdList[len(stdList)-1], "-std=")
+	}
+	return
+}
+
+func GetArmMode(flags ...[]string) (armMode string) {
+	// Look for the flag setting thumb or not thumb
+	thumb := utils.Filter(ThumbFlag, flags...)
+	arm := utils.Filter(ArmFlag, flags...)
+	if len(thumb) > 0 && len(arm) > 0 {
+		panic("Both thumb and no thumb (arm) options are specified")
+	} else if len(thumb) > 0 {
+		armMode = "thumb"
+	} else if len(arm) > 0 {
+		armMode = "arm"
+	}
+	return
 }


### PR DESCRIPTION
This commit updates Android.bp backend to extract C/C++ standard flags
as well as `-mthumb` and `-marm` by setting appropriate Soong properties,
while removing all other `-m.*` options.

Change-Id: I52f7f6427e60563c5b7c0e447e804f10db9ce4aa
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>