### PR TITLE
Always run config when no arguments provided

### DIFF
--- a/tests/bootstrap_android
+++ b/tests/bootstrap_android
@@ -121,7 +121,7 @@ source "${BUILDDIR}/.bob.bootstrap"
 # Setup the buildme script to just run bob
 ln -sf "bob" "${BUILDDIR}/buildme"
 
-if [ ! -z "$*" ] || [ ! -f "$ANDROIDMK_DIR/$CONFIGNAME" ] ; then
+if [ $MENU -ne 1 ] || [ ! -f "$ANDROIDMK_DIR/$CONFIGNAME" ] ; then
     # Have arguments or missing bob.config. Run config.
     "$ANDROIDMK_DIR/config" ANDROID=y "$@"
 fi

--- a/tests/bootstrap_androidbp
+++ b/tests/bootstrap_androidbp
@@ -107,7 +107,7 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 # Pick up some info that bob has worked out
 source "${BUILDDIR}/.bob.bootstrap"
 
-if [ ! -z "$*" ] || [ ! -f "${BPBUILD_DIR}/${CONFIGNAME}" ] ; then
+if [ $MENU -ne 1 ] || [ ! -f "${BPBUILD_DIR}/${CONFIGNAME}" ] ; then
     # Have arguments or missing bob.config. Run config.
     "${BPBUILD_DIR}/config" ANDROID=y BUILDER_ANDROID_BP=y "$@"
 fi


### PR DESCRIPTION
Refresh the configuration every time bootstrap_androidbp is run, even
when no arguments are provided. This makes it consistent with the
behaviour when initially run (which already runs the config, even with
no arguments specified).

Update Android.mk behaviour to do the same.

Change-Id: I6f1e08f5aebaf7d71ec415650a7b3180d74210a2
Signed-off-by: Chris Diamand <chris.diamand@arm.com>