### PR TITLE
Set kernel and generated compiler on Android.bp

### DIFF
--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -211,7 +211,7 @@ config STATIC_LIB_TOGGLE
 config GEN_CC
 	string "Compiler"
 	default "$(CLANG) -fuse-ld=lld" if BUILDER_ANDROID_MAKE
-	default HOST_CLANG_PREFIX + CLANG_CC_BINARY + " -fuse-ld=lld" if BUILDER_SOONG
+	default HOST_CLANG_PREFIX + CLANG_CC_BINARY + " -fuse-ld=lld" if BUILDER_ANDROID_BP || BUILDER_SOONG
 	default HOST_GNU_PREFIX + GNU_CC_BINARY
 
 config GEN_AR
@@ -222,7 +222,7 @@ config GEN_AR
 config KERNEL_CC
 	string "Kernel compiler"
 	default "$(CLANG)" if BUILDER_ANDROID_MAKE
-	default HOST_CLANG_PREFIX + CLANG_CC_BINARY if BUILDER_SOONG
+	default HOST_CLANG_PREFIX + CLANG_CC_BINARY if BUILDER_ANDROID_BP || BUILDER_SOONG
 
 config KERNEL_CLANG_TRIPLE
 	string "Kernel Clang triple"


### PR DESCRIPTION
On Android.bp we need to get the full path to the compiler used for
generated sources and kernel modules. This is the same as for the Soong
plugin, so add some `|| BUILDER_ANDROID_BP` clauses to the relevant
config options.

Change-Id: Ie83aff7c12bff9f616e009066eab9f1694248f17
Signed-off-by: Chris Diamand <chris.diamand@arm.com>