### PR TITLE
Specify cxxflags & conlyflags and refactor ccflags package

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -96,7 +96,12 @@ func specifyCompilerStandard(varname string, flags ...[]string) (line string) {
 }
 
 func specifyArmMode(flags ...[]string) (line string) {
-	if armMode := ccflags.GetArmMode(flags...); armMode != "" {
+	armMode, err := ccflags.GetArmMode(flags...)
+	if err != nil {
+		panic(err)
+	}
+
+	if armMode != "" {
 		line = "LOCAL_ARM_MODE:=" + armMode + "\n"
 	}
 	return

--- a/core/androidbp_test.go
+++ b/core/androidbp_test.go
@@ -35,48 +35,73 @@ func (m *MockModule) AddString(name, value string) {
 	m.Called(name, value)
 }
 
-func Test_filterCFlags(t *testing.T) {
+func (m *MockModule) AddStringList(name string, values []string) {
+	m.Called(name, values)
+}
+
+func Test_addCFlags(t *testing.T) {
 	m := new(MockModule)
 
 	m.On("AddString", "c_std", "c11")
 	m.On("AddString", "cpp_std", "c++11")
 	m.On("AddString", "instruction_set", "arm")
+	m.On("AddStringList", "cflags", []string{"-cl-no-signed-zeros"})
+	m.On("AddStringList", "conlyflags", []string(nil))
+	m.On("AddStringList", "cxxflags", []string(nil))
 
 	cflags := []string{"-marm", "-mx32", "-cl-no-signed-zeros"}
 	conlyFlags := []string{"-std=c11"}
 	cxxFlags := []string{"-std=c++11"}
 
-	assert.Equal(t, []string{"-cl-no-signed-zeros"}, filterCFlags(m, cflags, conlyFlags, cxxFlags))
+	addCFlags(m, cflags, conlyFlags, cxxFlags)
 
 	m.AssertExpectations(t)
 }
 
-func Test_filterCFlags2(t *testing.T) {
+func Test_addCFlags2(t *testing.T) {
 	m := new(MockModule)
 
 	m.On("AddString", "c_std", "c17")
 	m.On("AddString", "cpp_std", "c++17")
 	m.On("AddString", "instruction_set", "thumb")
+	m.On("AddStringList", "cflags", []string(nil))
+	m.On("AddStringList", "conlyflags", []string(nil))
+	m.On("AddStringList", "cxxflags", []string(nil))
 
 	cflags := []string{"-mthumb", "-mx32"}
 	conlyFlags := []string{"-std=c17"}
 	cxxFlags := []string{"-std=c++17"}
 
-	assert.Equal(t, []string(nil), filterCFlags(m, cflags, conlyFlags, cxxFlags))
+	addCFlags(m, cflags, conlyFlags, cxxFlags)
 
 	m.AssertExpectations(t)
 }
 
-func Test_filterCFlags3(t *testing.T) {
+func Test_addCFlags3(t *testing.T) {
 	m := new(MockModule)
 
 	m.On("AddString", "cpp_std", "c++17")
+	m.On("AddStringList", "cflags", []string(nil))
+	m.On("AddStringList", "conlyflags", []string(nil))
+	m.On("AddStringList", "cxxflags", []string(nil))
 
 	cflags := []string{"-mx32"}
 	conlyFlags := []string{}
 	cxxFlags := []string{"-std=c++17"}
 
-	assert.Equal(t, []string(nil), filterCFlags(m, cflags, conlyFlags, cxxFlags))
+	addCFlags(m, cflags, conlyFlags, cxxFlags)
 
 	m.AssertExpectations(t)
+}
+
+func Test_addCFlags4(t *testing.T) {
+	m := new(MockModule)
+
+	cflags := []string{"-marm", "-mthumb"}
+	conlyFlags := []string{}
+	cxxFlags := []string{}
+
+	err := addCFlags(m, cflags, conlyFlags, cxxFlags)
+
+	assert.Equal(t, err.Error(), "Both thumb and no thumb (arm) options are specified")
 }

--- a/internal/ccflags/ccflags.go
+++ b/internal/ccflags/ccflags.go
@@ -20,6 +20,7 @@ package ccflags
 // Encapsulate knowledge about common compiler and linker flags
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/ARM-software/bob-build/internal/utils"
@@ -31,15 +32,15 @@ func machineSpecificFlag(s string) bool {
 }
 
 // This flag selects the compiler standard
-func CompilerStandard(s string) bool {
+func compilerStandard(s string) bool {
 	return strings.HasPrefix(s, "-std=")
 }
 
-func ThumbFlag(s string) bool {
+func thumbFlag(s string) bool {
 	return s == "-mthumb"
 }
 
-func ArmFlag(s string) bool {
+func armFlag(s string) bool {
 	return s == "-marm" || s == "-mno-thumb"
 }
 
@@ -49,7 +50,7 @@ func ArmFlag(s string) bool {
 // can do multi-arch builds) and compiler standard, so filter these
 // out from module properties.
 func AndroidCompileFlags(s string) bool {
-	return !(machineSpecificFlag(s) || CompilerStandard(s))
+	return !(machineSpecificFlag(s) || compilerStandard(s))
 }
 
 // Identify whether a link flag should be used on android
@@ -63,7 +64,7 @@ func AndroidLinkFlags(s string) bool {
 
 func GetCompilerStandard(flags ...[]string) (std string) {
 	// Look for the flag setting compiler standard
-	stdList := utils.Filter(CompilerStandard, flags...)
+	stdList := utils.Filter(compilerStandard, flags...)
 	if len(stdList) > 0 {
 		// Use last definition only
 		std = strings.TrimPrefix(stdList[len(stdList)-1], "-std=")
@@ -71,12 +72,12 @@ func GetCompilerStandard(flags ...[]string) (std string) {
 	return
 }
 
-func GetArmMode(flags ...[]string) (armMode string) {
+func GetArmMode(flags ...[]string) (armMode string, err error) {
 	// Look for the flag setting thumb or not thumb
-	thumb := utils.Filter(ThumbFlag, flags...)
-	arm := utils.Filter(ArmFlag, flags...)
+	thumb := utils.Filter(thumbFlag, flags...)
+	arm := utils.Filter(armFlag, flags...)
 	if len(thumb) > 0 && len(arm) > 0 {
-		panic("Both thumb and no thumb (arm) options are specified")
+		err = fmt.Errorf("Both thumb and no thumb (arm) options are specified")
 	} else if len(thumb) > 0 {
 		armMode = "thumb"
 	} else if len(arm) > 0 {


### PR DESCRIPTION
This commit removes redundant exports and calls to `panic` (the errors
are instead propagated to `bob/core`) from `ccflags` package, and also
adds code to specify `cxxflags` and `conlyflags` in `core/androidbp_cclibs.go`.

Change-Id: I63187da005aa14d48665c12f8d84b1ec97103407
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>