### PR TITLE
Follow toolchain symlinks

### DIFF
--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -139,7 +139,9 @@ func lookPathSecond(toolUnqualified string, firstHit string) (string, error) {
 	return "", &exec.Error{Name: toolUnqualified, Err: exec.ErrNotFound}
 }
 
-func getToolPath(toolUnqualified string) (toolPath string) {
+func getToolPath(toolUnqualified string) string {
+	var toolPath string
+
 	if filepath.IsAbs(toolUnqualified) {
 		toolPath = toolUnqualified
 		toolUnqualified = filepath.Base(toolUnqualified)
@@ -163,7 +165,15 @@ func getToolPath(toolUnqualified string) (toolPath string) {
 			}
 		}
 	}
-	return
+
+	// Follow symlinks to get to the actual tool location, in case e.g. it
+	// is going via something like update-alternatives.
+	realToolPath, err := filepath.EvalSymlinks(toolPath)
+	if err != nil {
+		panic(fmt.Errorf("Could not follow toolchain symlink %s: %v", toolPath, err))
+	}
+
+	return realToolPath
 }
 
 // Run the compiler with the -print-file-name option, and return the result.


### PR DESCRIPTION
Correctly detect the installation locations of toolchains accessed via
update-alternatives links by expanding symlinks in $PATH.

Change-Id: Ib097bc6f97fdfec16d8e65029be2a6a9eb2a3678
Signed-off-by: Chris Diamand <chris.diamand@arm.com>