### PR TITLE
Implement generator actions for Android.bp

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -44,6 +44,7 @@ bootstrap_go_package {
         "core/androidbp_cclibs.go",
         "core/androidbp_kernel_module.go",
         "core/androidbp_resource.go",
+        "core/androidbp_generated.go",
         "core/alias.go",
         "core/build_structs.go",
         "core/config_props.go",

--- a/bootstrap_androidbp.bash
+++ b/bootstrap_androidbp.bash
@@ -31,7 +31,7 @@ function die {
 
 # Remove any stalled symlinks from Soong plugin bootstrap
 pushd "${SRCDIR}" >&/dev/null
-find -name Android.bp -xtype l -delete
+find -name Android.bp -type l -delete
 popd >&/dev/null
 
 # Set up Android.bp with plugins

--- a/core/androidbp_backend.go
+++ b/core/androidbp_backend.go
@@ -44,15 +44,6 @@ func AndroidBpFile() bpwriter.File {
 }
 
 func (g *androidBpGenerator) aliasActions(*alias, blueprint.ModuleContext) {}
-func (g *androidBpGenerator) generateSourceActions(*generateSource, blueprint.ModuleContext, []inout) {
-}
-func (g *androidBpGenerator) genBinaryActions(*generateBinary, blueprint.ModuleContext, []inout) {}
-func (g *androidBpGenerator) genSharedActions(*generateSharedLibrary, blueprint.ModuleContext, []inout) {
-}
-func (g *androidBpGenerator) genStaticActions(*generateStaticLibrary, blueprint.ModuleContext, []inout) {
-}
-func (g *androidBpGenerator) transformSourceActions(*transformSource, blueprint.ModuleContext, []inout) {
-}
 
 func (g *androidBpGenerator) buildDir() string                         { return "" }
 func (g *androidBpGenerator) sourcePrefix() string                     { return "" }

--- a/core/androidbp_generated.go
+++ b/core/androidbp_generated.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/blueprint"
+	"github.com/google/blueprint/proptools"
+
+	"github.com/ARM-software/bob-build/internal/bpwriter"
+)
+
+func (g *androidBpGenerator) genBinaryActions(m *generateBinary, mctx blueprint.ModuleContext, inouts []inout) {
+	if enabledAndRequired(m) {
+		panic(fmt.Errorf("Generated binaries are not supported (%s)", m.Name()))
+	}
+}
+
+func (g *androidBpGenerator) genSharedActions(m *generateSharedLibrary, mctx blueprint.ModuleContext, inouts []inout) {
+	if enabledAndRequired(m) {
+		panic(fmt.Errorf("Generated shared libraries are not supported (%s)", m.Name()))
+	}
+}
+
+func (g *androidBpGenerator) genStaticActions(m *generateStaticLibrary, mctx blueprint.ModuleContext, inouts []inout) {
+	if enabledAndRequired(m) {
+		panic(fmt.Errorf("Generated static libraries are not supported (%s)", m.Name()))
+	}
+}
+
+func populateCommonProps(gc *generateCommon, mctx blueprint.ModuleContext, m bpwriter.Module) {
+	// Replace ${args} immediately
+	cmd := strings.Replace(proptools.String(gc.Properties.Cmd), "${args}",
+		strings.Join(gc.Properties.Args, " "), -1)
+	m.AddString("cmd", cmd)
+
+	if gc.Properties.Tool != nil {
+		m.AddString("tool", *gc.Properties.Tool)
+	}
+	if gc.Properties.Rsp_content != nil {
+		m.AddString("rsp_content", *gc.Properties.Rsp_content)
+	}
+	if gc.Properties.Host_bin != nil {
+		m.AddString("host_bin", ccModuleName(mctx, gc.getHostBinModule(mctx).Name()))
+	}
+	m.AddBool("depfile", proptools.Bool(gc.Properties.Depfile))
+
+	m.AddStringList("module_deps", gc.Properties.Module_deps)
+	m.AddStringList("module_srcs", gc.Properties.Module_srcs)
+	m.AddStringList("encapsulates", gc.Properties.Encapsulates)
+	m.AddStringList("export_gen_include_dirs", gc.Properties.Export_gen_include_dirs)
+	m.AddStringList("cflags", gc.Properties.FlagArgsBuild.Cflags)
+	m.AddStringList("conlyflags", gc.Properties.FlagArgsBuild.Conlyflags)
+	m.AddStringList("cxxflags", gc.Properties.FlagArgsBuild.Cxxflags)
+	m.AddStringList("asflags", gc.Properties.FlagArgsBuild.Asflags)
+	m.AddStringList("ldflags", gc.Properties.FlagArgsBuild.Ldflags)
+	m.AddStringList("ldlibs", gc.Properties.FlagArgsBuild.Ldlibs)
+}
+
+func (g *androidBpGenerator) generateSourceActions(gs *generateSource, mctx blueprint.ModuleContext, inouts []inout) {
+	if !enabledAndRequired(gs) {
+		return
+	}
+
+	m, err := AndroidBpFile().NewModule("genrule_bob", gs.shortName())
+	if err != nil {
+		panic(err.Error())
+	}
+
+	m.AddStringList("srcs", gs.generateCommon.Properties.getSources(mctx))
+	m.AddStringList("out", gs.Properties.Out)
+	m.AddStringList("implicit_srcs", gs.Properties.Implicit_srcs)
+	m.AddStringList("implicit_outs", gs.Properties.Implicit_outs)
+
+	populateCommonProps(&gs.generateCommon, mctx, m)
+}
+
+func (g *androidBpGenerator) transformSourceActions(ts *transformSource, mctx blueprint.ModuleContext, inouts []inout) {
+	if !enabledAndRequired(ts) {
+		return
+	}
+
+	m, err := AndroidBpFile().NewModule("genrule_bob", ts.shortName())
+	if err != nil {
+		panic(err.Error())
+	}
+
+	m.AddStringList("multi_out_srcs", ts.generateCommon.Properties.getSources(mctx))
+
+	gr := m.NewGroup("multi_out_props")
+	// if REs had double slashes in original value, at parsing they got removed, so compensate for that
+	gr.AddString("match", strings.Replace(ts.Properties.TransformSourceProps.Out.Match, "\\", "\\\\", -1))
+	gr.AddStringList("replace", ts.Properties.TransformSourceProps.Out.Replace)
+	gr.AddStringList("implicit_srcs", ts.Properties.TransformSourceProps.Out.Implicit_srcs)
+	gr.AddStringList("implicit_outs", ts.Properties.TransformSourceProps.Out.Implicit_outs)
+
+	populateCommonProps(&ts.generateCommon, mctx, m)
+}

--- a/plugins/Android.bp.in
+++ b/plugins/Android.bp.in
@@ -16,6 +16,15 @@
  */
 
 bootstrap_go_package {
+    name: "bob-utils-@@PROJ_NAME@@",
+    pluginFor: ["soong_build"],
+    srcs: [
+        "../internal/utils/utils.go",
+    ],
+    pkgPath: "github.com/ARM-software/bob-build/internal/utils",
+}
+
+bootstrap_go_package {
     name: "bob-plugins-prebuilt-@@PROJ_NAME@@",
     pluginFor: ["soong_build"],
     deps: [
@@ -25,4 +34,20 @@ bootstrap_go_package {
         "prebuilt/prebuilt_data.go",
     ],
     pkgPath: "github.com/ARM-software/bob-build/plugins/prebuilt",
+}
+
+bootstrap_go_package {
+    name: "bob-plugins-genrulebob-@@PROJ_NAME@@",
+    pluginFor: ["soong_build"],
+    deps: [
+        "blueprint",
+        "soong-android",
+        "soong-cc",
+        "soong-genrule",
+        "bob-utils-@@PROJ_NAME@@",
+    ],
+    srcs: [
+        "genrulebob/genrule.go",
+    ],
+    pkgPath: "github.com/ARM-software/bob-build/plugins/genrulebob",
 }

--- a/plugins/genrulebob/genrule.go
+++ b/plugins/genrulebob/genrule.go
@@ -47,7 +47,7 @@ type GenruleProps struct {
 	Implicit_outs           []string
 	Export_gen_include_dirs []string
 	Cmd                     string
-	HostBin                 string
+	Host_bin                string
 	Tool                    string
 	Depfile                 bool
 	Module_deps             []string
@@ -168,9 +168,9 @@ func (m *genrulebob) GeneratedDeps() (srcs android.Paths) {
 }
 
 func (m *genrulebob) DepsMutator(mctx android.BottomUpMutatorContext) {
-	if m.Properties.HostBin != "" {
+	if m.Properties.Host_bin != "" {
 		mctx.AddFarVariationDependencies(mctx.Config().BuildOSTarget.Variations(),
-			hostToolBinTag, m.Properties.HostBin)
+			hostToolBinTag, m.Properties.Host_bin)
 	}
 
 	// `module_deps` and `module_srcs` can refer not only to source
@@ -188,13 +188,13 @@ func (m *genrulebob) DepsMutator(mctx android.BottomUpMutatorContext) {
 }
 
 func (m *genrulebob) getHostBin(ctx android.ModuleContext) android.OptionalPath {
-	if m.Properties.HostBin == "" {
+	if m.Properties.Host_bin == "" {
 		return android.OptionalPath{}
 	}
-	hostBinModule := ctx.GetDirectDepWithTag(m.Properties.HostBin, hostToolBinTag)
+	hostBinModule := ctx.GetDirectDepWithTag(m.Properties.Host_bin, hostToolBinTag)
 	htp, ok := hostBinModule.(genrule.HostToolProvider)
 	if !ok {
-		panic(fmt.Errorf("%s is not a host tool", m.Properties.HostBin))
+		panic(fmt.Errorf("%s is not a host tool", m.Properties.Host_bin))
 	}
 	return htp.HostToolPath()
 }
@@ -387,7 +387,7 @@ func (m *genrulebob) GenerateAndroidBuildActions(ctx android.ModuleContext) {
 	}
 
 	if m.Properties.Tool != "" {
-		tool := android.PathForSource(ctx, filepath.Join(ctx.ModuleDir(), m.Properties.Tool))
+		tool := android.PathForModuleSrc(ctx, m.Properties.Tool)
 		args["tool"] = tool.String()
 		implicits = append(implicits, tool)
 	}

--- a/tests/generate_libs/build.bp
+++ b/tests/generate_libs/build.bp
@@ -70,6 +70,10 @@ bob_generate_shared_library {
         /* On Soong generated libraries are not supported. */
         enabled: false,
     },
+    builder_android_bp: {
+        /* On Android BP generated libraries are not supported. */
+        enabled: false,
+    },
 }
 
 bob_binary {
@@ -81,7 +85,11 @@ bob_binary {
     target_supported: false,
     build_by_default: true,
     builder_soong: {
-        /* On Soong generated binaries are not supported. */
+        /* On Soong generated libraries are not supported. */
+        enabled: false,
+    },
+    builder_android_bp: {
+        /* On Android BP generated libraries are not supported. */
         enabled: false,
     },
 }
@@ -105,6 +113,10 @@ bob_generate_static_library {
         /* On Soong generated libraries are not supported. */
         enabled: false,
     },
+    builder_android_bp: {
+        /* On Android BP generated libraries are not supported. */
+        enabled: false,
+    },
 }
 
 bob_binary {
@@ -116,7 +128,11 @@ bob_binary {
     target_supported: false,
     build_by_default: true,
     builder_soong: {
-        /* On Soong generated binaries are not supported. */
+        /* On Soong generated libraries are not supported. */
+        enabled: false,
+    },
+    builder_android_bp: {
+        /* On Android BP generated libraries are not supported. */
         enabled: false,
     },
 }

--- a/tests/match_source/build.bp
+++ b/tests/match_source/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Arm Limited.
+ * Copyright 2019-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,6 +47,10 @@ bob_binary {
     osx: {
         srcs: ["order_file.txt"],
         ldflags: ["-Wl,-order_file,{{match_srcs \"*.txt\"}}"],
+    },
+    builder_android_bp: {
+        /* On Android BP match_srcs macro is not working correctly yet */
+        enabled: false,
     },
 }
 

--- a/tests/rsp/build.bp
+++ b/tests/rsp/build.bp
@@ -53,10 +53,13 @@ bob_binary {
         "-Wall",
         "-Werror",
     ],
-    // RSP files do work on Soong, but `module_srcs` is not currently
+    // RSP files do work on Soong and Android.bp, but `module_srcs` is not currently
     // implemented, so the merge_multiple_sources module generates incorrect
     // output. This should be re-enabled once `module_srcs` is fixed.
     builder_soong: {
+        enabled: false,
+    },
+    builder_android_bp: {
         enabled: false,
     },
 }


### PR DESCRIPTION
Add missing genrule plugin definition.

HostBin property renamed to Host_bin, as required by Soong.

Add Tool property handling in processPaths().

Slight refactoring of getHostBinModule and getHostBin functions.

Disabled some tests not supported on Android BP backend.

Fix deleting of stalled Android.bp symlinks.

Change-Id: I2f4f04b6a09472e0520608bac65727a86a186c5a
Signed-off-by: Michal Przeplata <michal.przeplata@arm.com>