### PR TITLE
Path helpers II

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -520,7 +520,7 @@ func (g *androidMkGenerator) resourceActions(m *resource, ctx blueprint.ModuleCo
 	androidMkWriteString(ctx, m.altShortName(), sb)
 }
 
-func (g *androidMkGenerator) sourcePrefix() string {
+func (g *androidMkGenerator) sourceDir() string {
 	return "$(LOCAL_PATH)"
 }
 
@@ -530,7 +530,7 @@ func (g *androidMkGenerator) buildDir() string {
 
 func (g *androidMkGenerator) bobScriptsDir() string {
 	srcToScripts, _ := filepath.Rel(getSourceDir(), getBobScriptsDir())
-	return filepath.Join(g.sourcePrefix(), srcToScripts)
+	return filepath.Join(g.sourceDir(), srcToScripts)
 }
 
 func outputDirVarName(m *generateCommon) string {

--- a/core/android_make.go
+++ b/core/android_make.go
@@ -528,6 +528,11 @@ func (g *androidMkGenerator) buildDir() string {
 	return "$(BOB_ANDROIDMK_DIR)"
 }
 
+func (g *androidMkGenerator) bobScriptsDir() string {
+	srcToScripts, _ := filepath.Rel(getSourceDir(), getBobScriptsDir())
+	return filepath.Join(g.sourcePrefix(), srcToScripts)
+}
+
 func outputDirVarName(m *generateCommon) string {
 	return m.Name() + "_GEN_DIR"
 }

--- a/core/androidbp_backend.go
+++ b/core/androidbp_backend.go
@@ -55,7 +55,13 @@ func (g *androidBpGenerator) genStaticActions(*generateStaticLibrary, blueprint.
 func (g *androidBpGenerator) transformSourceActions(*transformSource, blueprint.ModuleContext, []inout) {
 }
 
-func (g *androidBpGenerator) buildDir() string { return "" }
+func (g *androidBpGenerator) buildDir() string {
+	// The androidbp backend writes an Android.bp file, which should
+	// never reference an actual output directory (which will be
+	// chosen by Soong). Therefore this function returns an empty
+	// string.
+	return ""
+}
 
 func (g *androidBpGenerator) sourceDir() string {
 	// The androidbp backend writes paths into an Android.bp file in
@@ -71,12 +77,31 @@ func (g *androidBpGenerator) bobScriptsDir() string {
 	return filepath.Join(g.sourceDir(), srcToScripts)
 }
 
-func (g *androidBpGenerator) sharedLibsDir(tgtType) string             { return "" }
+func (g *androidBpGenerator) sharedLibsDir(tgtType) string {
+	// When writing link commands, it's common to put all the shared
+	// libraries in a single location to make it easy for the linker to
+	// find them. This function tells us where this is for the current
+	// generatorBackend.
+	//
+	// In the androidbp backend, we don't write link command lines. Soong
+	// will do this after processing the generated Android.bp. Therefore
+	// this function just returns an empty string.
+	return ""
+}
+
+//// Module specific functions identifying where backends expect module output to go.
+
+// The androidbp backend writes Android.bp files, which should never
+// need to reference files in their actual output location. Soong will
+// add the necessary paths when it runs. Therefore all these return an
+// empty string.
 func (g *androidBpGenerator) sourceOutputDir(*generateCommon) string   { return "" }
 func (g *androidBpGenerator) binaryOutputDir(*binary) string           { return "" }
 func (g *androidBpGenerator) staticLibOutputDir(*staticLibrary) string { return "" }
 func (g *androidBpGenerator) sharedLibOutputDir(*sharedLibrary) string { return "" }
 func (g *androidBpGenerator) kernelModOutputDir(*kernelModule) string  { return "" }
+
+//// End module specific functions
 
 type androidBpSingleton struct {
 }

--- a/core/androidbp_backend.go
+++ b/core/androidbp_backend.go
@@ -18,6 +18,7 @@
 package core
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/google/blueprint"
@@ -54,8 +55,22 @@ func (g *androidBpGenerator) genStaticActions(*generateStaticLibrary, blueprint.
 func (g *androidBpGenerator) transformSourceActions(*transformSource, blueprint.ModuleContext, []inout) {
 }
 
-func (g *androidBpGenerator) buildDir() string                         { return "" }
-func (g *androidBpGenerator) sourcePrefix() string                     { return "" }
+func (g *androidBpGenerator) buildDir() string { return "" }
+
+func (g *androidBpGenerator) sourcePrefix() string {
+	// The androidbp backend writes paths into an Android.bp file in
+	// the project directory. All paths should be relative to that
+	// file, so there should be no need for the source directory.
+	return ""
+}
+
+func (g *androidBpGenerator) bobScriptsDir() string {
+	// In the androidbp backend, we just want the relative path to the
+	// script directory.
+	srcToScripts, _ := filepath.Rel(getSourceDir(), getBobScriptsDir())
+	return filepath.Join(g.sourcePrefix(), srcToScripts)
+}
+
 func (g *androidBpGenerator) sharedLibsDir(tgtType) string             { return "" }
 func (g *androidBpGenerator) sourceOutputDir(*generateCommon) string   { return "" }
 func (g *androidBpGenerator) binaryOutputDir(*binary) string           { return "" }

--- a/core/androidbp_backend.go
+++ b/core/androidbp_backend.go
@@ -57,7 +57,7 @@ func (g *androidBpGenerator) transformSourceActions(*transformSource, blueprint.
 
 func (g *androidBpGenerator) buildDir() string { return "" }
 
-func (g *androidBpGenerator) sourcePrefix() string {
+func (g *androidBpGenerator) sourceDir() string {
 	// The androidbp backend writes paths into an Android.bp file in
 	// the project directory. All paths should be relative to that
 	// file, so there should be no need for the source directory.
@@ -68,7 +68,7 @@ func (g *androidBpGenerator) bobScriptsDir() string {
 	// In the androidbp backend, we just want the relative path to the
 	// script directory.
 	srcToScripts, _ := filepath.Rel(getSourceDir(), getBobScriptsDir())
-	return filepath.Join(g.sourcePrefix(), srcToScripts)
+	return filepath.Join(g.sourceDir(), srcToScripts)
 }
 
 func (g *androidBpGenerator) sharedLibsDir(tgtType) string             { return "" }

--- a/core/androidbp_kernel_module.go
+++ b/core/androidbp_kernel_module.go
@@ -48,7 +48,7 @@ func (g *androidBpGenerator) kernelModuleActions(l *kernelModule, mctx blueprint
 
 	out := l.outputName() + ".ko"
 
-	kmod_build, _ := filepath.Rel(getSourceDir(), getPathInScriptDir("kmod_build.py"))
+	kmod_build := getBackendPathInBobScriptsDir(g, "kmod_build.py")
 
 	srcs := l.Properties.getSources(mctx)
 	for _, mod := range l.extraSymbolsModules(mctx) {

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -88,6 +88,7 @@ type generatorBackend interface {
 	// Backend specific info for module types
 	buildDir() string
 	sourcePrefix() string
+	bobScriptsDir() string
 	sharedLibsDir(tgt tgtType) string
 	sourceOutputDir(m *generateCommon) string
 	binaryOutputDir(m *binary) string
@@ -117,6 +118,10 @@ type AndroidProps struct {
 	Owner string
 }
 
+func getBobScriptsDir() string {
+	return filepath.Join(getBobDir(), "scripts")
+}
+
 // Construct a path to a file within the build directory that Go can
 // use to create a file.
 //
@@ -141,15 +146,6 @@ func getPathsInSourceDir(filelist []string) []string {
 	return utils.PrefixDirs(filelist, getSourceDir())
 }
 
-// Construct a path to a file within the scripts directory that Go can
-// use to create a file.
-//
-// This _is_ intended for use in writing ninja rules, but will use an explicit path
-// instead of backend specific variable expansions.
-func getPathInScriptDir(elems ...string) string {
-	return filepath.Join(append([]string{getBobDir(), "scripts"}, elems...)...)
-}
-
 // Construct a path to a file within the build directory to be used
 // in backend output files.
 func getBackendPathInBuildDir(g generatorBackend, elems ...string) string {
@@ -166,6 +162,12 @@ func getBackendPathInSourceDir(g generatorBackend, elems ...string) string {
 // backend output files.
 func getBackendPathsInSourceDir(g generatorBackend, filelist []string) []string {
 	return utils.PrefixDirs(filelist, g.sourcePrefix())
+}
+
+// Construct a path to a file within the scripts directory to be used
+// in backend output files.
+func getBackendPathInBobScriptsDir(g generatorBackend, elems ...string) string {
+	return filepath.Join(append([]string{g.bobScriptsDir()}, elems...)...)
 }
 
 func glob(ctx abstr.BaseModuleContext, globs []string, excludes []string) []string {

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -87,7 +87,7 @@ type generatorBackend interface {
 
 	// Backend specific info for module types
 	buildDir() string
-	sourcePrefix() string
+	sourceDir() string
 	bobScriptsDir() string
 	sharedLibsDir(tgt tgtType) string
 	sourceOutputDir(m *generateCommon) string
@@ -155,13 +155,13 @@ func getBackendPathInBuildDir(g generatorBackend, elems ...string) string {
 // Construct a path to a file within the source directory to be used
 // in backend output files.
 func getBackendPathInSourceDir(g generatorBackend, elems ...string) string {
-	return filepath.Join(append([]string{g.sourcePrefix()}, elems...)...)
+	return filepath.Join(append([]string{g.sourceDir()}, elems...)...)
 }
 
 // Construct paths to files within the source directory to be used in
 // backend output files.
 func getBackendPathsInSourceDir(g generatorBackend, filelist []string) []string {
-	return utils.PrefixDirs(filelist, g.sourcePrefix())
+	return utils.PrefixDirs(filelist, g.sourceDir())
 }
 
 // Construct a path to a file within the scripts directory to be used

--- a/core/filepath.go
+++ b/core/filepath.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Arm Limited.
+ * Copyright 2019-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,7 +68,7 @@ func (file sourceFilePath) moduleDir() string {
 }
 
 func newSourceFilePath(path string, ctx abstr.BaseModuleContext, g generatorBackend) filePath {
-	return sourceFilePath{path, projectModuleDir(ctx), g.sourcePrefix()}
+	return sourceFilePath{path, projectModuleDir(ctx), g.sourceDir()}
 }
 
 // Represents a file created in the generated output directory

--- a/core/generated.go
+++ b/core/generated.go
@@ -394,7 +394,7 @@ func (m *generateCommon) getArgs(ctx blueprint.ModuleContext) (string, map[strin
 		"headers_generated": "",
 		"module_dir":        getBackendPathInSourceDir(g, ctx.ModuleDir()),
 		"shared_libs_dir":   g.sharedLibsDir(m.Properties.GenerateProps.Target),
-		"src_dir":           g.sourcePrefix(),
+		"src_dir":           g.sourceDir(),
 		"srcs_generated":    "",
 	}
 

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -174,7 +174,7 @@ func (m *kernelModule) generateKbuildArgs(ctx abstr.VisitableModuleContext) kbui
 		extraIncludePaths = append(extraIncludePaths, includeDir)
 	}
 
-	kmodBuild := getPathInScriptDir("kmod_build.py")
+	kmodBuild := getBackendPathInBobScriptsDir(g, "kmod_build.py")
 	kdir := m.Properties.Build.Kernel_dir
 	if kdir != "" && !filepath.IsAbs(kdir) {
 		kdir = getBackendPathInSourceDir(g, kdir)

--- a/core/linux.go
+++ b/core/linux.go
@@ -42,6 +42,9 @@ var (
 	_ = pctx.VariableFunc("BuildDir", func(interface{}) (string, error) {
 		return getBuildDir(), nil
 	})
+	_ = pctx.VariableFunc("BobScriptsDir", func(interface{}) (string, error) {
+		return getBobScriptsDir(), nil
+	})
 )
 
 type linuxGenerator struct {
@@ -84,6 +87,10 @@ func (g *linuxGenerator) sourcePrefix() string {
 
 func (g *linuxGenerator) buildDir() string {
 	return "${BuildDir}"
+}
+
+func (g *linuxGenerator) bobScriptsDir() string {
+	return "${BobScriptsDir}"
 }
 
 func (g *linuxGenerator) sourceOutputDir(m *generateCommon) string {
@@ -463,7 +470,7 @@ var staticLibraryRule = pctx.StaticRule("static_library",
 		Description: "$out",
 	}, "ar", "build_wrapper")
 
-var wholeStaticScript = getPathInScriptDir("whole_static.py")
+var wholeStaticScript = "${BobScriptsDir}/whole_static.py"
 var wholeStaticLibraryRule = pctx.StaticRule("whole_static_library",
 	blueprint.RuleParams{
 		Command:     "$whole_static_tool --build-wrapper \"$build_wrapper\" --ar $ar --out $out $in $whole_static_libs",
@@ -803,7 +810,7 @@ func (*linuxGenerator) aliasActions(m *alias, ctx blueprint.ModuleContext) {
 		})
 }
 
-var stripScript = getPathInScriptDir("strip.py")
+var stripScript = "${BobScriptsDir}/strip.py"
 var stripRule = pctx.StaticRule("strip",
 	blueprint.RuleParams{
 		Command: stripScript +

--- a/core/linux.go
+++ b/core/linux.go
@@ -81,7 +81,7 @@ func addPhony(p phonyInterface, ctx blueprint.ModuleContext,
 		})
 }
 
-func (g *linuxGenerator) sourcePrefix() string {
+func (g *linuxGenerator) sourceDir() string {
 	return "${SrcDir}"
 }
 

--- a/core/soong_plugin.go
+++ b/core/soong_plugin.go
@@ -139,7 +139,7 @@ func (g *soongGenerator) staticActions(*staticLibrary, blueprint.ModuleContext) 
 func (g *soongGenerator) transformSourceActions(*transformSource, blueprint.ModuleContext, []inout) {}
 
 func (g *soongGenerator) buildDir() string                           { return getBuildDir() }
-func (g *soongGenerator) sourcePrefix() string                       { return getSourceDir() }
+func (g *soongGenerator) sourceDir() string                          { return getSourceDir() }
 func (g *soongGenerator) bobScriptsDir() string                      { return getBobScriptsDir() }
 func (g *soongGenerator) sharedLibsDir(tgt tgtType) string           { return "" }
 func (g *soongGenerator) sourceOutputDir(m *generateCommon) string   { return "" }

--- a/core/soong_plugin.go
+++ b/core/soong_plugin.go
@@ -140,6 +140,7 @@ func (g *soongGenerator) transformSourceActions(*transformSource, blueprint.Modu
 
 func (g *soongGenerator) buildDir() string                           { return getBuildDir() }
 func (g *soongGenerator) sourcePrefix() string                       { return getSourceDir() }
+func (g *soongGenerator) bobScriptsDir() string                      { return getBobScriptsDir() }
 func (g *soongGenerator) sharedLibsDir(tgt tgtType) string           { return "" }
 func (g *soongGenerator) sourceOutputDir(m *generateCommon) string   { return "" }
 func (g *soongGenerator) binaryOutputDir(m *binary) string           { return "" }


### PR DESCRIPTION
Fixup the path helper for the script directory so that it can use build system path variables.
Rename sourcePrefix() for consistency.
Add documentation for the Android backend path helpers.