### PR TITLE
relative_path: Expand source symlinks

### DIFF
--- a/bob.bash
+++ b/bob.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 source ".bob.bootstrap"
 
 # Switch to the working directory
-cd "${WORKDIR}"
+cd -P "${WORKDIR}"
 
 # Get Bob bootstrap version
 source "${BOB_DIR}/bob.bootstrap.version"

--- a/bob_graph.bash
+++ b/bob_graph.bash
@@ -30,7 +30,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 source ".bob.bootstrap"
 
 # Switch to the working directory
-cd "${WORKDIR}"
+cd -P "${WORKDIR}"
 
 BOB_BUILDER_TARGET=".bootstrap/bin/bob"
 BOB_BUILDER="${BUILDDIR}/${BOB_BUILDER_TARGET}"

--- a/config.bash
+++ b/config.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,7 +43,7 @@ do
 done
 
 # Move to the working directory
-cd "${WORKDIR}"
+cd -P "${WORKDIR}"
 
 "${BOB_DIR}/config_system/update_config.py" --new -d "${SRCDIR}/Mconfig" \
     ${BOB_CONFIG_OPTS} ${BOB_CONFIG_PLUGIN_OPTS} \

--- a/menuconfig.bash
+++ b/menuconfig.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ cd $(dirname "${BASH_SOURCE[0]}")
 source ".bob.bootstrap"
 
 # Move to the working directory
-cd "${WORKDIR}"
+cd -P "${WORKDIR}"
 
 "${BOB_DIR}/config_system/menuconfig.py" -d "${SRCDIR}/Mconfig" \
     ${BOB_CONFIG_OPTS} ${BOB_CONFIG_PLUGIN_OPTS} \

--- a/tests/build_tests.sh
+++ b/tests/build_tests.sh
@@ -74,7 +74,9 @@ pushd "${BOB_ROOT}" &> /dev/null
 
 TEST_DIRS=("build-indep"
            "build-in-outp"
-           "tests/build-in-src")
+           "tests/build-in-src"
+           "build-link"
+           "build-link-target")
 rm -rf "${TEST_DIRS[@]}"
 
 # Test by explicitly requesting the `bob_tests` alias, which should include all
@@ -90,6 +92,14 @@ popd &> /dev/null
 
 # Build in an independent working directory
 build_dir=build-indep
+tests/bootstrap_linux -o ${build_dir}
+${build_dir}/config ${OPTIONS} && ${build_dir}/buildme bob_tests
+check_build_output "${build_dir}"
+
+# Build in a directory referred to via a symlink
+build_dir=build-link
+mkdir -p build-link-target/builds/build
+ln -s build-link-target/builds/build ${build_dir}
 tests/bootstrap_linux -o ${build_dir}
 ${build_dir}/config ${OPTIONS} && ${build_dir}/buildme bob_tests
 check_build_output "${build_dir}"

--- a/tests/relative_path_tests.sh
+++ b/tests/relative_path_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,8 +27,15 @@ function test_relpath() {
     local SOURCE="${1}"
     local TARGET="${2}"
     local EXPECTED="${3}"
+    local STDERR="${4}"
+    local RESULT=
 
-    local RESULT=$(relative_path "${SOURCE}" "${TARGET}")
+    if [ -n "${STDERR}" ]; then
+        RESULT="$(relative_path "${SOURCE}" "${TARGET}" 2>&1)"
+        EXPECTED="${STDERR}"
+    else
+        RESULT="$(relative_path "${SOURCE}" "${TARGET}")"
+    fi
 
     if [ "${RESULT}" != "${EXPECTED}" ] ; then
         echo FAIL: relative_path ${SOURCE} ${TARGET} expected to return ${EXPECTED}, got ${RESULT}
@@ -36,16 +43,10 @@ function test_relpath() {
     fi
 }
 
-if [ -e "a" ] ; then
-    echo "Abort: Need to create temporary directory heirarchy to test. 'a' already exists"
-    exit 1
-fi
-if [ -e "x" ] ; then
-    echo "Abort: Need to create temporary directory heirarchy to test. 'x' already exists"
-    exit 1
-fi
+TEST_DIR="$(mktemp -d -t relative_path_tests.XXXXXX)"
+pushd "${TEST_DIR}" >&/dev/null
 
-mkdir -p "a/b/c"
+mkdir -p "a/b/c/d"
 mkdir -p "a/b2/c"
 mkdir -p "a/b/g"
 mkdir -p "a/e/g"
@@ -86,9 +87,60 @@ test_relpath "a/b2/c" "a/b"  "../../b"
 test_relpath "/usr" "/bin" "../bin"
 test_relpath "/usr/local/bin" "/bin/bash" "../../../bin/bash"
 test_relpath "/" "/usr/include/stdio.h" "usr/include/stdio.h"
-test_relpath "/bin" "/" ".."
+# On merged-usr systems, `/bin` is a symlink to `/usr/bin`, so needs an extra
+# `..` for this case.
+[[ -L /bin ]] && test_relpath "/bin" "/" "../.." || test_relpath "/bin" "/" ".."
+
+# Test when the source path contains symlinks. This is a non-trivial part of
+# the implementation, because using `..` on symlinked directory will return the
+# parent dir of the _target_, not the link. When this is the case, some
+# symlinks may need to be expanded.
+ln -s "a/b" "sym"
+
+test_relpath "sym" "a/b/c" "c"
+test_relpath "sym/c" "sym/c/d" "d"
+test_relpath "sym/c/d" "sym/c" ".."
+test_relpath "sym" "." "../.."
+
+# Test with source paths containing multiple symlinks. The top-level
+# `multiple_links` directory should generally _not_ be expanded in these test
+# cases, but the symlinks inside it are.
+mkdir -p "multiple_links_dir/first_linked_dir"
+mkdir -p "multiple_links_dir/first_linked_dir/a"
+mkdir -p "multiple_links_dir/first_linked_dir/x/y/z"
+ln -s "multiple_links_dir/first_linked_dir" "multiple_links"
+ln -s "x/y" "multiple_links/sym_y"
+
+test_relpath "multiple_links" "multiple_links/sym_y/z" "sym_y/z"
+test_relpath "multiple_links/sym_y" "multiple_links" "../.."
+test_relpath "multiple_links/sym_y/z" "multiple_links" "../../.."
+test_relpath "multiple_links/sym_y/z" "multiple_links/a" "../../../a"
+test_relpath "multiple_links/sym_y/z" "sym/c" "../../../../../sym/c"
+test_relpath "multiple_links" "multiple_links" "."
+test_relpath "multiple_links" "multiple_links_dir/first_linked_dir/x/y" "x/y"
+test_relpath "multiple_links_dir" "multiple_links/x" "../multiple_links/x"
+
+# Check that nothing goes horribly wrong with recursive symlinks
+ln -s "cycle1" "cycle2"
+ln -s "cycle2" "cycle1"
+test_relpath "cycle1" "cycle2" "" "relative_path: Source path 'cycle1' does not exist"
+
+# Create a directory of symlinks all pointing to their parent dir, which means
+# we can construct paths within it containing any combination of the directory
+# names.
+mkdir "combinations"
+for i in a b c; do
+    mkdir "combinations/${i}"
+    for j in a b c; do
+        ln -s ".." "combinations/${i}/${j}"
+    done
+done
+
+test_relpath "combinations/c/b/a" "combinations/b" "../b"
+test_relpath "combinations/c/a" "combinations/b/c/a/b" "b/c/a/b"
 
 # Cleanup
-rm -rf a x
+popd >&/dev/null
+rm -rf "${TEST_DIR}"
 
 exit ${HAVE_FAILURE}


### PR DESCRIPTION
The current implementation of `relative_path` in `pathtools.bash` does a
simple lexical calculation on the absolute paths to calculate the
result.

However, this is not correct if the source path contains a symlink. This
is because using `..` from inside a soft-linked directory will return
the parent directory of the *link target*, not the link location.

For example, consider the directory `/x/y`, and a symlink `/y -> /x/y`.

At first glance, and according to the current implementation,
the relative path from `/y` to somewhere outside it (say `/home`) should
be `../home`. However, because of the aforementioned reason, this is
incorrect. The `/y` symlink points  to `/x/y`, and therefore to get up
to the root directory we need *two* `../` path components. So the
correct relative path result from `/y` to `/home` is `../../home`.

The simple solution to this would be to simply expand all symlinks in
the source path. However, this doesn't really make sense without also
expanding the target, which we can't do, because of commit `dfcae5e
Don't expand symlinks in relative_path`. Consider for example a source
and target directory, both inside a symlinked dir (e.g. `/y/src` and
`/y/target`). The relative path from source to target is obviously
`../target`, regardless of the `/y` symlink; however, expanding just the
source symlink would result in comparing `/x/y/src` and `/y/target`,
resulting in `../../y/target` - a correct but unnecessarily complicated
answer.

Instead, limit symlink expanding to as few source path components as
possible. When we "chop off" a path component in order to find a common
prefix, we must expand links if that component is a symlink. If we do
not "reach" that path component, though, it is left as-is. This results
in the correct and simplest answer for both the "`/home` from `/y`"
*and* "`/y/target` from `/y/src`" cases.

Update the relative path tests to cover this. To handle the extra links
and directories created, simplify the cleanup code by running the tests
inside a temporary directory.

Remove the comment incorrectly stating that an absolute path will be
returned if it is shorter than the relative one.

Fix up some of the Bob scripts to use `cd -P` rather than `cd`; this
causes `cd` to go to the "physical" parent directory rather than the
logical, which is required now that paths inside `.bob.bootstrap` are
calculated w.r.t. the physical directory layout.

Change-Id: I4f16d64ead8e49466a7f2ea708fc85d64cadc481
Signed-off-by: Chris Diamand <chris.diamand@arm.com>