### PR TITLE
Deprecate export_[ldlibs|shared_libs|static_libs]

### DIFF
--- a/bob_graph.bash
+++ b/bob_graph.bash
@@ -58,7 +58,7 @@ echo "
 # white           - external library (not defined in Bob)
 
 # Marked node
-# double circle   -  marked node
+# double circle   - marked node
 
 # Edges
 # orange edge     - linked by shared_libs
@@ -66,7 +66,7 @@ echo "
 # red edge        - linked by whole_static
 # blue edge       - linked by ldlibs
 # yellow edge     - uses defaults
-# dashed edge     - linked using an export_ property
+# dashed edge     - dependency propagated to closest binary or shared library
 "
 
 "${BOB_BUILDER}" -l "${BLUEPRINT_LIST_FILE}" -b "${BUILDDIR}" "$@" "${SRCDIR}/${TOPNAME}"

--- a/core/android_make.go
+++ b/core/android_make.go
@@ -253,11 +253,9 @@ func androidLibraryBuildAction(sb *strings.Builder, mod blueprint.Module, ctx bl
 	// Setup ARM mode if needed
 	sb.WriteString(specifyArmMode(cflagsList, m.Properties.Conlyflags, m.Properties.Cxxflags))
 
-	// convert Shared_libs, Export_shared_libs, Resolved_static_libs, and
-	// Whole_static_libs to Android module names rather than Bob module
-	// names
-	sharedLibs := append(androidModuleNames(m.Properties.Shared_libs),
-		androidModuleNames(m.Properties.Export_shared_libs)...)
+	// convert Shared_libs, Resolved_static_libs, and Whole_static_libs
+	// to Android module names rather than Bob module names
+	sharedLibs := androidModuleNames(m.Properties.Shared_libs)
 	staticLibs := androidModuleNames(m.Properties.ResolvedStaticLibs)
 	wholeStaticLibs := androidModuleNames(m.Properties.Whole_static_libs)
 	exportHeaderLibs := androidModuleNames(m.Properties.Export_header_libs)

--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -152,7 +152,7 @@ func addCcLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContex
 
 	cflags := utils.NewStringSlice(l.Properties.Cflags, l.Properties.Export_cflags, exported_cflags)
 
-	sharedLibs := ccModuleNames(mctx, l.Properties.Shared_libs, l.Properties.Export_shared_libs)
+	sharedLibs := ccModuleNames(mctx, l.Properties.Shared_libs)
 	staticLibs := ccModuleNames(mctx, l.Properties.ResolvedStaticLibs)
 	// Exported header libraries must be mentioned in both header_libs
 	// *and* export_header_lib_headers - i.e., we can't export a header
@@ -185,7 +185,7 @@ func addCcLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContex
 	}
 	m.AddStringList("include_dirs", l.Properties.Include_dirs)
 	m.AddStringList("local_include_dirs", l.Properties.Local_include_dirs)
-	m.AddStringList("shared_libs", ccModuleNames(mctx, l.Properties.Shared_libs, l.Properties.Export_shared_libs))
+	m.AddStringList("shared_libs", ccModuleNames(mctx, l.Properties.Shared_libs))
 	m.AddStringList("static_libs", staticLibs)
 	m.AddStringList("whole_static_libs", ccModuleNames(mctx, l.Properties.Whole_static_libs))
 	m.AddStringList("header_libs", headerLibs)

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -363,13 +363,11 @@ func dependerMutator(mctx blueprint.BottomUpMutatorContext) {
 		}
 		mctx.AddVariationDependencies(nil, wholeStaticDepTag, build.Whole_static_libs...)
 		mctx.AddVariationDependencies(nil, staticDepTag, build.Static_libs...)
-		mctx.AddVariationDependencies(nil, staticDepTag, build.Export_static_libs...)
 
 		mctx.AddVariationDependencies(nil, headerDepTag, build.Header_libs...)
 		mctx.AddVariationDependencies(nil, headerDepTag, build.Export_header_libs...)
 
 		mctx.AddVariationDependencies(nil, sharedDepTag, build.Shared_libs...)
-		mctx.AddVariationDependencies(nil, sharedDepTag, build.Export_shared_libs...)
 	}
 	if km, ok := mctx.Module().(*kernelModule); ok {
 		mctx.AddDependency(mctx.Module(), kernelModuleDepTag, km.Properties.Extra_symbols...)

--- a/core/graphviz.go
+++ b/core/graphviz.go
@@ -121,6 +121,7 @@ func (handler *graphvizHandler) graphvizMutator(mctx blueprint.BottomUpMutatorCo
 	}
 
 	showLdlibs := handler.showLdlibs
+	depEdgeStyle := "solid"
 
 	// Set type of node
 	switch mainModule.(type) {
@@ -133,6 +134,7 @@ func (handler *graphvizHandler) graphvizMutator(mctx blueprint.BottomUpMutatorCo
 		// Don't show ldlibs usage on static libraries, as these
 		// aren't actually applied
 		showLdlibs = false
+		depEdgeStyle = "dashed"
 	case *sharedLibrary:
 		if !handler.showSharedLibraries {
 			return
@@ -161,12 +163,7 @@ func (handler *graphvizHandler) graphvizMutator(mctx blueprint.BottomUpMutatorCo
 			for _, lib := range mainBuild.Shared_libs {
 				handler.graph.AddEdge(mainModule.Name(), lib)
 				handler.graph.SetEdgeColor(mainModule.Name(), lib, "orange")
-			}
-
-			for _, lib := range mainBuild.Export_shared_libs {
-				handler.graph.AddEdge(mainModule.Name(), lib)
-				handler.graph.SetEdgeColor(mainModule.Name(), lib, "orange")
-				handler.graph.SetEdgeProperty(mainModule.Name(), lib, "style", "dashed")
+				handler.graph.SetEdgeProperty(mainModule.Name(), lib, "style", depEdgeStyle)
 			}
 		}
 
@@ -174,12 +171,7 @@ func (handler *graphvizHandler) graphvizMutator(mctx blueprint.BottomUpMutatorCo
 			for _, lib := range mainBuild.Static_libs {
 				handler.graph.AddEdge(mainModule.Name(), lib)
 				handler.graph.SetEdgeColor(mainModule.Name(), lib, "green")
-			}
-
-			for _, lib := range mainBuild.Export_static_libs {
-				handler.graph.AddEdge(mainModule.Name(), lib)
-				handler.graph.SetEdgeColor(mainModule.Name(), lib, "green")
-				handler.graph.SetEdgeProperty(mainModule.Name(), lib, "style", "dashed")
+				handler.graph.SetEdgeProperty(mainModule.Name(), lib, "style", depEdgeStyle)
 			}
 		}
 
@@ -199,14 +191,7 @@ func (handler *graphvizHandler) graphvizMutator(mctx blueprint.BottomUpMutatorCo
 				handler.graph.SetNodeBackgroundColor(lib, "skyblue")
 				handler.graph.AddEdge(mainModule.Name(), lib)
 				handler.graph.SetEdgeColor(mainModule.Name(), lib, "skyblue")
-			}
-
-			// We will only be outputing export_ldlibs for defaults
-			for _, lib := range mainBuild.Export_ldlibs {
-				handler.graph.SetNodeBackgroundColor(lib, "skyblue")
-				handler.graph.AddEdge(mainModule.Name(), lib)
-				handler.graph.SetEdgeColor(mainModule.Name(), lib, "skyblue")
-				handler.graph.SetEdgeProperty(mainModule.Name(), lib, "style", "dashed")
+				handler.graph.SetEdgeProperty(mainModule.Name(), lib, "style", depEdgeStyle)
 			}
 		}
 	}

--- a/core/linux.go
+++ b/core/linux.go
@@ -478,10 +478,6 @@ var wholeStaticLibraryRule = pctx.StaticRule("whole_static_library",
 	}, "ar", "build_wrapper", "whole_static_libs", "whole_static_tool")
 
 func (g *linuxGenerator) staticActions(m *staticLibrary, ctx blueprint.ModuleContext) {
-	if len(m.Properties.Static_libs) > 0 || len(m.Properties.Shared_libs) > 0 {
-		panic(errors.New("static library cannot include another library, only include it using whole_static"))
-	}
-
 	rule := staticLibraryRule
 
 	buildWrapper, buildWrapperDeps := m.Properties.Build.getBuildWrapperAndDeps(ctx)

--- a/docs/module_types/bob_defaults.md
+++ b/docs/module_types/bob_defaults.md
@@ -45,18 +45,15 @@ bob_defaults {
     ldflags: ["..."],
     export_ldflags: ["..."],
 
-    static_libs: ["bob_static_lib.name"],
-    export_static_libs: ["..."],
+    static_libs: ["bob_static_lib.name", "..."],
 
-    shared_libs: ["bob_shared_lib.name"],
-    export_shared_libs: ["..."],
+    shared_libs: ["bob_shared_lib.name", "..."],
 
     reexport_libs: ["bob_shared_lib.name", "bob_static_lib.name"],
 
     whole_static_libs: ["bob_shared_lib.name", "bob_static_lib.name"],
 
-    ldlibs: ["-lz"],
-    export_ldlibs: ["-llog"],
+    ldlibs: ["-lz", "..."],
 
     generated_headers: ["bob_generate_source.name"],
     generated_sources: ["bob_transform_source.name"],

--- a/docs/module_types/bob_static_library.md
+++ b/docs/module_types/bob_static_library.md
@@ -13,8 +13,12 @@ linker command-line - in this example, `libA` must appear *before* `libB`.
 With shared libraries, this is handled automatically by the linker, because
 dependencies can be encoded in the shared library file itself. However,
 static libraries are simply collections of `.o` files, so this is not possible.
-Instead, Bob provides two tools to automatically generate the correct library
-order - `export_static_libs` and `whole_static_libs`.
+Bob allows static libraries to declare dependencies on other static libraries.
+When binaries and shared libraries are linked, all dependent static libraries
+are sorted and added to the command line. Bob also allows static libraries to
+specify dependent shared libraries and ldlibs, and these will all propagate to
+the link commands of binaries and shared libraries that use the static library.
+`whole_static_libs` can also be used to aggregate static libraries.
 
 ## Full specification of `bob_static_library` properties
 `bob_static_library` supports [features](../features.md)
@@ -53,14 +57,14 @@ bob_static_library {
     ldflags: ["..."],
     export_ldflags: ["..."],
 
-    export_static_libs: ["libFooStatic"],
+    static_libs: ["libFooStatic"],
 
-    export_shared_libs: ["..."],
+    shared_libs: ["..."],
 
     reexport_libs: ["bob_shared_lib.name", "bob_static_lib.name"],
     whole_static_libs: ["bob_static_lib.name"],
 
-    export_ldlibs: ["-llog"],
+    ldlibs: ["-llog"],
 
     generated_headers: ["bob_generate_source.name"],
     generated_sources: ["bob_transform_source.name"],
@@ -90,11 +94,11 @@ bob_static_library {
 Linker flags to be propagated to the top-level shared library or binary.
 
 ----
-### **bob_static_lib.export_static_libs** (optional)
-Static libraries can use the `export_static_libs` property to tell Bob about
-any other static libraries they depend on. Bob will ensure that all static
-libraries are placed earlier in the link order than their dependents. The
-earlier example could therefore be resolved as follows:
+### **bob_static_lib.static_libs** (optional)
+Static libraries can use the `static_libs` property to tell Bob about any other
+static libraries they depend on. Bob ensures that all static libraries are
+placed earlier in the link order than their dependents. The earlier example
+could therefore be resolved as follows:
 
 ```bp
 bob_static_library {
@@ -104,7 +108,7 @@ bob_static_library {
 
 bob_static_library {
     name: "libA",
-    export_static_libs: ["libB"],
+    static_libs: ["libB"],
     srcs: ["a.c"],
 }
 
@@ -156,14 +160,14 @@ bob_static_library {
 ```
 
 ----
-### **bob_static_lib.export_shared_libs** (optional)
+### **bob_static_lib.shared_libs** (optional)
 The libraries mentioned here will be appended to `shared_libs` of the top-level
 build object (shared library or binary) linking with this module.
-`export_shared_libs` is an indication that this module is using a shared
+`shared_libs` is an indication that this module is using a shared
 library, and users of this module need to link it.
 
 
 ----
-### **bob_static_lib.export_ldlibs** (optional)
+### **bob_static_lib.ldlibs** (optional)
 Library dependency-related linker flags which should be added to the link
 command of the top-level build object (shared library or binary).

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -137,10 +137,18 @@ directories this library should both import and export to its users.
 ----
 ### **bob_module.static_libs** (optional)
 The list of static lib modules that this library depends on.
+These are propagated to the closest linking object when specified on static
+libraries.
+`static_libs` is an indication that this module is using a static library, and
+users of this module need to link against it.
 
 ----
 ### **bob_module.shared_libs** (optional)
 The list of shared lib modules that this library depends on.
+These are propagated to the closest linking object when specified on static
+libraries.
+`shared_libs` is an indication that this module is using a shared library, and
+users of this module need to link against it.
 
 ----
 ### **bob_module.reexport_libs** (optional)
@@ -153,6 +161,8 @@ identifiers.
 ### **bob_module.ldlibs** (optional)
 Linker flags required to link to the necessary system libraries. Unlike
 `ldflags`, this is added to the _end_ of the linker command-line.
+These are propagated to the closest linking object when specified on static
+libraries.
 
 ----
 ### **bob_module.generated_headers** (optional)

--- a/docs/user_guide/libraries_2.md
+++ b/docs/user_guide/libraries_2.md
@@ -60,9 +60,9 @@ its users to rebuild.
 
 A library may call code from other libraries. To ensure that the
 executable (or shared library) links against the right thing, use
-`export_static_libs`, `export_shared_libs` and `export_ldlibs`. These
-effectively say "I'm using this library, make sure it is added to your
-list of (static|shared|system) libraries".
+`static_libs`, `shared_libs` and `ldlibs`. These effectively say
+"I'm using this library, make sure it is added to your list of
+(static|shared|system) libraries".
 
 For completeness, `export_ldflags` is also supported. This propagates
 linker flags to modules that link against this library. You can use
@@ -88,7 +88,7 @@ bob_static_library {
     name: "libcompression",
     srcs: ["compression/compression.c"],
     export_local_include_dirs: ["compression/include"],
-    export_static_libs: ["libgzip"],
+    static_libs: ["libgzip"],
 
     // One of the libcompression's external headers includes a gzip header
     reexport_libs: ["libgzip"],
@@ -101,9 +101,8 @@ bob_static_library {
 }
 ```
 
-The other export properties, `export_static_libs`,
-`export_shared_libs`, `export_ldlibs`, and `export_ldflags`, always
-propagate to the nearest module doing the link i.e. the nearest
+On static libraries `static_libs`, `shared_libs`, `ldlibs`, and `export_ldflags`
+always propagate to the nearest module doing the link i.e. the nearest
 `bob_binary` or `bob_shared_library`.
 
 ## Static Library Encapsulation
@@ -128,7 +127,7 @@ bob_binary {
 
 bob_static_library {
     name: "libhelpers",
-    export_static_libs: [
+    static_libs: [
         "libcompression",
         "libsha1",
         "libutf8",
@@ -141,7 +140,7 @@ bob_static_library {
         "compress.c",
         "inflate.c",
     ],
-    export_static_libs: [
+    static_libs: [
         "libgzip",
         "libbzip",
         "liblzma",
@@ -206,17 +205,16 @@ bob_static_library {
 
 ## Link What You Use
 
-When `export_static_libs` and `export_shared_libs` are used
-extensively you may find that builds happen to work because the
-exports from low level libraries satisfy the requirements of higher
-level libraries.
+When `static_libs` and `shared_libs` are used extensively on static
+libraries (where they are propagated) you may find that builds happen
+to work because the exports from low level libraries satisfy the
+requirements of higher level libraries.
 
 Although this works, avoid relying on this. This is an analogous
 situation to C/C++ header usage, and the advice is the same. Instead
 of "Include What You Use", "Link What You Use" - for every (external)
 symbol in the `srcs` of your module the library that supplies the
-symbol must be listed in either `static_libs`, `shared_libs`,
-`export_static_libs`, `export_shared_libs` or
+symbol must be listed in either `static_libs`, `shared_libs` or
 `whole_static_libs`. Symbols include function calls and global
 variable access. Note that for enumeration and macro values you can
 get away with just including headers, and not linking - however it's
@@ -294,7 +292,7 @@ retained in the shared library.
 bob_static_library {
     name: "libcompapi",
     srcs: "api.c",
-    export_static_libs: [
+    static_libs: [
         "libgzip",
         "libbzip",
         "liblzma",
@@ -304,7 +302,7 @@ bob_static_library {
 bob_static_library {
     name: "libhelpers",
     srcs: "helpers.c"
-    export_static_libs: [
+    static_libs: [
          "libsha1",
          "libutf8",
     ],

--- a/docs/user_guide/libraries_3.md
+++ b/docs/user_guide/libraries_3.md
@@ -76,7 +76,7 @@ bob_static_library {
 
     export_cflags: ["{{.libdrm_cflags}}"],
     export_ldflags: ["{{.libdrm_ldflags}}"],
-    export_ldlibs: ["{{.libdrm_ldlibs}}"],
+    ldlibs: ["{{.libdrm_ldlibs}}"],
 }
 
 bob_binary {

--- a/tests/external_libs/build.bp
+++ b/tests/external_libs/build.bp
@@ -46,8 +46,9 @@ bob_binary {
 
 bob_static_library {
     name: "libbob_test_external_shared_proxy",
-    export_shared_libs: ["libbob_test_external_shared"],
-    // export_shared_libs just makes the final link use `-l$LIBNAME` - to
+    shared_libs: ["libbob_test_external_shared"],
+
+    // shared_libs just makes the final link use `-l$LIBNAME` - to
     // propagate the include paths, we also need reexport_libs.
     reexport_libs: ["libbob_test_external_shared"],
     enabled: false,
@@ -59,7 +60,7 @@ bob_static_library {
 bob_static_library {
     name: "use_external_lib_proxy",
     srcs: ["use_external_shared_via_proxy.c"],
-    export_static_libs: ["libbob_test_external_shared_proxy"],
+    static_libs: ["libbob_test_external_shared_proxy"],
     enabled: false,
     android: {
         enabled: true,

--- a/tests/static_libs/build.bp
+++ b/tests/static_libs/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Arm Limited.
+ * Copyright 2018-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -109,7 +109,7 @@ bob_binary {
 bob_static_library {
     name: "sl_libb_export_static",
     srcs: ["b.c"],
-    export_static_libs: ["sl_liba"],
+    static_libs: ["sl_liba"],
 }
 
 bob_binary {
@@ -148,7 +148,7 @@ bob_static_library {
         "-DCALL1=do_e1",
         "-DCALL2=do_f",
     ],
-    export_static_libs: [
+    static_libs: [
         "sl_libe",
         "sl_libf",
     ],
@@ -162,7 +162,7 @@ bob_static_library {
         "-DCALL1=do_g1",
         "-DCALL2=do_h",
     ],
-    export_static_libs: [
+    static_libs: [
         "sl_libg",
         "sl_libh",
     ],
@@ -175,7 +175,7 @@ bob_static_library {
         "-DFUNCTION=do_f",
         "-DCALL=do_g2",
     ],
-    export_static_libs: ["sl_libg"],
+    static_libs: ["sl_libg"],
 }
 
 bob_static_library {
@@ -185,7 +185,7 @@ bob_static_library {
         "-DFUNCTION=do_h",
         "-DCALL=do_e2",
     ],
-    export_static_libs: ["sl_libe"],
+    static_libs: ["sl_libe"],
 }
 
 bob_static_library {

--- a/tests/static_libs/check_link_order.py
+++ b/tests/static_libs/check_link_order.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018, 2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,7 +46,7 @@ deps = {
     "sl_libf.a": ["sl_libg.a"],
     "sl_libh.a": ["sl_libe.a"],
 
-    # Implicit dependencies in export_static_libs are not followed
+    # Implicit dependencies in static_libs are not followed
     # "sl_libe.a" : ["sl_libf.a"],
     # "sl_libg.a" : ["sl_libh.a"],
     "sl_libe.a": [],


### PR DESCRIPTION
`export_*libs` properties negatively affect memory consumption, are
redundant and decrease clarity. They will be completely removed in the
near future.

This commit merges these properties with their non-export variants.
The changes do not break existing `.bp` files, however, they should be
updated asap to use the non-export variants of these properties.

Change-Id: I726c641dc67baf8d815e376de00c8c0adc0e3ad0
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>