### PR TITLE
Test `bob_generate_binary` module

### DIFF
--- a/tests/build_tests.sh
+++ b/tests/build_tests.sh
@@ -54,6 +54,7 @@ function check_build_output() {
     check_installed "${DIR}/gen_sh_lib/libblah_shared${SHARED_LIBRARY_EXTENSION}"
     check_installed "${DIR}/gen_sh_bin/binary_linked_to_gen_shared"
     check_installed "${DIR}/gen_sh_bin/binary_linked_to_gen_static"
+    check_installed "${DIR}/gen_sh_bin/generated_binary"
     check_installed "${DIR}/gen_sh_src/validate_install_generate_sources.txt"
     check_installed "${DIR}/gen_sh_src/f3.validate_install_transform_source.txt"
     check_installed "${DIR}/gen_sh_src/f4.validate_install_transform_source.txt"

--- a/tests/generate_libs/build.bp
+++ b/tests/generate_libs/build.bp
@@ -113,10 +113,28 @@ bob_binary {
     },
 }
 
+bob_generate_binary {
+    name: "generated_binary",
+    srcs: ["main2.c"],
+    install_group: "IG_genlib_bin",
+
+    /* Note that we make this a host binary to avoid having to figure
+     * out GCC arguments.
+     */
+    cmd: "{{.gen_cc}} -fPIE -o ${out} ${in}",
+    target: "host",
+    build_by_default: true,
+    builder_android_bp: {
+        /* On Android BP generated binaries are not supported. */
+        enabled: false,
+    },
+}
+
 bob_alias {
     name: "bob_test_generate_libs",
     srcs: [
         "binary_linked_to_gen_static",
         "binary_linked_to_gen_shared",
+        "generated_binary",
     ],
 }

--- a/tests/generate_libs/main2.c
+++ b/tests/generate_libs/main2.c
@@ -1,0 +1,4 @@
+int main()
+{
+	return 0;
+}


### PR DESCRIPTION
This commit creates a separate test case for the `bob_generate_binary`
module.

Change-Id: If43e212ee874c8dcd80d26638f97e48c9ddc2c4d
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>