### PR TITLE
Refactor handling of Android.bp.in for plugins

### DIFF
--- a/bootstrap_androidbp.bash
+++ b/bootstrap_androidbp.bash
@@ -16,22 +16,3 @@
 # limitations under the License.
 
 source $(dirname "${BASH_SOURCE[0]}")/bootstrap.bash
-
-BOB_DIR=$(dirname "${BASH_SOURCE[0]}")
-
-function die {
-    echo "${BASH_SOURCE[0]}: ${*}"
-    exit 1
-}
-
-# ${VAR:-} will substitute an empty string if the variable is unset, which
-# stops `set -u` complaining before `die` is invoked.
-[[ -z ${SRCDIR:-} ]] && die "\$SRCDIR not set"
-[[ -z ${PROJ_NAME:-} ]] && die "\$PROJ_NAME not set"
-
-# Set up Android.bp with plugins
-TMP_ANDROID_BP=$(mktemp)
-sed -e "s#@@PROJ_NAME@@#${PROJ_NAME}#" \
-    "${BOB_DIR}/plugins/Android.bp.in" > "${TMP_ANDROID_BP}"
-rsync --checksum "${TMP_ANDROID_BP}" "${BOB_DIR}/plugins/Android.bp"
-rm -f "${TMP_ANDROID_BP}"

--- a/plugins/Android.bp.in
+++ b/plugins/Android.bp.in
@@ -16,38 +16,38 @@
  */
 
 bootstrap_go_package {
-    name: "bob-utils-@@PROJ_NAME@@",
+    name: "bob-utils-@@PROJ_UID@@",
     pluginFor: ["soong_build"],
     srcs: [
-        "../internal/utils/utils.go",
+        "@@BOB_DIR@@/internal/utils/utils.go",
     ],
     pkgPath: "github.com/ARM-software/bob-build/internal/utils",
 }
 
 bootstrap_go_package {
-    name: "bob-plugins-prebuilt-@@PROJ_NAME@@",
+    name: "bob-plugins-prebuilt-@@PROJ_UID@@",
     pluginFor: ["soong_build"],
     deps: [
         "soong-android",
     ],
     srcs: [
-        "prebuilt/prebuilt_data.go",
+        "@@BOB_DIR@@/plugins/prebuilt/prebuilt_data.go",
     ],
     pkgPath: "github.com/ARM-software/bob-build/plugins/prebuilt",
 }
 
 bootstrap_go_package {
-    name: "bob-plugins-genrulebob-@@PROJ_NAME@@",
+    name: "bob-plugins-genrulebob-@@PROJ_UID@@",
     pluginFor: ["soong_build"],
     deps: [
         "blueprint",
         "soong-android",
         "soong-cc",
         "soong-genrule",
-        "bob-utils-@@PROJ_NAME@@",
+        "bob-utils-@@PROJ_UID@@",
     ],
     srcs: [
-        "genrulebob/genrule.go",
+        "@@BOB_DIR@@/plugins/genrulebob/genrule.go",
     ],
     pkgPath: "github.com/ARM-software/bob-build/plugins/genrulebob",
 }


### PR DESCRIPTION
Instead of creating separate plugins/Android.bp from bootstrap script,
we combine it with main Android.bp containing all modules. That way we
have only single file.

Use project-unique identifier in definition of bootstrap go packages,
enabling us to have multiple projects using plugins in parallel, without
overwriting then-shared plugins/Android.bp.
Use hash of source dir path to generate such id, so we don't need to
depend on other env variable such as PROJ_NAME.

Change-Id: Ie3d43034f839fb4fe8102a7f10b82eab7e23b7de
Signed-off-by: Michal Przeplata <michal.przeplata@arm.com>