### PR TITLE
Fix unnecessary rule reruns

### DIFF
--- a/tests/generate_source/build.bp
+++ b/tests/generate_source/build.bp
@@ -210,6 +210,7 @@ bob_generate_source {
     depfile: true,
     tool: "gen_with_dep.py",
     cmd: "${tool} -o ${out} -d ${depfile} ${in}",
+    build_by_default: true,
 }
 
 bob_generate_source {
@@ -222,6 +223,7 @@ bob_generate_source {
     implicit_outs: [
         "out.h",
     ],
+    build_by_default: true,
 }
 
 bob_generate_source {

--- a/tests/transform_source/build.bp
+++ b/tests/transform_source/build.bp
@@ -92,11 +92,11 @@ bob_transform_source {
     name: "validate_install_transform_source",
     srcs: [
         "f3.in",
-        "f4.in"
+        "f4.in",
     ],
     out: {
         match: "(.+)\\.in",
-        replace: ["$1.validate_install_transform_source.txt"]
+        replace: ["$1.validate_install_transform_source.txt"],
     },
     cmd: "touch ${out}",
     install_group: "IG_gensrc",
@@ -113,11 +113,11 @@ bob_transform_source {
     ],
     out: {
         match: "(.+/.+)\\.in",
-        replace: ["$1.txt"]
+        replace: ["$1.txt"],
     },
     depfile: true,
     rsp_content: "${in}",
-    cmd: "touch ${depfile}; cat ${rspfile} > ${out}",
+    cmd: "echo '${out}:' > ${depfile} && cat $$(cat ${rspfile}) > ${out}",
     build_by_default: true,
 }
 
@@ -131,11 +131,11 @@ bob_transform_source {
     ],
     out: {
         match: ".+/(.+)\\.in",
-        replace: ["$1.txt"]
+        replace: ["$1.txt"],
     },
     depfile: true,
     rsp_content: "${in}",
-    cmd: "touch ${depfile}; cat ${rspfile} > ${out}",
+    cmd: "echo '${out}:' > ${depfile} && cat $$(cat ${rspfile}) > ${out}",
     build_by_default: true,
 }
 


### PR DESCRIPTION
The bob_transform_source tests added in `36973f4 Clarify RSP and depfile
locations in transform source modules` were always being run on the
Android.bp backend, even on an incremental build with no files touched.

This appears to be because the depfiles generated by those rules were
not valid; they were just empty files. This causes Soong to rerun the
rule on every build, regardless of whether its inputs have changed.

Fix this by generating a correct depfile. While we're here, use
${rspfile} correctly, by interpreting it as an input list, and enable
the generated source depfile tests by setting `build_by_default: true`.

Also run `bpfmt` on the modified files.

Change-Id: Ie1df68b0a16fc40150908dc6d66a08735b19b4e4
Signed-off-by: Chris Diamand <chris.diamand@arm.com>