### PR TITLE
Check for outdated Android.bp

### DIFF
--- a/core/standalone.go
+++ b/core/standalone.go
@@ -43,11 +43,16 @@ type moduleBase struct {
 	blueprint.SimpleName
 }
 
+// configProvider allows the retrieval of configuration
+type configProvider interface {
+	Config() interface{}
+}
+
 func projectModuleDir(ctx blueprint.BaseModuleContext) string {
 	return ctx.ModuleDir()
 }
 
-func getConfig(ctx blueprint.BaseModuleContext) *bobConfig {
+func getConfig(ctx configProvider) *bobConfig {
 	return ctx.Config().(*bobConfig)
 }
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -98,6 +98,20 @@ func SortedKeysBoolMap(m map[string]bool) []string {
 	return keys
 }
 
+func SortedKeysByteSlice(m map[string][]byte) []string {
+	keys := make([]string, len(m))
+
+	i := 0
+	for key := range m {
+		keys[i] = key
+		i++
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
 /* Identifies whether the array 'list' contains the string 'x'. */
 func Contains(list []string, x string) bool {
 	for _, y := range list {

--- a/scripts/check_buildbp.py
+++ b/scripts/check_buildbp.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# Copyright 2020 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import hashlib
+import os
+import sys
+
+
+def parse_args():
+    ap = argparse.ArgumentParser()
+
+    ap.add_argument("--hash", type=str, required=True,
+                    help="Combined hash of build.bp files")
+    # We have to create an output file to stop the check being run on every
+    # build. FileType("wt") will automatically create one, so there's no need
+    # for any extra code.
+    ap.add_argument("--out", type=argparse.FileType("wt"),
+                    help="Dummy output file name. This is written, but not used")
+    ap.add_argument("inputs", nargs="+", type=str, default=[],
+                    help="build.bp files to check")
+
+    return ap.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    combinedHash = hashlib.sha1()
+
+    for buildbp in sorted(args.inputs):
+        fileHash = hashlib.sha1()
+        with open(buildbp, "rb") as fp:
+            fileHash.update(fp.read())
+        combinedHash.update(fileHash.digest())
+
+    if combinedHash.hexdigest() != args.hash:
+        lines = [
+            "+---------------------------------------------------------------------------+",
+            "| WARNING: build.bp files have been changed since Android.bp was generated! |",
+            "| WARNING:                  Please regenerate Android.bp                    |",
+            "+---------------------------------------------------------------------------+",
+        ]
+        for line in lines:
+            sys.stderr.write(line + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Because the Android.bp file is generated separately to the actual build
(`mm` or equivalent), it is possible for build.bp files to have been
changed since running bootstrap_androidbp. This may cause incorrect
builds, e.g. if a build.bp was updated to adjust for a corresponding
change in the code.

Rather than continuing with the build and then ending up with a
compilation error, detect when this has occurred and output a warning.

This is done by creating a new genrule module, whose sources are the
build.bp files, and then checking that their hashes are the same as when
Android.bp was generated.

It would be possible to just implement this using mtimes. However:
 * The hashing is cheap, because we only do it when the build.bp files
   have been changed (i.e. when Bob is being run, or the genrule is
   being run because its source list contains something with a newer
   mtime).
 * Using a hash accounts is more correct; a warning is only printed when
   the build.bp files have _definitely_ changed. With an mtime check,
   the warning would be triggered if e.g. a change to a file was made,
   then reverted. This also means it is actually possible that we could
   *fail* the build when the warning is triggered, rather than just
   printing.

Reinstate the configProvider interface, to allow getConfig() to be
called from the SingletonContext when generating the new genrule.

Change-Id: Ia68cdbbf15bbd31eadc7965ad8186f2c71e9eac6
Signed-off-by: Chris Diamand <chris.diamand@arm.com>