### PR TITLE
Implement module_srcs on Android.bp

### DIFF
--- a/tests/generate_source/build.bp
+++ b/tests/generate_source/build.bp
@@ -29,7 +29,7 @@ bob_generate_source {
     out: ["single.cpp"],
 
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${out}",
+    cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in",
 }
 
 bob_generate_source {
@@ -42,7 +42,7 @@ bob_generate_source {
     out: ["multiple_in.cpp"],
 
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${out}",
+    cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in before_generate2.in before_generate3.in",
 }
 
 bob_generate_source {
@@ -56,7 +56,7 @@ bob_generate_source {
     ],
 
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${out}",
+    cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in",
 }
 
 bob_generate_source {
@@ -72,7 +72,7 @@ bob_generate_source {
     },
 
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${out}",
+    cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in before_generate2.in before_generate3.in",
 }
 
 // Simple cases
@@ -88,7 +88,7 @@ bob_generate_source {
     out: ["level_1_single.cpp"],
 
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${out}",
+    cmd: "python ${tool} --in ${in} --out ${out} --expect-in single.cpp",
 }
 
 bob_generate_source {
@@ -98,7 +98,7 @@ bob_generate_source {
     out: ["level_2_single.cpp"],
 
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${out}",
+    cmd: "python ${tool} --in ${in} --out ${out} --expect-in level_1_single.cpp",
 }
 
 bob_generate_source {
@@ -108,7 +108,7 @@ bob_generate_source {
     out: ["level_3_single.cpp"],
 
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${out}",
+    cmd: "python ${tool} --in ${in} --out ${out} --expect-in level_2_single.cpp",
 }
 
 bob_generate_source {
@@ -121,7 +121,7 @@ bob_generate_source {
     out: ["extra_single.cpp"],
 
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${out}",
+    cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in level_2_single.cpp",
 }
 
 // Nested cases
@@ -140,7 +140,7 @@ bob_generate_source {
     out: ["deps.cpp"],
 
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} ${generate_source_single_out} --out ${out}",
+    cmd: "python ${tool} --in ${in} ${generate_source_single_out} --out ${out} --expect-in before_generate.in single.cpp",
 }
 
 bob_generate_source {
@@ -153,7 +153,7 @@ bob_generate_source {
     out: ["deps2.cpp"],
 
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${out}",
+    cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in deps.cpp",
 }
 
 // Depends cases

--- a/tests/generate_source/generator.py
+++ b/tests/generate_source/generator.py
@@ -1,6 +1,6 @@
 #!/bin/python
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,17 +19,28 @@ from __future__ import print_function
 
 import argparse
 import os
+import sys
 
 parser = argparse.ArgumentParser(description='Test generator.')
 parser.add_argument('--in', nargs='*', dest='input', action='store', help='Input files')
 parser.add_argument('--out', nargs='*', dest='output', action='store', help='Output file')
+parser.add_argument("--expect-in", nargs='*', action='store',
+                    help='Basenames of expected input files')
 
 args = parser.parse_args()
+
+if args.expect_in:
+    received_basenames = sorted(os.path.basename(i) for i in args.input)
+    expected_basenames = sorted(args.expect_in)
+    if received_basenames != expected_basenames:
+        print("Expected the following files:", ", ".join(expected_basenames))
+        print("But received these:", ", ".join(received_basenames))
+        sys.exit(1)
 
 for input_file in args.input:
     if not os.path.exists(input_file):
         print("Input file doesn't exist: " + input_file)
-        exit(-1)
+        sys.exit(1)
 
 for out in args.output:
     file_name = os.path.basename(out)

--- a/tests/rsp/build.bp
+++ b/tests/rsp/build.bp
@@ -53,10 +53,4 @@ bob_binary {
         "-Wall",
         "-Werror",
     ],
-    // RSP files do work on Android.bp, but `module_srcs` is not currently
-    // implemented, so the merge_multiple_sources module generates incorrect
-    // output. This should be re-enabled once `module_srcs` is fixed.
-    builder_android_bp: {
-        enabled: false,
-    },
 }


### PR DESCRIPTION
Include generated sources in the inputs list of genrule_bob modules.
This wasn't caught by previous testing, so update the generated_source
tests to actually check their input lists. Enable the RSP tests which
were previously disabled due to depending on this feature.

Change-Id: Ia336b9eba075e18e4cd551f4b47c254a88e53fcc
Signed-off-by: Chris Diamand <chris.diamand@arm.com>