### PR TITLE
Fix dependencies on split modules

### DIFF
--- a/core/androidbp_generated.go
+++ b/core/androidbp_generated.go
@@ -62,8 +62,8 @@ func populateCommonProps(gc *generateCommon, mctx blueprint.ModuleContext, m bpw
 	}
 	m.AddBool("depfile", proptools.Bool(gc.Properties.Depfile))
 
-	m.AddStringList("module_deps", gc.Properties.Module_deps)
-	m.AddStringList("module_srcs", gc.Properties.Module_srcs)
+	m.AddStringList("module_deps", getShortNamesForDirectDepsWithTags(mctx, generatedDepTag))
+	m.AddStringList("module_srcs", getShortNamesForDirectDepsWithTags(mctx, generatedSourceTag))
 	m.AddStringList("encapsulates", gc.Properties.Encapsulates)
 	m.AddStringList("export_gen_include_dirs", gc.Properties.Export_gen_include_dirs)
 	m.AddStringList("cflags", gc.Properties.FlagArgsBuild.Cflags)

--- a/tests/generate_source/build.bp
+++ b/tests/generate_source/build.bp
@@ -249,6 +249,27 @@ bob_binary {
     ],
 }
 
+// Check that generated modules can depend on a specific variant of a module
+bob_binary {
+    name: "host_and_target_supported_binary",
+    host_supported: true,
+    target_supported: true,
+    build_by_default: true,
+    srcs: ["simple_main.c"],
+    // Verify that the generated module doesn't accidentally pick up the target variant
+    host: {
+        out: "host_binary",
+    },
+}
+
+bob_generate_source {
+    name: "use_target_specific_library",
+    out: ["libout.a"],
+    module_deps: ["host_and_target_supported_binary:host"],
+    cmd: "test $$(basename ${host_and_target_supported_binary_out}) = host_binary && cp ${host_and_target_supported_binary_out} ${out}",
+    build_by_default: true,
+}
+
 bob_alias {
     name: "bob_test_generate_source",
     srcs: [

--- a/tests/generate_source/simple_main.c
+++ b/tests/generate_source/simple_main.c
@@ -1,0 +1,4 @@
+int main(void)
+{
+	return 0;
+}


### PR DESCRIPTION
Allow generated modules to depend on split libraries and binaries using
the `:host` syntax on Android.bp by writing the `module_deps` and
`module_srcs` fields using the shortName() of the dependencies, rather
than just copying from the properties.

Tweak the genrule backend by stripping `__host` and `__target` suffixes
off module names when setting variables, to ensure commands referencing
split modules still work.

Add a test.

Change-Id: Ia30024cea3cbe235261dd22d1e3559485c49386a
Signed-off-by: Chris Diamand <chris.diamand@arm.com>