### PR TITLE
Fix C++ flags on Android.bp

### DIFF
--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -136,7 +136,7 @@ func addCFlags(m bpwriter.Module, cflags []string, conlyFlags []string, cxxFlags
 
 	m.AddStringList("cflags", utils.Filter(ccflags.AndroidCompileFlags, cflags))
 	m.AddStringList("conlyflags", utils.Filter(ccflags.AndroidCompileFlags, conlyFlags))
-	m.AddStringList("cxxflags", utils.Filter(ccflags.AndroidCompileFlags, cxxFlags))
+	m.AddStringList("cppflags", utils.Filter(ccflags.AndroidCompileFlags, cxxFlags))
 	return nil
 }
 

--- a/core/androidbp_test.go
+++ b/core/androidbp_test.go
@@ -47,7 +47,7 @@ func Test_addCFlags(t *testing.T) {
 	m.On("AddString", "instruction_set", "arm")
 	m.On("AddStringList", "cflags", []string{"-cl-no-signed-zeros"})
 	m.On("AddStringList", "conlyflags", []string(nil))
-	m.On("AddStringList", "cxxflags", []string(nil))
+	m.On("AddStringList", "cppflags", []string(nil))
 
 	cflags := []string{"-marm", "-mx32", "-cl-no-signed-zeros"}
 	conlyFlags := []string{"-std=c11"}
@@ -66,7 +66,7 @@ func Test_addCFlags2(t *testing.T) {
 	m.On("AddString", "instruction_set", "thumb")
 	m.On("AddStringList", "cflags", []string(nil))
 	m.On("AddStringList", "conlyflags", []string(nil))
-	m.On("AddStringList", "cxxflags", []string(nil))
+	m.On("AddStringList", "cppflags", []string(nil))
 
 	cflags := []string{"-mthumb", "-mx32"}
 	conlyFlags := []string{"-std=c17"}
@@ -83,7 +83,7 @@ func Test_addCFlags3(t *testing.T) {
 	m.On("AddString", "cpp_std", "c++17")
 	m.On("AddStringList", "cflags", []string(nil))
 	m.On("AddStringList", "conlyflags", []string(nil))
-	m.On("AddStringList", "cxxflags", []string(nil))
+	m.On("AddStringList", "cppflags", []string(nil))
 
 	cflags := []string{"-mx32"}
 	conlyFlags := []string{}

--- a/tests/cxx11_simple/build.bp
+++ b/tests/cxx11_simple/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,4 +18,7 @@
 bob_binary {
     name: "bob_test_cxx11simple",
     srcs: ["simple.cpp"],
+    conlyflags: ["-DEXTRA_CONLYFLAGS"],
+    cflags: ["-DEXTRA_CFLAGS"],
+    cxxflags: ["-DEXTRA_CXXFLAGS"],
 }

--- a/tests/cxx11_simple/simple.cpp
+++ b/tests/cxx11_simple/simple.cpp
@@ -1,6 +1,16 @@
 #include <iostream>
 #include <string>
 
+#ifdef EXTRA_CONLYFLAGS
+    #error "C-specific flags was set"
+#endif
+#ifndef EXTRA_CFLAGS
+    #error "Common C flags were not set"
+#endif
+#ifndef EXTRA_CXXFLAGS
+    #error "C++-specific flags were not set"
+#endif
+
 using namespace std;
 
 int main() {


### PR DESCRIPTION
Soong's `cc` modules use `cppflags`, not `cxxflags`, for their
C++-specific flags. Fix the module generation and update the tests.

Change-Id: Idabf458d51aa634a2afb6b99caa75e3d08572b25
Signed-off-by: Chris Diamand <chris.diamand@arm.com>