### PR TITLE
Update Bob examples for Android BP backend

### DIFF
--- a/docs/project_setup.md
+++ b/docs/project_setup.md
@@ -25,7 +25,8 @@ order to use Bob. It contains the following files:
 
 |File|Description|
 |---|---|
-|bootstrap_androidmk.bash | Android bootstrap script |
+|bootstrap_androidmk.bash | Android Make bootstrap script |
+|bootstrap_androidbp.bash | Android BP bootstrap script |
 |bootstrap_linux.bash     | Linux bootstrap script |
 |bplist                   | Blueprint list file |
 |Mconfig                  | Project configuration database |

--- a/example/bootstrap_androidbp.bash
+++ b/example/bootstrap_androidbp.bash
@@ -22,17 +22,15 @@
 # Finally run Bob to generate the Android.bp for the configuration.
 
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
-BOB_DIR=bob
-PROJ_NAME="bob_tests"
-
-source "${SCRIPT_DIR}/bootstrap_utils.sh"
+BOB_DIR=bob-build
+PROJ_NAME="bob_example"
 
 BASENAME=$(basename $0)
 function usage {
     cat <<EOF
 $BASENAME
 
-Sets up the Bob tests to build for Android using Android.bp files.
+Sets up the Bob to build for Android using Android.bp files.
 
 Usage:
  $BASENAME CONFIG_OPTIONS...
@@ -77,22 +75,14 @@ done
 [[ -n ${OUT} ]] || { echo "\$OUT is not set - did you run 'lunch'?"; exit 1; }
 [[ -n ${ANDROID_BUILD_TOP} ]] || { echo "\$ANDROID_BUILD_TOP is not set - did you run 'lunch'?"; exit 1; }
 
-# The tests need a symlink in the source directory to the parent bob
-# directory, as Blueprint won't accept ..
-create_link .. "${SCRIPT_DIR}/${BOB_DIR}"
-
 source "${SCRIPT_DIR}/${BOB_DIR}/pathtools.bash"
 
 PROJ_DIR=$(relative_path "${ANDROID_BUILD_TOP}" "${SCRIPT_DIR}")
 
-# Add a symlink to enable the external_libs test
-create_link external_lib.bp "${SCRIPT_DIR}/external_libs/external/Android.bp"
-
 # Change to the working directory
 cd "${ANDROID_BUILD_TOP}"
 
-### Variables required for Bob and Android.bp bootstrap ###
-
+### Variables required for Bob and Android.mk bootstrap ###
 BPBUILD_DIR="${OUT}/gen/STATIC_LIBRARIES/bobbp_${PROJ_NAME}_intermediates"
 export BUILDDIR="${BPBUILD_DIR}"
 export TOPNAME="build.bp"

--- a/example/bootstrap_androidmk.bash
+++ b/example/bootstrap_androidmk.bash
@@ -112,9 +112,9 @@ source "${BUILDDIR}/.bob.bootstrap"
 # Setup the buildme script to just run bob
 ln -sf "bob" "${BUILDDIR}/buildme"
 
-if [ ! -z "$*" ] || [ ! -f "$ANDROIDMK_DIR/$CONFIGNAME" ] ; then
+if [ $MENU -ne 1 ] || [ ! -f "$ANDROIDMK_DIR/$CONFIGNAME" ] ; then
     # Have arguments or missing bob.config. Run config.
-    "$ANDROIDMK_DIR/config" ANDROID=y "$@"
+    "$ANDROIDMK_DIR/config" ANDROID=y BUILDER_ANDROID_MK=y "$@"
 fi
 
 if [ $MENU -eq 1 ] ; then

--- a/example/buildme.bash
+++ b/example/buildme.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,14 +28,14 @@ cd $(dirname "${BASH_SOURCE[0]}")
 
 source ".bob.bootstrap"
 
-# Check for missing configuration
-if [ ! -f "${CONFIGNAME}" ] ; then
-    echo "${CONFIGNAME} is missing. Use config or menuconfig to configure the project."
-    exit 1
-fi
-
 # Move to the working directory
 cd "${WORKDIR}"
+
+# Check for missing configuration
+if [ ! -f "${CONFIG_FILE}" ] ; then
+    echo "${CONFIG_FILE} is missing. Use config or menuconfig to configure the project."
+    exit 1
+fi
 
 # Build
 "${BUILDDIR}/bob" "$@"

--- a/tests/build_tests.sh
+++ b/tests/build_tests.sh
@@ -77,7 +77,8 @@ TEST_DIRS=("build-indep"
            "build-in-outp"
            "tests/build-in-src"
            "build-link"
-           "build-link-target")
+           "build-link-target"
+           "build-example")
 rm -rf "${TEST_DIRS[@]}"
 
 # Test by explicitly requesting the `bob_tests` alias, which should include all
@@ -239,6 +240,31 @@ if [ "$OS" != "OSX" ] ; then
     UPDATE=(${build_dir}/target/kernel_modules/test_module1/test_module1.ko)
     check_dep_updates "kernel headers" "${build_dir}" "${SRC}" "${UPDATE[@]}"
 fi
+
+# Test example setup if it's buildable
+cp -r example build-example
+pushd build-example &> /dev/null
+git clone https://github.com/ARM-software/bob-build
+cd bob-build
+git submodule update --init
+cd -
+./bootstrap_linux.bash
+
+# Generate example source file
+cat > hello_world.cpp << EOF
+int main()
+{
+    int hello = 1;
+    hello += 1;
+    return 0;
+}
+EOF
+
+cd build
+./config ${OPTIONS}
+./buildme
+check_installed "out/bin/hello_world"
+popd &> /dev/null
 
 # Clean up
 rm -rf "${TEST_DIRS[@]}"


### PR DESCRIPTION
Renamed bootstrap_android to bootstrap_androidmk.

Remove 'export PROJ_NAME' that is not used anymore since commit
da339134498bb5b623243ba3a297e1b3bb8b7be7

Updated bootstrap_linux and made it basically testable - running
./bootstrap_linux and ./buildme is successful.

Updating build_tests.sh so Travis can run those too.

Change-Id: Ia6f06ef76906c0c78792ef1957d6be862ae1a3d0
Signed-off-by: Michal Przeplata <michal.przeplata@arm.com>