### PR TITLE
Strip empty host and target properties

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -272,7 +272,14 @@ func stripEmptyComponentsMutator(mctx blueprint.BottomUpMutatorContext) {
 		return
 	}
 
-	for _, props := range f.topLevelProperties() {
+	strippableProps := f.topLevelProperties()
+
+	if def, ok := mctx.Module().(targetable); ok {
+		strippableProps = append(strippableProps, []interface{}{&def.build().Host.BuildProps}...)
+		strippableProps = append(strippableProps, []interface{}{&def.build().Target.BuildProps}...)
+	}
+
+	for _, props := range strippableProps {
 		propsVal := reflect.Indirect(reflect.ValueOf(props))
 		stripEmptyComponentsRecursive(propsVal)
 	}


### PR DESCRIPTION
This commit extends `stripEmptyComponentsMutator` to strip empty
host and target properties.

Change-Id: Ifdbda68dacbdec3c8d61747ced77dd0f926d9672
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>