### PR TITLE
Make `out` a string pointer

### DIFF
--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -52,8 +52,8 @@ func (m *kernelModule) features() *Features {
 }
 
 func (m *kernelModule) outputName() string {
-	if len(m.Properties.Out) > 0 {
-		return m.Properties.Out
+	if m.Properties.Out != nil {
+		return *m.Properties.Out
 	}
 	return m.Name()
 }

--- a/core/library.go
+++ b/core/library.go
@@ -34,7 +34,7 @@ type BuildProps struct {
 	AliasableProps
 
 	// Alternate output name, used for the file name and Android rules
-	Out string
+	Out *string
 
 	// Flags used for C/C++ compilation
 	Cflags []string
@@ -357,8 +357,8 @@ func (l *library) getSplittableProps() *SplittableProps {
 }
 
 func (l *library) outputName() string {
-	if len(l.Properties.Out) > 0 {
-		return l.Properties.Out
+	if l.Properties.Out != nil {
+		return *l.Properties.Out
 	}
 	return l.Name()
 }


### PR DESCRIPTION
If a module using `out` includes a default also specifying `out`, the
two values will be concatenated. This is unlikely to be the desired
result; make it a string pointer so that the higher-priority one (i.e.
the one on the module) is used instead.

Change-Id: I0fcb43e4f3580c56609b5308da840714f08c2d13
Signed-off-by: Chris Diamand <chris.diamand@arm.com>