### PR TITLE
Depend on `module_deps` outputs in transformed sources

### DIFF
--- a/tests/transform_source/build.bp
+++ b/tests/transform_source/build.bp
@@ -30,7 +30,7 @@ bob_transform_source {
     },
     export_gen_include_dirs: ["single/transform_source"],
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${srcs_generated}",
+    cmd: "python ${tool} --in ${in} --gen-src ${srcs_generated} --gen-implicit-header",
 }
 
 bob_transform_source {
@@ -51,7 +51,7 @@ bob_transform_source {
     },
     export_gen_include_dirs: ["transform_source"],
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${srcs_generated}",
+    cmd: "python ${tool} --in ${in} --gen-src ${srcs_generated} --gen-implicit-header",
 }
 
 bob_generate_source {
@@ -79,7 +79,33 @@ bob_transform_source {
         "transform_source",
     ],
     tool: "generator.py",
-    cmd: "python ${tool} --in ${in} --out ${srcs_generated}",
+    cmd: "python ${tool} --in ${in} --gen-src ${srcs_generated} --gen-implicit-header",
+}
+
+bob_generate_source {
+    name: "generate_template_source_used_by_transform",
+    out: ["test_src.tmpl"],
+    // To get a single pair of braces `{}` in the output, we have to escape
+    // Go's templates and *then* Python's format() specifiers.
+    cmd: "echo 'void output_{func}(void) {{\"{{\"}}{{\"}}\"}}' > ${out}",
+}
+
+bob_transform_source {
+    name: "transform_source_module_deps",
+    module_deps: ["generate_template_source_used_by_transform"],
+    srcs: [
+        "f6.in",
+    ],
+    out: {
+        match: ".*/(.+).in",
+        replace: [
+            "$1.cpp",
+            "$1.h",
+        ],
+    },
+    export_gen_include_dirs: ["."],
+    tool: "generator.py",
+    cmd: "python ${tool} --in ${in} --gen-src ${srcs_generated} --gen-header ${headers_generated} --src-template ${generate_template_source_used_by_transform_out}",
 }
 
 bob_binary {
@@ -88,11 +114,13 @@ bob_binary {
         "transform_source_single_dir",
         "transform_source_single",
         "transform_source_multiple_in",
+        "transform_source_module_deps",
     ],
     generated_headers: [
         "transform_source_single_dir",
         "transform_source_single",
         "transform_source_multiple_in",
+        "transform_source_module_deps",
     ],
     srcs: ["main.cpp"],
 }

--- a/tests/transform_source/main.cpp
+++ b/tests/transform_source/main.cpp
@@ -3,6 +3,7 @@
 #include "f3.h"
 #include "f4.h"
 #include "f5.h"
+#include "f6.h"
 
 void validate_link()
 {
@@ -11,6 +12,7 @@ void validate_link()
 	output_f3();
 	output_f4();
 	output_f5();
+	output_f6();
 }
 
 int main()


### PR DESCRIPTION
Currently the genruleBob module calculates the implicit sources for a
module, including those required because of the `module_deps` field, but
then does _not_ pass them into the inouts created from Multi_out_srcs.

This means that bob_transform_source modules using module_deps may fail
to build, because Ninja is never informed of the dependency on the
dependent module's outputs. Note that it is possible for a build to
_appear_ correct, if by chance the dependent module is built first.

Fix this by including the common `implicits` list in the implicit
sources for transformed source inouts too.

Add a test which generates a source file to be used as a template for
each transformed source in a new transform_source module. This fits
quite neatly into the existing test pattern, as we just need to provide
an argument to use a specific file as the input template. However,
making this work sanely requires rewriting most of
`transform_source/generator.py` to be able to handle this.

Change-Id: I93811a82a638c8b3806980d670e02c3399893526
Signed-off-by: Chris Diamand <chris.diamand@arm.com>