### PR TITLE
Don't guess Clang prefix on out-of-tree Android builds

### DIFF
--- a/mconfig/host_toolchain.Mconfig
+++ b/mconfig/host_toolchain.Mconfig
@@ -22,12 +22,12 @@
 
 config HOST_GNU_PREFIX
 	string "Host GNU compiler prefix"
-	default "prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9/bin/x86_64-linux-android-" if ANDROID
+	default "prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9/bin/x86_64-linux-android-" if BUILDER_ANDROID_MAKE || BUILDER_ANDROID_BP
 	default ""
 
 config HOST_CLANG_PREFIX
 	string "Host Clang compiler prefix"
-	default "prebuilts/clang/host/linux-x86/clang-r370808/bin/" if ANDROID
+	default "prebuilts/clang/host/linux-x86/clang-r370808/bin/" if BUILDER_ANDROID_MAKE || BUILDER_ANDROID_BP
 	default ""
 
 config HOST_ARMCLANG_PREFIX


### PR DESCRIPTION
Only assume that the `prebuilts` directory exists on the Android.bp and
Android.mk backends.

Change-Id: I9d33a72564c87fb8c138511057b5a1ed95600d7b
Signed-off-by: Chris Diamand <chris.diamand@arm.com>