### PR TITLE
Update manifest to android-r-preview-2

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -2,70 +2,70 @@
 <manifest>
   <remote fetch="https://android.googlesource.com/" name="aosp" review="https://android-review.googlesource.com/"/>
 
-  <default remote="aosp" revision="master" sync-j="4"/>
+  <default remote="aosp" revision="refs/tags/android-r-preview-2" sync-j="4"/>
 
   <manifest-server url="http://android-smartsync.corp.google.com/android.googlesource.com/manifestserver"/>
 
-  <project groups="device,yukawa,pdk" name="device/amlogic/yukawa" revision="049141eb556d1edbaf181c13d914d1f06f7cd5f4" upstream="master"/>
-  <project clone-depth="2" groups="device,yukawa,pdk" name="device/amlogic/yukawa-kernel" revision="bed29330f24f2d0d9f625639a4a989a40ca6c643" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk" name="device/common" revision="587fc20905e241750152831bc27ffe99b576a535" upstream="master"/>
-  <project groups="pdk" name="device/generic/arm64" revision="b2aea8576e3928e9add8b616740e56c1c5a811d2" upstream="master"/>
-  <project groups="pdk" name="device/generic/armv7-a-neon" revision="90ffc33a7cae0202ac9c201aa2f926057ffe4cc6" upstream="master"/>
-  <project groups="pdk" name="device/generic/art" revision="874f67767d2863c42f65b0fc63842504306851c8" upstream="master"/>
-  <project groups="pdk" name="device/generic/car" revision="947654eabf8b3f18c479e940d55831ef4be16cbe" upstream="master"/>
-  <project groups="pdk" name="device/generic/common" revision="80c159aa90b03d46a7d0fa88eb3c9f195874652d" upstream="master"/>
-  <project groups="pdk" name="device/generic/goldfish" revision="57426c57a4c6533f3e1f2509d6a7f10eed037dbe" upstream="master"/>
-  <project groups="pdk" name="device/generic/goldfish-opengl" revision="b36e3f52f949b325a1314b98246d516dd21f4e2b" upstream="master"/>
-  <project groups="pdk" name="device/generic/mini-emulator-arm64" revision="672958caf7187fb355149546d886bf5f556ba3e6" upstream="master"/>
-  <project groups="pdk" name="device/generic/mini-emulator-armv7-a-neon" revision="8c906010786b63d1549ea76e0dba2e0c0abc399b" upstream="master"/>
-  <project groups="pdk" name="device/generic/mini-emulator-x86" revision="dc0e1610a68c17e4aaf3a2b06bf18062e8e5e4d0" upstream="master"/>
-  <project groups="pdk" name="device/generic/mini-emulator-x86_64" revision="0e0dc9eefb1226163a215ac3bac16dedf15d88f9" upstream="master"/>
-  <project groups="pdk" name="device/generic/opengl-transport" revision="d8f650f3b39c7d52108ea749deda39d1849ac213" upstream="master"/>
-  <project groups="pdk" name="device/generic/qemu" revision="c1f61c99afabd7d5da9017fe568f9c38a73a89be" upstream="master"/>
-  <project groups="pdk" name="device/generic/trusty" revision="3800dbdda7f4bdee7a2b955a6718a8c815ed4910" upstream="master"/>
-  <project groups="device,pdk" name="device/generic/uml" revision="5e9e45243e46645a487e6e5ba00d79deb94a9dd4" upstream="master"/>
-  <project groups="pdk" name="device/generic/x86" revision="7a73a1f8e9fd691cb8f45aa9de303f3c39c3837a" upstream="master"/>
-  <project groups="pdk" name="device/generic/x86_64" revision="506952733fdebb5a2ef086b519ceebe86a95ae31" upstream="master"/>
-  <project groups="device,broadcom_pdk,generic_fs,pdk" name="device/google/atv" revision="00e3cfffba4a442d5f7fd8e63f86a0dbfc1f04d8" upstream="master"/>
-  <project groups="device,bonito" name="device/google/bonito" revision="c14993de9cf813db7d0d03aff66c9a237a94a1b8" upstream="master"/>
-  <project clone-depth="1" groups="device,bonito" name="device/google/bonito-kernel" revision="be9f75f9e7976f4babbc9018e81ce9a55562e6c6" upstream="master"/>
-  <project groups="device,bonito" name="device/google/bonito-sepolicy" revision="37cffa7ac8fede00275b8cf0d2d6e1c826284a9e" upstream="master"/>
-  <project groups="device,pdk" name="device/google/contexthub" revision="1a27b954cbf225bfbb1d1b8051950504ccbf047f" upstream="master"/>
-  <project groups="device,coral" name="device/google/coral" revision="b380255c0e1d595b8c14343c25398176f4b8a95c" upstream="master"/>
-  <project clone-depth="1" groups="device,coral" name="device/google/coral-kernel" revision="c8f6757f33ff3f64d7968b26dbf4944deaab593f" upstream="master"/>
-  <project groups="device,coral" name="device/google/coral-sepolicy" revision="bdd5cecbaedd50c2bda19f757ebb9390ba7d6133" upstream="master"/>
-  <project groups="device,crosshatch,generic_fs" name="device/google/crosshatch" revision="247f5c95f067770555df2ad572fb07afe828faa3" upstream="master"/>
-  <project clone-depth="1" groups="device,crosshatch,generic_fs" name="device/google/crosshatch-kernel" revision="ad56bb12277884eac16930b8b7128c3fb769b1e5" upstream="master"/>
-  <project groups="device,crosshatch,generic_fs" name="device/google/crosshatch-sepolicy" revision="6f8945cf372e28c989145413f002ecba66fae91f" upstream="master"/>
-  <project groups="device,pdk" name="device/google/cuttlefish" revision="e5bd6d51804efee224f4766db5d4de65c37f4c58" upstream="master"/>
-  <project clone-depth="1" groups="device,pdk" name="device/google/cuttlefish_kernel" revision="ab36a98fd56838f2f51b9e9a39d1e10d3f7891c0" upstream="master"/>
-  <project clone-depth="1" groups="device,pdk" name="device/google/cuttlefish_vmm" revision="84ed4fc8b9901013f28453fbab606ab784b5aa8a" upstream="master"/>
-  <project groups="device" name="device/google/fuchsia" revision="955fb9863dc388a2abc40ce1b0d9b5879f75c90d" upstream="master"/>
-  <project groups="device,generic_fs,muskie" name="device/google/muskie" revision="4ddb24fdbbe99376797e85464a12326946c49e68" upstream="master"/>
-  <project groups="device,taimen" name="device/google/taimen" revision="1c42e7b4131975c2f06fd29d54ac75867effb37d" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="device/google/vrservices" revision="26db848a52bc3c0246b59a34e7b55611207cf477" upstream="master"/>
-  <project groups="device,generic_fs,wahoo" name="device/google/wahoo" revision="4a45ac54fe1494d2b28cee461104ce40e379cf2b" upstream="master"/>
-  <project clone-depth="1" groups="device,generic_fs,wahoo" name="device/google/wahoo-kernel" revision="6dcf78648c55ebc9f393d3164291107f8e35f7d1" upstream="master"/>
-  <project groups="device,generic_fs" name="device/google_car" revision="2f7ad9e79edfeeffcdb9aba5c7fca84f1c6b70b8" upstream="master"/>
-  <project name="device/linaro/bootloader/OpenPlatformPkg" revision="044ce29a658ec8719ca1e839a4502ff835e0ccb7" upstream="master"/>
-  <project name="device/linaro/bootloader/arm-trusted-firmware" revision="4a8974da598bde9881f85699fefd69ec776be5b4" upstream="master"/>
-  <project name="device/linaro/bootloader/edk2" revision="6141238127ffcef8fee2af2cd01757264a95bf09" upstream="master"/>
-  <project groups="device,dragonboard,pdk" name="device/linaro/dragonboard" revision="565dd57880b954ac110ae502f40958a10f79b3d4" upstream="master"/>
-  <project clone-depth="1" groups="device,dragonboard,pdk" name="device/linaro/dragonboard-kernel" revision="66edd93ead966a35ab8845ad718a8455aad5b659" upstream="master"/>
-  <project groups="device,hikey,pdk" name="device/linaro/hikey" revision="7357dcd8b39cf60a1b95995c4aff992b59dfd3c1" upstream="master"/>
-  <project clone-depth="1" groups="device,hikey,pdk" name="device/linaro/hikey-kernel" revision="81b995bb7a0c9e5d063985e1065b5669c496b3aa" upstream="master"/>
-  <project groups="device,poplar,pdk" name="device/linaro/poplar" revision="d8e1347b12462e0d42d049abf5488ca21f928ec7" upstream="master"/>
-  <project clone-depth="1" groups="device,poplar,pdk" name="device/linaro/poplar-kernel" revision="d9338d916fee52afdb36115925f2ad570ec0cb19" upstream="master"/>
-  <project groups="pdk" name="device/sample" revision="898c0141af5aa30f233d887e5a7d53568b63f38f" upstream="master"/>
-  <project groups="device,beagle_x15,pdk" name="device/ti/beagle-x15" path="device/ti/beagle_x15" revision="dd949e6894e9f44adace4b3d6594665bf7d09c76" upstream="master"/>
-  <project clone-depth="1" groups="device,beagle_x15,pdk" name="device/ti/beagle-x15-kernel" path="device/ti/beagle_x15-kernel" revision="0d99bf0b39100deba5ea9071d6472acb3bc09103" upstream="master"/>
-  <project name="kernel/build" revision="36c4f58902a6c86652e75d270fd090ed3ca4d0ba" upstream="master"/>
-  <project groups="vts,pdk" name="kernel/configs" revision="a70baf63ed11727704aade39046ab4b409e255d9" upstream="master"/>
-  <project groups="vts,pdk" name="kernel/tests" revision="277404bee6f570f078fe63a3df4f0fbeaf2d1171" upstream="master"/>
-  <project groups="pdk" name="platform/art" path="art" revision="e30457c0b52caba839b21a03af56200df7a975e2" upstream="master"/>
-  <project groups="pdk" name="platform/bionic" path="bionic" revision="f5421dde7f6c9d2c79f840e474072fab31478d25" upstream="master"/>
-  <project groups="pdk" name="platform/bootable/recovery" path="bootable/recovery" revision="1477c867f710faa7e754ea462c1e58c62b5cf8a3" upstream="master"/>
-  <project groups="pdk" name="platform/build" path="build/make" revision="345dad3c36684d65042f7c0279da9a8ad1e145a4" upstream="master">
+  <project groups="device,yukawa,pdk" name="device/amlogic/yukawa" revision="f704c3ce2a7bf00ec2e4ea47256f397b7ebe97fd" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="2" groups="device,yukawa,pdk" name="device/amlogic/yukawa-kernel" revision="90dc515e490b2cd481a0b1bdb36cd605a010c27a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk" name="device/common" revision="1332d8b9851af5ec38d43796e49757cb9b672539" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/arm64" revision="b2aea8576e3928e9add8b616740e56c1c5a811d2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/armv7-a-neon" revision="66a3702708ca934117f1217950d4d5abca05380f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/art" revision="7690f44d09180954226514403880f6f1f6df9b57" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/car" revision="96ca24806dc620d2830f161edcd636631d16eccb" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/common" revision="754ecb765b523baf6a284db336c1823998f6dda7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/goldfish" revision="2ec6502a3648527f1fa26437d38d94906dc5be0f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/goldfish-opengl" revision="f02c30629ed52d2a91b09853efe66e57822f11c7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/mini-emulator-arm64" revision="672958caf7187fb355149546d886bf5f556ba3e6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/mini-emulator-armv7-a-neon" revision="8c906010786b63d1549ea76e0dba2e0c0abc399b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/mini-emulator-x86" revision="dc0e1610a68c17e4aaf3a2b06bf18062e8e5e4d0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/mini-emulator-x86_64" revision="0e0dc9eefb1226163a215ac3bac16dedf15d88f9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/opengl-transport" revision="4157616ba2a705a6c8c50f3f7c73582e78587a4c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/qemu" revision="c8ce4857daa7c8044765bb4b99069f8ce1273bb8" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/trusty" revision="20d11f80a1a630cc4687e9f3a2daa477ef808fdc" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,pdk" name="device/generic/uml" revision="5fe965e13174c9eb6833f60dd398ced5b9fe19ca" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/x86" revision="7a73a1f8e9fd691cb8f45aa9de303f3c39c3837a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/generic/x86_64" revision="506952733fdebb5a2ef086b519ceebe86a95ae31" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,broadcom_pdk,generic_fs,pdk" name="device/google/atv" revision="a9bbff2a3029d702e65a25362dd24bbaf3e39d4c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,bonito" name="device/google/bonito" revision="c352f53fecf98c99c66a25c4894159fab99acba4" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="device,bonito" name="device/google/bonito-kernel" revision="40112b89bb6d461ee42a28c952b886caf3aa83a9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,bonito" name="device/google/bonito-sepolicy" revision="d6ffe0a3a8b5c4805d10c3bba8a6f9f507732e17" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,pdk" name="device/google/contexthub" revision="675f10e0e17e159392251156255583645684d6b3" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,coral" name="device/google/coral" revision="e7a2f830c511657d22d61d872fd9b3d62cf85eab" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="device,coral" name="device/google/coral-kernel" revision="3faa0ae96eb23edb82bfdc4926e525eae6574310" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,coral" name="device/google/coral-sepolicy" revision="75bd11b68ab88caba011981763b425ca93f6dc7c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,crosshatch,generic_fs" name="device/google/crosshatch" revision="087ec9a68fe9ff87852c6df79f8953d6fa23c82c" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="device,crosshatch,generic_fs" name="device/google/crosshatch-kernel" revision="4a98559b8ea2afdeaffb4f83da0fe932758bca2b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,crosshatch,generic_fs" name="device/google/crosshatch-sepolicy" revision="f482f278a07fd9c88a6e474ec878c6fba5e73c12" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,pdk" name="device/google/cuttlefish" revision="3751274ad917b783a90e754b19a16bd572c706ad" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="device,pdk" name="device/google/cuttlefish_kernel" revision="e78e91b5ab5c29bc24227deec49154718db7df14" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="device,pdk" name="device/google/cuttlefish_vmm" revision="036b31d939f2f09fb49f7229317a906cf7fe8688" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device" name="device/google/fuchsia" revision="bd27589b2b24d0975261e0b400c60b74bd18dfd4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,generic_fs,muskie" name="device/google/muskie" revision="f8e2fd922c404551025ba95976452edbcf8688bf" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,taimen" name="device/google/taimen" revision="ff36fc3eecf38da6f8e2a7dc47d72f2963745363" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="device/google/vrservices" revision="7cb17e865f59ce40ce0393dfccddbc0807698806" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,generic_fs,wahoo" name="device/google/wahoo" revision="2ece80947b49534569e2e67795f78a7d8502b85c" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="device,generic_fs,wahoo" name="device/google/wahoo-kernel" revision="c8ceca4330b08d70345fb3a715a13b8d256acde6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,generic_fs" name="device/google_car" revision="2f7ad9e79edfeeffcdb9aba5c7fca84f1c6b70b8" upstream="refs/tags/android-r-preview-2"/>
+  <project name="device/linaro/bootloader/OpenPlatformPkg" revision="044ce29a658ec8719ca1e839a4502ff835e0ccb7" upstream="refs/tags/android-r-preview-2"/>
+  <project name="device/linaro/bootloader/arm-trusted-firmware" revision="4a8974da598bde9881f85699fefd69ec776be5b4" upstream="refs/tags/android-r-preview-2"/>
+  <project name="device/linaro/bootloader/edk2" revision="6141238127ffcef8fee2af2cd01757264a95bf09" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,dragonboard,pdk" name="device/linaro/dragonboard" revision="c8a4acf7d45d080c1e618f81dc274df7918c277b" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="device,dragonboard,pdk" name="device/linaro/dragonboard-kernel" revision="613536d9b743155d0f5e075a33adb6fa32e0d5cd" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,hikey,pdk" name="device/linaro/hikey" revision="bbb5c4c78a5bf7ceeb2679a6a3a48ac4e39b122a" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="device,hikey,pdk" name="device/linaro/hikey-kernel" revision="11937728c652b4d006c6c6b6e39a927efcc8f40b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,poplar,pdk" name="device/linaro/poplar" revision="ccabcdbb5be800b96f92a664230343ff04d3f8fd" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="device,poplar,pdk" name="device/linaro/poplar-kernel" revision="d9338d916fee52afdb36115925f2ad570ec0cb19" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="device/sample" revision="9eb09f5c7858fcf1824020a9a04e73e159dd871d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="device,beagle_x15,pdk" name="device/ti/beagle-x15" path="device/ti/beagle_x15" revision="826fa06d1e8031b5a83469b095c85c6237acc4f5" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="device,beagle_x15,pdk" name="device/ti/beagle-x15-kernel" path="device/ti/beagle_x15-kernel" revision="0d99bf0b39100deba5ea9071d6472acb3bc09103" upstream="refs/tags/android-r-preview-2"/>
+  <project name="kernel/build" revision="0daf60d859d8c8b25e00c1cdd9e25df50dd95765" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="kernel/configs" revision="64e78fd9cf7fd467fb2327432ffd7f0360612b0c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="kernel/tests" revision="f34af4764ffd45ae683ae6dc753e4be4b2180490" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/art" path="art" revision="198955af0d596dd87d5398d610dd503cf818db86" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/bionic" path="bionic" revision="2a069b24df1efffde894b186a669b8b95d4f1fc2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/bootable/recovery" path="bootable/recovery" revision="4577dff5a0bb2b008a3454171898527174a71f74" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/build" path="build/make" revision="352e6a4d183759315de61db6a96c110f5e1d4381" upstream="refs/tags/android-r-preview-2">
     <copyfile dest="Makefile" src="core/root.mk"/>
     <linkfile dest="build/CleanSpec.mk" src="CleanSpec.mk"/>
     <linkfile dest="build/buildspec.mk.default" src="buildspec.mk.default"/>
@@ -74,743 +74,710 @@
     <linkfile dest="build/target" src="target"/>
     <linkfile dest="build/tools" src="tools"/>
   </project>
-  <project groups="pdk,tradefed" name="platform/build/blueprint" path="build/blueprint" revision="450c4f565a52ffc11d2239c86ea3f4568198e8ee" upstream="master"/>
-  <project groups="pdk,tradefed" name="platform/build/soong" path="build/soong" revision="e24093a7846af0fcc2b598c5984534243d45e891" upstream="master">
+  <project groups="pdk,tradefed" name="platform/build/blueprint" path="build/blueprint" revision="7a56608b919834534c714702ddedc6044eb18013" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,tradefed" name="platform/build/soong" path="build/soong" revision="2812418eacd35838bb3d3a231621fab013a081c0" upstream="refs/tags/android-r-preview-2">
     <linkfile dest="Android.bp" src="root.bp"/>
     <linkfile dest="bootstrap.bash" src="bootstrap.bash"/>
   </project>
-  <project groups="pdk" name="platform/compatibility/cdd" path="compatibility/cdd" revision="9c2ecb3152bfb69689dd57f5ccefbcbccbf2da9f" upstream="master"/>
-  <project groups="cts,pdk-cw-fs,pdk-fs" name="platform/cts" path="cts" revision="8c2621857b3a61f43d8003b31ac32717d05d99db" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/dalvik" path="dalvik" revision="54cc4ca1beb7eba4509005553e89ad1ea4528812" upstream="master"/>
-  <project groups="developers,pdk" name="platform/developers/build" path="developers/build" revision="112664b4ada23a340082746c93870a55f32d6a1b" upstream="master"/>
-  <project groups="developers" name="platform/developers/demos" path="developers/demos" revision="03814c35b8ee0a1284c667556260124d97466b28" upstream="master"/>
-  <project groups="developers" name="platform/developers/samples/android" path="developers/samples/android" revision="752c0d69bf305d2a0888044cb21692c1cbde2a7f" upstream="master"/>
-  <project groups="developers,pdk-cw-fs,pdk-fs" name="platform/development" path="development" revision="cfeef5f41c94b70791c31281d58fd38ea1e325a6" upstream="master"/>
-  <project groups="pdk" name="platform/external/ARMComputeLibrary" path="external/ARMComputeLibrary" revision="23a16533b968b01c0fab733dd13dc418bd8434ef" upstream="master"/>
-  <project groups="pdk" name="platform/external/ImageMagick" path="external/ImageMagick" revision="92d6fc9594fc15d47c29704bedc47cc202fa8673" upstream="master"/>
-  <project groups="pdk" name="platform/external/OpenCSD" path="external/OpenCSD" revision="698836bb1f51ed9c4d1c274b0d8e41e34fdb3612" upstream="master"/>
-  <project groups="pdk" name="platform/external/Reactive-Extensions/RxCpp" path="external/Reactive-Extensions/RxCpp" revision="37d2a9fffbbd702bb2c8cb74259090ad2bfb7818" upstream="master"/>
-  <project groups="pdk" name="platform/external/aac" path="external/aac" revision="7ea2e46dc1bce32d4d207408f2b4a14d5933bef5" upstream="master"/>
-  <project groups="pdk" name="platform/external/adeb" path="external/adeb" revision="a744f6b78ab37d01e5116fc4a77fe05a15b43429" upstream="master"/>
-  <project groups="pdk" name="platform/external/adhd" path="external/adhd" revision="e8f4fb5db0dc434e73080639208f1b20bbf5d962" upstream="master"/>
-  <project groups="pdk" name="platform/external/android-clat" path="external/android-clat" revision="6021ef919ba0a79243817a5e52c5e228441f1c64" upstream="master"/>
-  <project groups="pdk" name="platform/external/androidplot" path="external/androidplot" revision="b999712946d5141812fa2456e652db6b818d439e" upstream="master"/>
-  <project groups="pdk" name="platform/external/ant-glob" path="external/ant-glob" revision="45461635647e5481fa67473795782ce232e44fe1" upstream="master"/>
-  <project groups="pdk" name="platform/external/antlr" path="external/antlr" revision="f207c52043d762d9cfbfd87986b5194c855a318a" upstream="master"/>
-  <project groups="pdk" name="platform/external/apache-commons-bcel" path="external/apache-commons-bcel" revision="50e755197cd5de9d584414616d6d48877c92c649" upstream="master"/>
-  <project groups="pdk" name="platform/external/apache-commons-compress" path="external/apache-commons-compress" revision="5334065cacdd3d1af2688d4617918ec0460708e1" upstream="master"/>
-  <project groups="pdk" name="platform/external/apache-commons-math" path="external/apache-commons-math" revision="f30081520947ace21933c4f6ade062152c9b99f3" upstream="master"/>
-  <project groups="pdk" name="platform/external/apache-harmony" path="external/apache-harmony" revision="f298d3cab612752c01f4fc0fc3d291710a9b997c" upstream="master"/>
-  <project groups="pdk" name="platform/external/apache-http" path="external/apache-http" revision="f0bc40ffae5d6c11e3ab8d04b77614a110eb0da2" upstream="master"/>
-  <project groups="pdk" name="platform/external/apache-xml" path="external/apache-xml" revision="6527de11d5422dc57e524ddddec442e7888ab53b" upstream="master"/>
-  <project groups="pdk" name="platform/external/archive-patcher" path="external/archive-patcher" revision="a9bbfc523cdcff9f82ffd6da5b5d5319555e0116" upstream="master"/>
-  <project groups="vendor" name="platform/external/arm-neon-tests" path="external/arm-neon-tests" revision="bc9bbf361c8cabbd4ae0a215de5871fad527915e" upstream="master"/>
-  <project groups="pdk" name="platform/external/arm-optimized-routines" path="external/arm-optimized-routines" revision="9ba6fed26b1e0e83aba814268896682158e99c27" upstream="master"/>
-  <project groups="pdk" name="platform/external/arm-trusted-firmware" path="external/arm-trusted-firmware" revision="f8cb4bf36efbe497216e23043732fbb8949c7d43" upstream="master"/>
-  <project groups="pdk-fs" name="platform/external/autotest" path="external/autotest" revision="bd33d3ea61b097d1e6ee79ccf7ee4d8be724114b" upstream="master"/>
-  <project groups="pdk" name="platform/external/avb" path="external/avb" revision="9e1a84ca734db624bbc559b8f58597ea2b41dbd8" upstream="master"/>
-  <project groups="pdk" name="platform/external/bc" path="external/bc" revision="4241b89a43dea2f6c4e36d38c27f4ba048d588e4" upstream="master"/>
-  <project groups="pdk" name="platform/external/bcc" path="external/bcc" revision="29d1890d920cd2b35f8c9599c25594b22ed6c183" upstream="master"/>
-  <project groups="pdk" name="platform/external/blktrace" path="external/blktrace" revision="52402696fe0dcccd6cb931c9a65342c5ce037370" upstream="master"/>
-  <project groups="pdk" name="platform/external/boringssl" path="external/boringssl" revision="8e6bcab360befabef1b8dad249a91fd9bea3e714" upstream="master"/>
-  <project groups="pdk" name="platform/external/bouncycastle" path="external/bouncycastle" revision="53833bc1ebd9adc3b552d224e3328f8199d69b88" upstream="master"/>
-  <project groups="pdk" name="platform/external/brotli" path="external/brotli" revision="4c8fa5aafe1d6a003b81de5aa3bc6582b8441a19" upstream="master"/>
-  <project groups="pdk" name="platform/external/bsdiff" path="external/bsdiff" revision="5dd29168be0b04bd597f87099d7a6835a07ac9ae" upstream="master"/>
-  <project groups="pdk" name="platform/external/bzip2" path="external/bzip2" revision="3b55d19823772c35cc7106878e00fc3f6cfa0502" upstream="master"/>
-  <project groups="pdk" name="platform/external/caliper" path="external/caliper" revision="89cb92050512ed307a9896a07444e7c12cf0a3ee" upstream="master"/>
-  <project groups="pdk" name="platform/external/capstone" path="external/capstone" revision="f1f1cbc054db7021d4167a96b55783e087e1b7b4" upstream="master"/>
-  <project groups="pdk" name="platform/external/catch2" path="external/catch2" revision="a8f1a3dea29dbd45c1b7f3422c0aa29d5f06dbda" upstream="master"/>
-  <project groups="pdk" name="platform/external/cblas" path="external/cblas" revision="61ee00692011385347a5dd1ad872556899a5cf7a" upstream="master"/>
-  <project groups="pdk" name="platform/external/cbor-java" path="external/cbor-java" revision="0ec5da1700847008a252baa17f8adc169ad8b475" upstream="master"/>
-  <project groups="pdk" name="platform/external/chromium-libpac" path="external/chromium-libpac" revision="1e18f70f87fe01d71b6cceb9d97b8811955cfd03" upstream="master"/>
-  <project groups="pdk" name="platform/external/chromium-trace" path="external/chromium-trace" revision="4e8f1845d54bfa731d7a5985db5fe3d77a5798c3" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/external/chromium-webview" path="external/chromium-webview" revision="78b57c85dc1579b8a05716c735299c7cd3d84b73" upstream="master"/>
-  <project groups="pdk" name="platform/external/clang" path="external/clang" revision="4c9ce042c54a4bccb4f0fc36e605e3df5be5a296" upstream="master"/>
-  <project groups="pdk" name="platform/external/cldr" path="external/cldr" revision="a9317df749a4f7e9ad7c2210c7bc9ce989945f45" upstream="master"/>
-  <project groups="pdk" name="platform/external/cmockery" path="external/cmockery" revision="9199c7bfafefea32d1884182fa655b6e4578c1c4" upstream="master"/>
-  <project groups="pdk" name="platform/external/cn-cbor" path="external/cn-cbor" revision="ce9bc12ea70b0ee0d2861cb9309bce6ef9850095" upstream="master"/>
-  <project groups="pdk" name="platform/external/compiler-rt" path="external/compiler-rt" revision="c72b929327e09ae6c482ff6d091f191c64044c43" upstream="master"/>
-  <project groups="pdk" name="platform/external/conscrypt" path="external/conscrypt" revision="fcc36893cc4917aee305c17c8fc4378bb41ab300" upstream="master"/>
-  <project groups="pdk" name="platform/external/cpu_features" path="external/cpu_features" revision="b3deee8da1421bc7c66c99b6d9b24c018adad137" upstream="master"/>
-  <project groups="pdk" name="platform/external/crcalc" path="external/crcalc" revision="e98cd94d29a398572562218704dbce3cdfec86c5" upstream="master"/>
-  <project groups="pdk" name="platform/external/cros/system_api" path="external/cros/system_api" revision="38114471918da3af3eee5b26c4e1d7d93517af5b" upstream="master"/>
-  <project groups="pdk" name="platform/external/crosvm" path="external/crosvm" revision="e792dd6e1f76d3e3991829c479fd8cd100cb55a6" upstream="master"/>
-  <project groups="pdk" name="platform/external/curl" path="external/curl" revision="20c1fa87d386442426f42af68de56cc80b3fe206" upstream="master"/>
-  <project groups="pdk" name="platform/external/dagger2" path="external/dagger2" revision="ea6581738e54ed1b40f19be5edf204eb84c50a17" upstream="master"/>
-  <project groups="pdk-fs" name="platform/external/deqp" path="external/deqp" revision="1a8349f721a978681eff4ac9a4b228f70c34a1e0" upstream="master"/>
-  <project groups="pdk-fs" name="platform/external/deqp-deps/SPIRV-Headers" path="external/deqp-deps/SPIRV-Headers" revision="33de1aef825029c0cf7927a72df63ebe79745c6f" upstream="master"/>
-  <project groups="pdk-fs" name="platform/external/deqp-deps/SPIRV-Tools" path="external/deqp-deps/SPIRV-Tools" revision="2e6244127648ea760172bf07ecf687a59ee7bd17" upstream="master"/>
-  <project groups="pdk-fs" name="platform/external/deqp-deps/glslang" path="external/deqp-deps/glslang" revision="91b452070b219d80a82d98deb46c1514dc67f4b8" upstream="master"/>
-  <project groups="pdk" name="platform/external/desugar" path="external/desugar" revision="3041d69a3395243035260e72e56b43835c70a6cd" upstream="master"/>
-  <project groups="pdk" name="platform/external/dexmaker" path="external/dexmaker" revision="852829233ec4ac07b20ab85a5c2c1431cf48c4a8" upstream="master"/>
-  <project groups="pdk" name="platform/external/dlmalloc" path="external/dlmalloc" revision="3a9d0af27a9f8fe533931a9e7ca843fd8e5b54f1" upstream="master"/>
-  <project groups="pdk" name="platform/external/dng_sdk" path="external/dng_sdk" revision="021f4f74994635d7739d637f206aca1949eadc0a" upstream="master"/>
-  <project groups="pdk" name="platform/external/dnsmasq" path="external/dnsmasq" revision="bfce4be5569c60687509a40c4f2304f2962182cb" upstream="master"/>
-  <project groups="pdk" name="platform/external/doclava" path="external/doclava" revision="706da81e97b733ee2218fb3e18b9457d16933bdf" upstream="master"/>
-  <project groups="pdk" name="platform/external/dokka" path="external/dokka" revision="13c6a6032bbdb620a6ff51e855ef2e0850246943" upstream="master"/>
-  <project groups="drm_hwcomposer,pdk-fs" name="platform/external/drm_hwcomposer" path="external/drm_hwcomposer" revision="68b94c0faebf0bf2d024fab7ed812e706589bbf1" upstream="master"/>
-  <project groups="pdk" name="platform/external/droiddriver" path="external/droiddriver" revision="1f22097729682f02ddff07c8fbcf4edbf265d87a" upstream="master"/>
-  <project groups="pdk" name="platform/external/drrickorang" path="external/drrickorang" revision="9ace52f67095e71146d9d9fdc503c565a3477473" upstream="master"/>
-  <project groups="pdk" name="platform/external/dtc" path="external/dtc" revision="c7db36e4961918d5f0715984f6d28484e635ece3" upstream="master"/>
-  <project groups="pdk" name="platform/external/dynamic_depth" path="external/dynamic_depth" revision="c4e17d8ad11078cb976439950346ee774282d16c" upstream="master"/>
-  <project groups="pdk" name="platform/external/e2fsprogs" path="external/e2fsprogs" revision="e2c8b268cf994af605ef8698fc7a0ce80ee70703" upstream="master"/>
-  <project groups="pdk" name="platform/external/easymock" path="external/easymock" revision="afd503b419c6c25d6804e137f2642217f10ee980" upstream="master"/>
-  <project groups="pdk" name="platform/external/eigen" path="external/eigen" revision="47ec287e7645495ba9f454c54f674fd60e279436" upstream="master"/>
-  <project groups="pdk" name="platform/external/elfutils" path="external/elfutils" revision="2fdc74b3a887fca4e2f90957ec13801aed4fe3d2" upstream="master"/>
-  <project groups="pdk" name="platform/external/emma" path="external/emma" revision="c2aa4d22fc24295761a9c588836531a7b3d3d519" upstream="master"/>
-  <project groups="pdk" name="platform/external/epid-sdk" path="external/epid-sdk" revision="7d6a6b63582f241b4ae4248bab416277ed659968" upstream="master"/>
-  <project groups="pdk" name="platform/external/error_prone" path="external/error_prone" revision="b4f4d485f957a0508434dfc60dd0ccf6df2c9c1e" upstream="master"/>
-  <project groups="pdk" name="platform/external/ethtool" path="external/ethtool" revision="ec59d5f2221067868868c5d07d7695821dcb9817" upstream="master"/>
-  <project groups="pdk" name="platform/external/expat" path="external/expat" revision="b79e5225fd8ea40d0ffc91898fc04eb19fe6baaa" upstream="master"/>
-  <project groups="pdk" name="platform/external/f2fs-tools" path="external/f2fs-tools" revision="e7e1a49d8e384652cf70ff0bbd78bebf48824619" upstream="master"/>
-  <project groups="pdk" name="platform/external/fastrpc" path="external/fastrpc" revision="d970208a9770f3f02ccd311a621ca449dc35aec4" upstream="master"/>
-  <project groups="pdk" name="platform/external/fdlibm" path="external/fdlibm" revision="3eea558350ee7509b210f3bfa91bb9f318121e31" upstream="master"/>
-  <project groups="pdk" name="platform/external/fec" path="external/fec" revision="7049b92008752b4f939425ad91bf2aea86133216" upstream="master"/>
-  <project groups="pdk" name="platform/external/flac" path="external/flac" revision="b71b20865981d42204f666992aafcd1fee4713a5" upstream="master"/>
-  <project groups="pdk" name="platform/external/flatbuffers" path="external/flatbuffers" revision="b9c7cbd65c84d1f9bd81b47aa37df697f84a1486" upstream="master"/>
-  <project groups="pdk" name="platform/external/fmtlib" path="external/fmtlib" revision="289bd9700073441c2086388c1dc85aa3daea4e08" upstream="master"/>
-  <project groups="pdk" name="platform/external/fonttools" path="external/fonttools" revision="33b327bcebdc156e64fd6b8d5307332eb04e6f3b" upstream="master"/>
-  <project groups="pdk" name="platform/external/freetype" path="external/freetype" revision="4be5df0fc7c017e762914446c3edb9e6e312a5d0" upstream="master"/>
-  <project groups="pdk" name="platform/external/fsck_msdos" path="external/fsck_msdos" revision="65c509b75869d6bf60e51e8e35741b7c4fedeb6a" upstream="master"/>
-  <project groups="pdk" name="platform/external/fsverity-utils" path="external/fsverity-utils" revision="88a05e4c5f6c33b9915635b2a9b409936da57770" upstream="master"/>
-  <project groups="pdk" name="platform/external/gemmlowp" path="external/gemmlowp" revision="5481c18ff2c873db3f87948e62ee1007ccb19266" upstream="master"/>
-  <project groups="pdk" name="platform/external/gflags" path="external/gflags" revision="ab750f5fe55da2b363ab745908fe2673967610e9" upstream="master"/>
-  <project groups="pdk,qcom_msm8x26" name="platform/external/giflib" path="external/giflib" revision="341c85ed68d932afcdd4481d361d9c1e65b453e2" upstream="master"/>
-  <project groups="pdk" name="platform/external/glide" path="external/glide" revision="bd0082947a4c7b0058049c155d3c2517d462cc81" upstream="master"/>
-  <project groups="pdk" name="platform/external/golang-protobuf" path="external/golang-protobuf" revision="fcdf38bba2f334cda94ca7a01fef5b3a55307deb" upstream="master"/>
-  <project groups="pdk" name="platform/external/google-benchmark" path="external/google-benchmark" revision="8556c6c05e8636fcc73143434c390daa79a2fb4f" upstream="master"/>
-  <project groups="pdk-fs" name="platform/external/google-breakpad" path="external/google-breakpad" revision="05728773737deb58a10cdbe29750152c13e400bf" upstream="master"/>
-  <project groups="pdk" name="platform/external/google-fonts/arbutus-slab" path="external/google-fonts/arbutus-slab" revision="6a62a3a7283256e86faac4b4830e224f64946838" upstream="master"/>
-  <project groups="pdk" name="platform/external/google-fonts/arvo" path="external/google-fonts/arvo" revision="bca8c9b2d370ba24ac0280d674b063f647a038bd" upstream="master"/>
-  <project groups="pdk" name="platform/external/google-fonts/carrois-gothic-sc" path="external/google-fonts/carrois-gothic-sc" revision="8c54a6b341ce312cb1ef44add56b5fb0183aaf69" upstream="master"/>
-  <project groups="pdk" name="platform/external/google-fonts/coming-soon" path="external/google-fonts/coming-soon" revision="477b0ee78ac4bbdf6de0032e903eb4ade0c1de05" upstream="master"/>
-  <project groups="pdk" name="platform/external/google-fonts/cutive-mono" path="external/google-fonts/cutive-mono" revision="9178eb37f91560f7f3135489e533101db23d0fff" upstream="master"/>
-  <project groups="pdk" name="platform/external/google-fonts/dancing-script" path="external/google-fonts/dancing-script" revision="c2ee745ad605df8e37a181bce60350113228d091" upstream="master"/>
-  <project groups="pdk" name="platform/external/google-fonts/lato" path="external/google-fonts/lato" revision="139c627f77933688eeda9c16a575c1421af08808" upstream="master"/>
-  <project groups="pdk" name="platform/external/google-fonts/rubik" path="external/google-fonts/rubik" revision="4a650db6c054b9b328eb1364d217a82296143d25" upstream="master"/>
-  <project groups="pdk" name="platform/external/google-fonts/source-sans-pro" path="external/google-fonts/source-sans-pro" revision="ea1024073315464fc4ce2c5c0fccaf2ace8e18ac" upstream="master"/>
-  <project groups="pdk" name="platform/external/google-fonts/zilla-slab" path="external/google-fonts/zilla-slab" revision="11c07b19edec7867860296950b14cf7b687240bd" upstream="master"/>
-  <project groups="pdk" name="platform/external/google-fruit" path="external/google-fruit" revision="8ae85592a0481bdda1dee994a3f5c6bdbe22b2e6" upstream="master"/>
-  <project groups="pdk" name="platform/external/google-styleguide" path="external/google-styleguide" revision="c547d8f0b06e97aaae55eaac21d259bd475cadd5" upstream="master"/>
-  <project groups="pdk" name="platform/external/googletest" path="external/googletest" revision="b21299dc7da666f805e9a548f691a06bfbb32676" upstream="master"/>
-  <project groups="pdk" name="platform/external/gptfdisk" path="external/gptfdisk" revision="0da7f5dd7328f44ed37a6a752c16f827fb0a9de8" upstream="master"/>
-  <project groups="pdk,tradefed" name="platform/external/grpc-grpc" path="external/grpc-grpc" revision="8b547c4895c1455aada0406841b92343b186bc6e" upstream="master"/>
-  <project groups="pdk,tradefed" name="platform/external/grpc-grpc-java" path="external/grpc-grpc-java" revision="9b4f1a6db99b7cb7d46320e25e32317853b500dc" upstream="master"/>
-  <project groups="pdk" name="platform/external/guava" path="external/guava" revision="55e101ce9c48a1cc2df166104eb56b2cb695b0c7" upstream="master"/>
-  <project groups="pdk" name="platform/external/guice" path="external/guice" revision="536c2ca40acfa596853521db6ad49e0926d09b71" upstream="master"/>
-  <project groups="pdk" name="platform/external/gwp_asan" path="external/gwp_asan" revision="6f8ad46967731378ea2eb7d8ba23332c0c9569a7" upstream="master"/>
-  <project groups="pdk" name="platform/external/hamcrest" path="external/hamcrest" revision="77b3f40edc059d1366424d57caefc50d671050d2" upstream="master"/>
-  <project groups="pdk,qcom_msm8x26" name="platform/external/harfbuzz_ng" path="external/harfbuzz_ng" revision="e86af6134dd321954519036c7fedf610c84f183e" upstream="master"/>
-  <project groups="pdk" name="platform/external/honggfuzz" path="external/honggfuzz" revision="4da5ca807ec753ef0dba496f8db65738084c42bb" upstream="master"/>
-  <project groups="pdk" name="platform/external/hyphenation-patterns" path="external/hyphenation-patterns" revision="659329db951bf01b5e055c26217a0cc669929c00" upstream="master"/>
-  <project groups="pdk" name="platform/external/icu" path="external/icu" revision="7732eff7f3f078b7642f5fdc26bdb01c5666b6ea" upstream="master"/>
-  <project groups="pdk" name="platform/external/igt-gpu-tools" path="external/igt-gpu-tools" revision="89b0d3ba4d28a7f186b3a30ec4b27d37a2cf0ad4" upstream="master"/>
-  <project groups="pdk" name="platform/external/image_io" path="external/image_io" revision="135f7c04ae98ce694efcfc6d9a0d2bc38f4c3653" upstream="master"/>
-  <project groups="pdk" name="platform/external/ims" path="external/ims" revision="442da1408505ff574cdf2c8a6491ae1c6311d4a3" upstream="master"/>
-  <project groups="pdk" name="platform/external/iperf3" path="external/iperf3" revision="be4252fd76af2eca46d67ddc19dc3d45e04701ac" upstream="master"/>
-  <project groups="pdk" name="platform/external/iproute2" path="external/iproute2" revision="ab7379dd97e0d46fc84407a86de7397e0106a424" upstream="master"/>
-  <project groups="pdk" name="platform/external/ipsec-tools" path="external/ipsec-tools" revision="21841d18260f3247c0189c5157169c862632f0ec" upstream="master"/>
-  <project groups="pdk" name="platform/external/iptables" path="external/iptables" revision="c70f7ac0238cbe801ba4ce7148a1bb2d8d9ade36" upstream="master"/>
-  <project groups="pdk" name="platform/external/iputils" path="external/iputils" revision="7ff16b416c78cab221edbb57e569e161eefef331" upstream="master"/>
-  <project groups="pdk" name="platform/external/iw" path="external/iw" revision="e55a47ac749af802d894a1a715fa681af6c787e4" upstream="master"/>
-  <project groups="pdk" name="platform/external/jacoco" path="external/jacoco" revision="8e37ff147009b16f4dd904bcc32714990e5cf22a" upstream="master"/>
-  <project groups="pdk" name="platform/external/jarjar" path="external/jarjar" revision="d6f27420440536c7650e47ddde630f5f93ca27fc" upstream="master"/>
-  <project groups="pdk" name="platform/external/javaparser" path="external/javaparser" revision="1bace984128f31e89891a12e39d877f7aeefd760" upstream="master"/>
-  <project groups="pdk" name="platform/external/javapoet" path="external/javapoet" revision="c679ce9933a802fc637e8f2d69c0ea25cf376f88" upstream="master"/>
-  <project groups="pdk" name="platform/external/javasqlite" path="external/javasqlite" revision="c093f72b18ff45bd66c8884ef667399aa5891b9f" upstream="master"/>
-  <project groups="pdk" name="platform/external/jcommander" path="external/jcommander" revision="c4d97985b3787276d6b391510250246c9ca94541" upstream="master"/>
-  <project groups="pdk" name="platform/external/jdiff" path="external/jdiff" revision="fde1ff01f6272f0854ecb21184b56f38b70d6e09" upstream="master"/>
-  <project groups="pdk" name="platform/external/jemalloc" path="external/jemalloc" revision="e3ff6769f8262841c98245e21b96dc67536759dc" upstream="master"/>
-  <project groups="pdk" name="platform/external/jemalloc_new" path="external/jemalloc_new" revision="76307d1c5749f2fc14e124342782373c7410dbbb" upstream="master"/>
-  <project groups="pdk,tradefed,pdk-fs" name="platform/external/jline" path="external/jline" revision="478835d3c4603b43c28feb80912ff33f2c6811a6" upstream="master"/>
-  <project groups="pdk" name="platform/external/jsilver" path="external/jsilver" revision="241cd1b197ee8e520aa6b04f277c3b29a2ff0fe4" upstream="master"/>
-  <project groups="pdk" name="platform/external/jsmn" path="external/jsmn" revision="080ff0d1cb13f84b890d543ab6734394c314bae3" upstream="master"/>
-  <project groups="pdk" name="platform/external/jsoncpp" path="external/jsoncpp" revision="34ba61cd2766f63917262655c46f4075a3c14712" upstream="master"/>
-  <project groups="pdk" name="platform/external/jsr305" path="external/jsr305" revision="7b129a25432c1a1a3d1919499d8e2f583c753b8d" upstream="master"/>
-  <project groups="pdk" name="platform/external/jsr330" path="external/jsr330" revision="4221d13d2c4079d3299c1d3265ed93564b84c78b" upstream="master"/>
-  <project groups="pdk" name="platform/external/junit" path="external/junit" revision="b9c79460f7b94f7ec96a899cb60f46e44b78cce4" upstream="master"/>
-  <project groups="pdk" name="platform/external/junit-params" path="external/junit-params" revision="ed4bc1eedea9e248f690ed682e4bd1b65863268d" upstream="master"/>
-  <project groups="pdk" name="platform/external/kernel-headers" path="external/kernel-headers" revision="0da1207a923cf562aab37c63a0a9754ca46b90c8" upstream="master"/>
-  <project groups="pdk" name="platform/external/kmod" path="external/kmod" revision="e6d59a0146bd3fad69cb76c9c48742960c9a6293" upstream="master"/>
-  <project groups="pdk" name="platform/external/kotlinc" path="external/kotlinc" revision="e5d89a24a9b7092555014dc2546709b5bd0da816" upstream="master"/>
-  <project groups="pdk" name="platform/external/kotlinx.coroutines" path="external/kotlinx.coroutines" revision="7c05c673197996a302e09938d62bd2425b8124ba" upstream="master"/>
-  <project groups="pdk" name="platform/external/ksoap2" path="external/ksoap2" revision="05ed316a8d34fe7efe7073876a75ef35cbf175fa" upstream="master"/>
-  <project groups="pdk" name="platform/external/libaom" path="external/libaom" revision="ec201c274c3770d829470ab49facf02db456e6f8" upstream="master"/>
-  <project groups="pdk" name="platform/external/libavc" path="external/libavc" revision="dd964bfe0cd8340b58aabcc4145044ea3037c87b" upstream="master"/>
-  <project groups="pdk" name="platform/external/libbackup" path="external/libbackup" revision="be853756f8a215492b11ae545206d12b64d3a03c" upstream="master"/>
-  <project groups="pdk" name="platform/external/libbrillo" path="external/libbrillo" revision="d4a88f4821ed402c6515d3cf5442a90c95c529e6" upstream="master"/>
-  <project groups="pdk" name="platform/external/libcap" path="external/libcap" revision="2db20a0a41de7cf42cc78f4c8a9b0ef2ed47f6b7" upstream="master"/>
-  <project groups="pdk" name="platform/external/libcap-ng" path="external/libcap-ng" revision="e17ed85e2a3b4691efd6975a02f8e56277cc93af" upstream="master"/>
-  <project groups="pdk" name="platform/external/libchrome" path="external/libchrome" revision="7f5561196db242c11ffdca483b1a39fd7f1765dd" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/external/libcups" path="external/libcups" revision="bc263e03c16078ce6b9e322448e34a54c336377f" upstream="master"/>
-  <project groups="pdk" name="platform/external/libcxx" path="external/libcxx" revision="fb268a4f43cfa8edc0bde47c1370405d78605b75" upstream="master"/>
-  <project groups="pdk" name="platform/external/libcxxabi" path="external/libcxxabi" revision="8ba49a025b6ee7d2ea78e68b0a3b29181e0b2149" upstream="master"/>
-  <project groups="pdk" name="platform/external/libdaemon" path="external/libdaemon" revision="433dd14cb58a66737e158ad1331c02162a80f43f" upstream="master"/>
-  <project groups="pdk" name="platform/external/libdivsufsort" path="external/libdivsufsort" revision="abb3a16c4986c5f7dda62580c4f53c1930d4d1b9" upstream="master"/>
-  <project groups="pdk" name="platform/external/libdrm" path="external/libdrm" revision="adc4cefa026ce3a2325ab50996be043d2465a51b" upstream="master"/>
-  <project groups="pdk" name="platform/external/libepoxy" path="external/libepoxy" revision="c62140bafd3d35abab89eb54a2ba43ddcf5d20a3" upstream="master"/>
-  <project groups="pdk" name="platform/external/libese" path="external/libese" revision="d4842e849a77e2da14bf4ae8f7bde02646acefbb" upstream="master"/>
-  <project groups="pdk" name="platform/external/libevent" path="external/libevent" revision="38e40aa9e0ed7c20999d410bbcab9f01ffdfa4f3" upstream="master"/>
-  <project groups="pdk" name="platform/external/libexif" path="external/libexif" revision="6e84ee222d491625b3f57d38e16806e6b7a92b5d" upstream="master"/>
-  <project groups="pdk" name="platform/external/libffi" path="external/libffi" revision="bfe44f1a722c1622e84ee2971ba0cc47519c2ed1" upstream="master"/>
-  <project groups="pdk" name="platform/external/libfuse" path="external/libfuse" revision="54ee84ad311a9d0d16af37390f226185d5ceccc3" upstream="master"/>
-  <project groups="pdk" name="platform/external/libgav1" path="external/libgav1" revision="7f6a1063bebabcc9fad0d191a6042034573f7f58" upstream="master"/>
-  <project groups="pdk" name="platform/external/libgsm" path="external/libgsm" revision="1321c574befc82fd21a8ac38d36e1da1f3ffb336" upstream="master"/>
-  <project groups="pdk" name="platform/external/libhevc" path="external/libhevc" revision="3fac63c9b78796d97bdd7c33b238f4e099460051" upstream="master"/>
-  <project groups="pdk" name="platform/external/libjpeg-turbo" path="external/libjpeg-turbo" revision="9ac75d8528e6153973d8251ec4ee13251de308e0" upstream="master"/>
-  <project groups="pdk" name="platform/external/libkmsxx" path="external/libkmsxx" revision="90a6fa7c3b0988752fb5389c91f38b1a0c636242" upstream="master"/>
-  <project groups="pdk" name="platform/external/libldac" path="external/libldac" revision="93195ee38bd08ea8d9f87cbfa550635923f213de" upstream="master"/>
-  <project groups="pdk" name="platform/external/libmpeg2" path="external/libmpeg2" revision="96677b6e5025be5cebf336e73ee6b41c0af85405" upstream="master"/>
-  <project groups="pdk" name="platform/external/libmtp" path="external/libmtp" revision="1576a007aaa639a89311b245a0363fa80e22dcfb" upstream="master"/>
-  <project groups="pdk" name="platform/external/libnetfilter_conntrack" path="external/libnetfilter_conntrack" revision="a44a0c25fa5eb2575df464bd4d9e3e5c7da9ccf6" upstream="master"/>
-  <project groups="pdk" name="platform/external/libnfnetlink" path="external/libnfnetlink" revision="ac537e1d43625a99d8b266a362f4735762a42b66" upstream="master"/>
-  <project groups="pdk" name="platform/external/libnl" path="external/libnl" revision="173d924eceaa33fe7f731dfc692dd1e1cace80f3" upstream="master"/>
-  <project groups="pdk" name="platform/external/libogg" path="external/libogg" revision="7f296fb742e985fa37eed897fa71513a6a165594" upstream="master"/>
-  <project groups="pdk" name="platform/external/libopus" path="external/libopus" revision="d3e2bc19cbc342885fb6c57a71f662891fe4be8b" upstream="master"/>
-  <project groups="pdk" name="platform/external/libpcap" path="external/libpcap" revision="1974a6a92997523e1347f939a87ceb7c8339dd90" upstream="master"/>
-  <project groups="pdk" name="platform/external/libphonenumber" path="external/libphonenumber" revision="f1839a92036d1a0a8fd35474eb8352936cb78fa9" upstream="master"/>
-  <project groups="pdk" name="platform/external/libpng" path="external/libpng" revision="54ca51b2ee6da088d5eb1c7ef6430b1c83019977" upstream="master"/>
-  <project groups="pdk" name="platform/external/libprotobuf-mutator" path="external/libprotobuf-mutator" revision="7eae75fbc6bbf8803e915829a9c904f63968bf96" upstream="master"/>
-  <project groups="pdk" name="platform/external/libsrtp2" path="external/libsrtp2" revision="1904160d088401788daf6b5d1130819f087ff946" upstream="master"/>
-  <project groups="pdk" name="platform/external/libtextclassifier" path="external/libtextclassifier" revision="f75bee769a2bf71eff34e38a8d6af731bfcf033f" upstream="master"/>
-  <project groups="pdk" name="platform/external/libunwind" path="external/libunwind" revision="2f060ec263cd6fa3ea56140c84439d08e360621d" upstream="master"/>
-  <project groups="pdk" name="platform/external/libunwind_llvm" path="external/libunwind_llvm" revision="249d6896be0c5179c6d6b4fd1e3d8f092a01582d" upstream="master"/>
-  <project groups="pdk" name="platform/external/libusb" path="external/libusb" revision="e486a629e38d567d271f38f50deeccdac6b7fc62" upstream="master"/>
-  <project groups="pdk" name="platform/external/libusb-compat" path="external/libusb-compat" revision="c9943b468b27de46dc8a039d8e9973f442af0b8b" upstream="master"/>
-  <project groups="pdk" name="platform/external/libutf" path="external/libutf" revision="298ebabc533a318150dc6ec67a08c7dfeb197f60" upstream="master"/>
-  <project groups="pdk" name="platform/external/libvpx" path="external/libvpx" revision="02392be07c27e38ecfbd605a06c49d3af22e5c2c" upstream="master"/>
-  <project groups="pdk" name="platform/external/libvterm" path="external/libvterm" revision="2caab416f758b648c4034e9f22cb7b76c37203f0" upstream="master"/>
-  <project groups="pdk" name="platform/external/libxaac" path="external/libxaac" revision="b0e1293b6e1c27ce7bd3a760c087f718e02cf98b" upstream="master"/>
-  <project groups="pdk" name="platform/external/libxkbcommon" path="external/libxkbcommon" revision="c9ff5223a9240b75a909c7074c95721c6bf14ed5" upstream="master"/>
-  <project groups="pdk,libxml2" name="platform/external/libxml2" path="external/libxml2" revision="72ac6cf5b8ed69b2c05dcf5ba970b3fcdd4c1c4a" upstream="master"/>
-  <project groups="pdk,libyuv" name="platform/external/libyuv" path="external/libyuv" revision="ac0a9a68b20d28ef924452f30e4946d0107a8f06" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/linux-kselftest" path="external/linux-kselftest" revision="1fd93df10a94c15b6458f53f883e2575a53a37ca" upstream="master"/>
-  <project groups="pdk" name="platform/external/llvm" path="external/llvm" revision="428628891fde8aef207fb9302ca8917ff19dd025" upstream="master"/>
-  <project groups="pdk" name="platform/external/lmfit" path="external/lmfit" revision="3d36ea54c2216475d5e21da31ee0db4af24ebed1" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/ltp" path="external/ltp" revision="25651f12f6dc050aed39b14cf489e88dbbef0f2d" upstream="master"/>
-  <project groups="pdk" name="platform/external/lua" path="external/lua" revision="6aa88f805f86b8029f4f4b1a54d0c83a83795c4d" upstream="master"/>
-  <project groups="pdk" name="platform/external/lz4" path="external/lz4" revision="4a2a1bbe1b0f7a75aa7b5decbb84bd7fd7463c98" upstream="master"/>
-  <project groups="pdk" name="platform/external/lzma" path="external/lzma" revision="cb0b0185115eae47250b491cff5f8ad0dad75606" upstream="master"/>
-  <project groups="pdk" name="platform/external/markdown" path="external/markdown" revision="41a03193095447f4ff110690171574ed8b721292" upstream="master"/>
-  <project groups="pdk" name="platform/external/mdnsresponder" path="external/mdnsresponder" revision="b35ac896c39db3c4bc9cf674900ac895d6d8651a" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/external/mesa3d" path="external/mesa3d" revision="fdd134abe2183347383ab5257abcf3524010eb4c" upstream="master"/>
-  <project groups="pdk" name="platform/external/mime-support" path="external/mime-support" revision="96e928539738b6fac3c23912e5af58d9a30f3cc8" upstream="master"/>
-  <project groups="pdk" name="platform/external/minigbm" path="external/minigbm" revision="30f6c76384e15bd944ed331bdf9461717c576b09" upstream="master"/>
-  <project groups="pdk" name="platform/external/minijail" path="external/minijail" revision="b1b2eba6e7a8878d221a7d216b44132c88b95701" upstream="master"/>
-  <project groups="pdk" name="platform/external/mksh" path="external/mksh" revision="596fee7ca538540d29ffbf5335651c63125e2ea0" upstream="master"/>
-  <project groups="pdk" name="platform/external/mockftpserver" path="external/mockftpserver" revision="1f487440520b7264f9134079441bce0adcf05af0" upstream="master"/>
-  <project groups="pdk" name="platform/external/mockito" path="external/mockito" revision="2ac163eef3e0000a5c9990e3d2d64a0a9e30c113" upstream="master"/>
-  <project groups="pdk" name="platform/external/mockwebserver" path="external/mockwebserver" revision="deaedfdb8ca26ec22231727e076ae2cf4e4e944a" upstream="master"/>
-  <project groups="pdk" name="platform/external/modp_b64" path="external/modp_b64" revision="0666054d606adcd397fa15730bad4908b1731e19" upstream="master"/>
-  <project groups="pdk" name="platform/external/mp4parser" path="external/mp4parser" revision="91052b1c78aaf57b0db28a0b1e4f7b91e5d8fda6" upstream="master"/>
-  <project groups="pdk" name="platform/external/mtpd" path="external/mtpd" revision="d7faaf63dc60e7f26d5fe6f56393ed8c0c9ad846" upstream="master"/>
-  <project groups="pdk" name="platform/external/nanohttpd" path="external/nanohttpd" revision="9e6fdd3de9cf7ebc3a16c614147a28e63e62485e" upstream="master"/>
-  <project groups="pdk" name="platform/external/nanopb-c" path="external/nanopb-c" revision="07c127e075f66a33ffc6dedfa490a2fd1b9d693c" upstream="master"/>
-  <project groups="pdk" name="platform/external/naver-fonts" path="external/naver-fonts" revision="37ba854a88b1721057585111c7a1d7e5fd02b556" upstream="master"/>
-  <project groups="pdk" name="platform/external/neon_2_sse" path="external/neon_2_sse" revision="7dff91633c4faf01e78427a0d1626853d96289ab" upstream="master"/>
-  <project groups="pdk" name="platform/external/neven" path="external/neven" revision="07b172807c1a4607997d1f72c62bbe9caa025aa2" upstream="master"/>
-  <project groups="pdk" name="platform/external/newfs_msdos" path="external/newfs_msdos" revision="6cbd5a634d77914c907cdc00b5bb9fdb1fbc438d" upstream="master"/>
-  <project groups="pdk" name="platform/external/nfacct" path="external/nfacct" revision="da41b2d4c2089f96a7fcb81a8b686046e635da7d" upstream="master"/>
-  <project groups="pdk" name="platform/external/nist-pkits" path="external/nist-pkits" revision="c6abef8efa5b933087f53a4f349c56c869d126b4" upstream="master"/>
-  <project groups="pdk" name="platform/external/nist-sip" path="external/nist-sip" revision="d0a7687d3a0fff06ea6c1fe7d11cbff9864beb99" upstream="master"/>
-  <project groups="pixel" name="platform/external/nos/host/generic" path="external/nos/host/generic" revision="c66ba0a8ac17527aa01c758ca2bcd62e9395f3b8" upstream="master"/>
-  <project groups="pdk" name="platform/external/noto-fonts" path="external/noto-fonts" revision="69f101ab75d58384119f105fdbc9c57c12860532" upstream="master"/>
-  <project groups="pdk" name="platform/external/oauth" path="external/oauth" revision="2f79a0fdace446afd17a6b539b391be92214fd47" upstream="master"/>
-  <project groups="pdk" name="platform/external/objenesis" path="external/objenesis" revision="60a5a5f706502d79f832198df9466af33777d4e5" upstream="master"/>
-  <project groups="pdk" name="platform/external/oj-libjdwp" path="external/oj-libjdwp" revision="8ba580cf7482ecd22a0d80b7d1d7ac9140f8b5dd" upstream="master"/>
-  <project groups="pdk" name="platform/external/okhttp" path="external/okhttp" revision="518242f5e64a1974076ae4f7d54262eb874498dc" upstream="master"/>
-  <project groups="pdk" name="platform/external/one-true-awk" path="external/one-true-awk" revision="2b2ca9f3fb281122e14253c2d58b88e3e3ee3335" upstream="master"/>
-  <project groups="pdk,tradefed" name="platform/external/opencensus-java" path="external/opencensus-java" revision="610a17c2139830070c0dc56540d35aeb64222ec7" upstream="master"/>
-  <project groups="pdk" name="platform/external/oss-fuzz" path="external/oss-fuzz" revision="223784e722e518dde126fd325afd60fdcf209343" upstream="master"/>
-  <project groups="pdk" name="platform/external/owasp/sanitizer" path="external/owasp/sanitizer" revision="062866cd9bb19a038a7365a7bf7f4cdee2e3f441" upstream="master"/>
-  <project groups="pdk" name="platform/external/parameter-framework" path="external/parameter-framework" revision="712f1b36862c16b767ebf5fe35ebeef683b32b1e" upstream="master"/>
-  <project groups="pdk" name="platform/external/pcre" path="external/pcre" revision="986dc24ace8aea66189a95510813747155fa3800" upstream="master"/>
-  <project groups="pdk" name="platform/external/pdfium" path="external/pdfium" revision="e17209343c448a816dc59579ed416a95136352b0" upstream="master"/>
-  <project groups="pdk" name="platform/external/perfetto" path="external/perfetto" revision="41bac066c90239348a34b8ebf2e40729e2c4c0f4" upstream="master"/>
-  <project groups="pdk" name="platform/external/piex" path="external/piex" revision="4ef665fbfefde0dfaa764cad81d7170ff5667bcd" upstream="master"/>
-  <project groups="pdk" name="platform/external/ply" path="external/ply" revision="2354a645554e4f1161c5019439311029bfb4f1eb" upstream="master"/>
-  <project groups="pdk" name="platform/external/ppp" path="external/ppp" revision="f39a656871ed774e290150e3d007d418858bdb27" upstream="master"/>
-  <project groups="pdk" name="platform/external/proguard" path="external/proguard" revision="4049237427905fe053ec217c082ce222f9edc814" upstream="master"/>
-  <project groups="pdk" name="platform/external/protobuf" path="external/protobuf" revision="e6ebc68a04883e79701373894a8eceb142b9c258" upstream="master"/>
-  <project groups="pdk" name="platform/external/protobuf-javalite" path="external/protobuf-javalite" revision="8f2ef780c041a8feed10b426eb954c2ff35c119e" upstream="master"/>
-  <project groups="pdk" name="platform/external/puffin" path="external/puffin" revision="4effb50064a04a3b2394d8132f0544cf851107a4" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/Pillow" path="external/python/Pillow" revision="90ec1d6e7ee5c236f62e0a374a7065657ed3c15c" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/apitools" path="external/python/apitools" revision="bdeff76114e0a969d9922da09e8c3b317f1bcda1" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/appdirs" path="external/python/appdirs" revision="f26193e797c3f8f98aaa7e4afd555d2140b3fcb8" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/asn1crypto" path="external/python/asn1crypto" revision="4918382e86a0e67e560b39d57a5fd4b7274c01d5" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/atomicwrites" path="external/python/atomicwrites" revision="be4fa9eb05f3e640647e30454b6f1c2625c34811" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/attrs" path="external/python/attrs" revision="9c3e89fa82d47246ab9b257d202726da133de5b2" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/cachetools" path="external/python/cachetools" revision="0377d4b9d25a15e2cc4284730a551a42b7a10d22" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/cffi" path="external/python/cffi" revision="dae345f4957b8f626cac08a31d119daac0293c8a" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/cpython2" path="external/python/cpython2" revision="96459324c3f633af4b35c29a16ac25aeb7894a7d" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/cpython3" path="external/python/cpython3" revision="ff869db7bed86eef6252c8e663af05edcf57ea5b" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/cryptography" path="external/python/cryptography" revision="0a934061cfaa974ed32e33a5821923267b7c338a" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/dateutil" path="external/python/dateutil" revision="ba5d32995c192b4b9c80e11147dc98eb770c33b6" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/dill" path="external/python/dill" revision="1de25625afbfa39196b4873a3aa45f09a076a97a" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/enum" path="external/python/enum" revision="9e4d9c3502331544e9d02205ab3b8df3e19f1c71" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/enum34" path="external/python/enum34" revision="334b9905b2c05d90be4f1364cf45317f9c680870" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/funcsigs" path="external/python/funcsigs" revision="5ccd26feec15afbbb2aa45963a0941ab22535ce6" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/future" path="external/python/future" revision="b785374c2b816d432e9936782e2b214b192c73fe" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/futures" path="external/python/futures" revision="89a8fe6ab75db54c27ab073acda54b57b3a1187b" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/gapic-google-cloud-pubsub-v1" path="external/python/gapic-google-cloud-pubsub-v1" revision="de91f91b3e0e8cd36ade69e16b831712e8181b5e" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/google-api-python-client" path="external/python/google-api-python-client" revision="766c2204b06d53441bdbc347b104390358f375f1" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/google-auth" path="external/python/google-auth" revision="d812ee31b10e88762eac9aeded408702e69280df" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/google-auth-httplib2" path="external/python/google-auth-httplib2" revision="f83658f8b9f7efd85af695bfdac0f00eeacfc5ed" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/google-cloud-core" path="external/python/google-cloud-core" revision="fb31d0b0d90ce27047c575c7cf7bd187d9df36e4" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/google-cloud-pubsub" path="external/python/google-cloud-pubsub" revision="0d91fcf1c53d49055575bfde7c6eb24f345c307b" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/google-gax" path="external/python/google-gax" revision="6654a7907460eeed423c35577b1ebdce0b94991e" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/googleapis" path="external/python/googleapis" revision="48ac1fcf49fb23895e9eaa1514e3799a4e3cc6a9" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/grpc-google-iam-v1" path="external/python/grpc-google-iam-v1" revision="9bd66e8ca00804a0432ffeddc50d8a552daae05e" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/grpcio" path="external/python/grpcio" revision="cac720b2a4a33f52bafbe652639ae1d368be74a2" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/httplib2" path="external/python/httplib2" revision="cd49a07c9cd64170e3758a3240902c5bb5bfac5e" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/ipaddress" path="external/python/ipaddress" revision="917fd112a2b615e7ca9fce3f100b3e2ea929494d" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/matplotlib" path="external/python/matplotlib" revision="19ad7ac700c9cf081418aa10ea5fa9c66a6b6973" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/mock" path="external/python/mock" revision="335a5621295c6878f3ac1827f55b9de7298ec598" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/more-itertools" path="external/python/more-itertools" revision="f408bc183266f6b74c973549c9d0155d44ffda36" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/numpy" path="external/python/numpy" revision="111b7e10af77635c85bbbea1d0d35a649dc45ae1" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/oauth2client" path="external/python/oauth2client" revision="d54ca598262122360935f487dbfe54c30fe8c8b7" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/olefile" path="external/python/olefile" revision="4b57860bf2c6d6eeb560d84adb20a09e3119d4d5" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/packaging" path="external/python/packaging" revision="b16fb277554ec5eb8e2fb2f9e7fedf95c60355de" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/parse" path="external/python/parse" revision="3e6bd0ef0c68250e04efab06e3d8bac9a723a79a" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/pluggy" path="external/python/pluggy" revision="476c801f6efdea24faab8e234c8802ae3f6cb1dc" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/ply" path="external/python/ply" revision="a06f18c56dfe3148c43ec4ed712bba663923516d" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/proto-google-cloud-pubsub-v1" path="external/python/proto-google-cloud-pubsub-v1" revision="61035093eedea6edd613d98cfc64de2edcc42824" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/protobuf" path="external/python/protobuf" revision="16d0b123e41dc05cb82bd5d7e7194e37ecca5684" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/py" path="external/python/py" revision="bdf459ce1c2c467574869af67ad3c245fea6c031" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/pyasn1" path="external/python/pyasn1" revision="1017340302b90abbf6f6d4f6363b69b0439b8af7" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/pyasn1-modules" path="external/python/pyasn1-modules" revision="f7e72735b6077918e283b9f36e3a033a9a9ca498" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/pybind11" path="external/python/pybind11" revision="3439ae790a4c4a64183b37b9936d06eaf838530e" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/pycparser" path="external/python/pycparser" revision="6bf3c94558f1bb33fc0c8c24d12d9179633d9f88" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/pyopenssl" path="external/python/pyopenssl" revision="50ab7f8d5b6627f2bb3ebb099ffe516f16ebed52" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/pyparsing" path="external/python/pyparsing" revision="bf90b1fc3425729cb5768af5182a83edfeb7ba2b" upstream="master"/>
-  <project groups="pdk" name="platform/external/python/pytest" path="external/python/pytest" revision="b3cd64044963b2b0eabaf60b7bd01a47e8395d29" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/requests" path="external/python/requests" revision="11d7236da2593f0908774fd027b175f4ff3e19fa" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/rsa" path="external/python/rsa" revision="7ed71f197cf1bf81e071575edd6f8862d4fb58ff" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/scipy" path="external/python/scipy" revision="921f53db519df603fe9ff681a49dd18be838febf" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/setuptools" path="external/python/setuptools" revision="513ec3d6bb6f7786d02caf51720497a118b8f4be" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/six" path="external/python/six" revision="97451854af03f086716f5fbac3c66ad22cdf47f4" upstream="master"/>
-  <project groups="vts,pdk" name="platform/external/python/uritemplates" path="external/python/uritemplates" revision="eab8cbc70cc7907afb0105d11ebf812aa99c11d0" upstream="master"/>
-  <project groups="pdk" name="platform/external/rappor" path="external/rappor" revision="24abc025df68928ce97749b18521c4dbfa3faaf7" upstream="master"/>
-  <project groups="pdk" name="platform/external/replicaisland" path="external/replicaisland" revision="9d7ae289b1769756044a0060f06b5264f992f4e6" upstream="master"/>
-  <project groups="pdk" name="platform/external/rmi4utils" path="external/rmi4utils" revision="eab13882ca581b5ef579eeeca311957f5fa2eada" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/external/robolectric-shadows" path="external/robolectric-shadows" revision="99f97b4756523aaa9c4b6d4589d1aae71439d8e7" upstream="master"/>
-  <project groups="pdk" name="platform/external/roboto-fonts" path="external/roboto-fonts" revision="c83d9308a20aac7f872710c12a56d2a20cc9ddc7" upstream="master"/>
-  <project groups="pdk" name="platform/external/rootdev" path="external/rootdev" revision="2b38487945c95283b77047a5470aa750af02f847" upstream="master"/>
-  <project groups="pdk" name="platform/external/rust/crates/byteorder" path="external/rust/crates/byteorder" revision="7a6bcadee4647cba947cfeebe6bf5459d6192998" upstream="master"/>
-  <project groups="pdk" name="platform/external/rust/crates/libc" path="external/rust/crates/libc" revision="e9a2a71408a807e48a89f1265333b7a954f49c8b" upstream="master"/>
-  <project groups="pdk" name="platform/external/rust/crates/proc-macro2" path="external/rust/crates/proc-macro2" revision="b69cdae19ad1307dcc2fcb223d7b67cf5bc20870" upstream="master"/>
-  <project groups="pdk" name="platform/external/rust/crates/quote" path="external/rust/crates/quote" revision="bc76ba87ac2d9c3038ee55e5fcf71b3e31d0f66e" upstream="master"/>
-  <project groups="pdk" name="platform/external/rust/crates/remain" path="external/rust/crates/remain" revision="d921a46f26454b774ce9343a78d4c4e9022f509d" upstream="master"/>
-  <project groups="pdk" name="platform/external/rust/crates/syn" path="external/rust/crates/syn" revision="23bc9a1ec2d5a7ffcd44b345a5cf742849d05e7d" upstream="master"/>
-  <project groups="pdk" name="platform/external/rust/crates/unicode-xid" path="external/rust/crates/unicode-xid" revision="9d7cf926efeecd1ab96863471428d0373133bf49" upstream="master"/>
-  <project groups="pdk-fs" name="platform/external/scapy" path="external/scapy" revision="2c6d26c6fc374a6b26b012ff4523a24e903d8329" upstream="master"/>
-  <project groups="pdk" name="platform/external/scrypt" path="external/scrypt" revision="d6114db148b1ededd120de0cf2d1fc73ba1611ac" upstream="master"/>
-  <project groups="pdk" name="platform/external/scudo" path="external/scudo" revision="df4af6db94da71390668bc87384a08860824ed03" upstream="master"/>
-  <project groups="pdk" name="platform/external/seccomp-tests" path="external/seccomp-tests" revision="2795191f28591534096193bf5a92124367786b88" upstream="master"/>
-  <project groups="pdk" name="platform/external/selinux" path="external/selinux" revision="a8173ef21e91b6db955e631138262cd6788d6b8d" upstream="master"/>
-  <project groups="pdk" name="platform/external/setupcompat" path="external/setupcompat" revision="b0d0585095c80713e195085dd88bf529b2ba48f7" upstream="master"/>
-  <project groups="pdk" name="platform/external/setupdesign" path="external/setupdesign" revision="22bf3d9646db9c30c58865ab0e405ae954618e3e" upstream="master"/>
-  <project groups="pdk,qcom_msm8x26" name="platform/external/sfntly" path="external/sfntly" revision="2d2c9d6d382132446e5789e3c3ddb729eea5a833" upstream="master"/>
-  <project groups="pdk" name="platform/external/shaderc/spirv-headers" path="external/shaderc/spirv-headers" revision="c88e6a2a23e8bbacd011d4b4f0038e84225e52fc" upstream="master"/>
-  <project groups="pdk" name="platform/external/shflags" path="external/shflags" revision="6d6812d19da2747fdbee25421af1bd3583d75bf0" upstream="master"/>
-  <project groups="pdk,qcom_msm8x26" name="platform/external/skia" path="external/skia" revision="74bbe01575cea3494df5a07b4b5607ad0402e8c1" upstream="master"/>
-  <project clone-depth="1" groups="cts" name="platform/external/skqp" path="external/skqp" revision="1308793d7c0366b327377ec98a0b47dc38866c27" upstream="master"/>
-  <project groups="pdk" name="platform/external/sl4a" path="external/sl4a" revision="304c22adb7c0c35054bf713cb549b841e1f08f71" upstream="master"/>
-  <project groups="pdk" name="platform/external/slf4j" path="external/slf4j" revision="4cd3f35de15e9270f3d5822c3f04a7c2b02189ea" upstream="master"/>
-  <project groups="pdk" name="platform/external/smali" path="external/smali" revision="b45eb8f09a2f77cb8a522b04b481d69304c55117" upstream="master"/>
-  <project groups="pdk" name="platform/external/snakeyaml" path="external/snakeyaml" revision="5df2ff5ed7c5eebfaff21a8299019e21f648b0f6" upstream="master"/>
-  <project groups="pdk" name="platform/external/sonic" path="external/sonic" revision="043398f5c456fc78cd8f5f2057e3a2e767eebfca" upstream="master"/>
-  <project groups="pdk" name="platform/external/sonivox" path="external/sonivox" revision="fac6001a845c1879d9d646659b5f5e07c934da44" upstream="master"/>
-  <project groups="pdk" name="platform/external/speex" path="external/speex" revision="8816ee364c759758cb10571f831fd2da5cc12fba" upstream="master"/>
-  <project groups="pdk" name="platform/external/sqlite" path="external/sqlite" revision="7b99e6b1484c73dc520874552e698add4dc96038" upstream="master"/>
-  <project groups="pdk" name="platform/external/squashfs-tools" path="external/squashfs-tools" revision="26929f59a759b06cb01c539ba45630958a8e3a76" upstream="master"/>
-  <project groups="pdk" name="platform/external/strace" path="external/strace" revision="f1cb53780e02e7a9112b4aa53a132cae53a1fa15" upstream="master"/>
-  <project groups="pdk" name="platform/external/stressapptest" path="external/stressapptest" revision="4d151d9e70555f617bd5c8859d9b3857be31fde3" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/external/subsampling-scale-image-view" path="external/subsampling-scale-image-view" revision="5fb46aa47bd8d0ca763b7f17033a6f842e57d4f9" upstream="master"/>
-  <project groups="pdk" name="platform/external/swiftshader" path="external/swiftshader" revision="d3adebce65f37bf08915dacbe1cec03e82481319" upstream="master"/>
-  <project groups="pdk" name="platform/external/tagsoup" path="external/tagsoup" revision="80c9aa0ff8916d26f163e7bad20b42616e42ffb4" upstream="master"/>
-  <project groups="pdk" name="platform/external/tcpdump" path="external/tcpdump" revision="f50b8b00f4d40eaaeb7e0e3a398d441d27e63d54" upstream="master"/>
-  <project groups="pdk" name="platform/external/tensorflow" path="external/tensorflow" revision="6341b8975b7660244e1ca3003bfce5371f1fd167" upstream="master"/>
-  <project groups="pdk" name="platform/external/testng" path="external/testng" revision="74aac3e648e789b5f462bd42debc34a16507dbad" upstream="master"/>
-  <project groups="pdk" name="platform/external/tinyalsa" path="external/tinyalsa" revision="d968f23fb2add5450ef773317bc0467fbd267f43" upstream="master"/>
-  <project groups="pdk" name="platform/external/tinycompress" path="external/tinycompress" revision="65450e5be45f28f93f7bc40f6245259c805a0958" upstream="master"/>
-  <project groups="pdk" name="platform/external/tinyxml" path="external/tinyxml" revision="3eb636e00be67fa8d5d837d613db63c215dc60b0" upstream="master"/>
-  <project groups="pdk" name="platform/external/tinyxml2" path="external/tinyxml2" revision="ea167020144c9c8b15979090af636b5812edae96" upstream="master"/>
-  <project name="platform/external/toolchain-utils" path="external/toolchain-utils" revision="b506c21cfb0267cef08643eb79ba0e3295832415" upstream="master"/>
-  <project groups="pdk" name="platform/external/toybox" path="external/toybox" revision="f3f88ad0dcdf9ff633a7d46f18d345b0753509a0" upstream="master"/>
-  <project groups="pdk" name="platform/external/tremolo" path="external/tremolo" revision="eddb87383c57d0fa12596566e54069df88edeb4a" upstream="master"/>
-  <project groups="pdk" name="platform/external/turbine" path="external/turbine" revision="dca05ffd5d3ebff0affeb939cdf6c01eef10deb2" upstream="master"/>
-  <project groups="pdk" name="platform/external/u-boot" path="external/u-boot" revision="8511c75bb4fe3ec225dad073208d17aa71330e8e" upstream="master"/>
-  <project groups="pdk" name="platform/external/ukey2" path="external/ukey2" revision="cd9c844bd676ff9ff69a74bc49e157149a7f0918" upstream="master"/>
-  <project groups="pdk" name="platform/external/unicode" path="external/unicode" revision="02fb19b968e803c4004265bece58eb173a4091cb" upstream="master"/>
-  <project name="platform/external/universal-tween-engine" path="external/universal-tween-engine" revision="507b8885296104d7efe1bc16efbc07e2d22ef66d" upstream="master"/>
-  <project groups="pdk" name="platform/external/v4l2_codec2" path="external/v4l2_codec2" revision="b214db3d5c4d5651923d80fb094313c902735e05" upstream="master"/>
-  <project groups="pdk" name="platform/external/v8" path="external/v8" revision="77008027c3252aa4e9d5f03f66c42e435bd69aee" upstream="master"/>
-  <project groups="vboot,pdk-fs" name="platform/external/vboot_reference" path="external/vboot_reference" revision="df6d6b6e5280520b096fb1f565b758948bc872ee" upstream="master"/>
-  <project groups="pdk" name="platform/external/virglrenderer" path="external/virglrenderer" revision="808f7d45c820d38a423ae95d6be378790d775c43" upstream="master"/>
-  <project groups="pdk" name="platform/external/vixl" path="external/vixl" revision="4ffae8eec534828d6dca56d9c8fba259298613d0" upstream="master"/>
-  <project groups="pdk" name="platform/external/vogar" path="external/vogar" revision="75a4cda65c621079e1e210168c01027ae32b5b36" upstream="master"/>
-  <project groups="pdk" name="platform/external/volley" path="external/volley" revision="ab93ab6a714a5529afe10502f8065a0eb7fa3f87" upstream="master"/>
-  <project groups="pdk" name="platform/external/vulkan-headers" path="external/vulkan-headers" revision="7cb58527146fe5dc417db0d6428854cbf961fbd0" upstream="master"/>
-  <project groups="pdk" name="platform/external/vulkan-validation-layers" path="external/vulkan-validation-layers" revision="6a90c9e616e3fca5433b668f37cd4a3f03877b1e" upstream="master"/>
-  <project groups="pdk" name="platform/external/walt" path="external/walt" revision="53c47a96bc0d6129d3dad8219a9a1a793c3da963" upstream="master"/>
-  <project groups="pdk" name="platform/external/wayland" path="external/wayland" revision="e5b8a15d85c1d3fe1d5bb7392863dd2eb913dff2" upstream="master"/>
-  <project groups="pdk" name="platform/external/wayland-protocols" path="external/wayland-protocols" revision="8b68a950aae5a84e929cc331e94e09851e440f94" upstream="master"/>
-  <project groups="pdk,qcom_msm8x26" name="platform/external/webp" path="external/webp" revision="f6623f00a5dae9ec51cccb19570c43e742de7647" upstream="master"/>
-  <project groups="pdk" name="platform/external/webrtc" path="external/webrtc" revision="cf0ffc92d1efdaaacf7e2c8045af754463e34813" upstream="master"/>
-  <project groups="pdk" name="platform/external/wpa_supplicant_8" path="external/wpa_supplicant_8" revision="a515753b18f9b054b54588acab651f5dd6c6c9e2" upstream="master"/>
-  <project groups="pdk" name="platform/external/wycheproof" path="external/wycheproof" revision="d9fb540d132da6130b83fdb15691e4e5a2d75048" upstream="master"/>
-  <project groups="pdk" name="platform/external/xmp_toolkit" path="external/xmp_toolkit" revision="44d7e4d00ef6da63a75bf3a4f9296872cc4d2ac1" upstream="master"/>
-  <project groups="pdk" name="platform/external/xz-embedded" path="external/xz-embedded" revision="51923a98b0af813e3db6a027d64471ee8710a4f2" upstream="master"/>
-  <project groups="pdk" name="platform/external/xz-java" path="external/xz-java" revision="bd7892bb8927360cd34805bc332039154a2110e0" upstream="master"/>
-  <project groups="vts,projectarch,pdk" name="platform/external/yapf" path="external/yapf" revision="45d923c40605a71867d174abcd04a1db76945651" upstream="master"/>
-  <project groups="pdk" name="platform/external/zlib" path="external/zlib" revision="8dda2712464d8bc3a8da36accca0726ed495e079" upstream="master"/>
-  <project groups="pdk" name="platform/external/zopfli" path="external/zopfli" revision="9bdeb8615dc9a4eda08f72c1f81479075a4cb425" upstream="master"/>
-  <project groups="pdk" name="platform/external/zxing" path="external/zxing" revision="65193280855e46d11bf5b44f1a7e49ec0c7bd57e" upstream="master"/>
-  <project groups="pdk" name="platform/frameworks/av" path="frameworks/av" revision="c226ea4b0660b7e4bcfdd71e8a8950c7bd351556" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/base" path="frameworks/base" revision="00d0c52470a78cb87a9297b8c96541feddd170ec" upstream="master"/>
-  <project groups="pdk" name="platform/frameworks/compile/libbcc" path="frameworks/compile/libbcc" revision="499e5d5476a3f9bde71cc7d7e2bf34dc2efe3622" upstream="master"/>
-  <project groups="pdk" name="platform/frameworks/compile/mclinker" path="frameworks/compile/mclinker" revision="e262086a37bb2a9c8fbd99804077fa915a0a1920" upstream="master"/>
-  <project groups="pdk" name="platform/frameworks/compile/slang" path="frameworks/compile/slang" revision="1f6e3fb0448c1b6f2e3230e5133fb8369f4c1e93" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/ex" path="frameworks/ex" revision="883e1d0668f26f8b8b16b4ebe24c36701ae763e0" upstream="master"/>
-  <project groups="pdk" name="platform/frameworks/hardware/interfaces" path="frameworks/hardware/interfaces" revision="4ef8ef31f5064197ce974060a088f74541189b01" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/layoutlib" path="frameworks/layoutlib" revision="08870696a53cc26598ca5a08321e34f26c9f966a" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/libs/net" path="frameworks/libs/net" revision="583e599481dff20cafe530be70cb546de47d50f6" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/minikin" path="frameworks/minikin" revision="e1e26b6c6ebf4da2a604fedb7385a0a2f8658d2a" upstream="master"/>
-  <project groups="pdk" name="platform/frameworks/ml" path="frameworks/ml" revision="23a9d82468e8345c567256fe329cc4c8b83cba66" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/multidex" path="frameworks/multidex" revision="fa83e46b7608229c746384c377655929464c56e0" upstream="master"/>
-  <project groups="pdk" name="platform/frameworks/native" path="frameworks/native" revision="cfeafaa02cc22bff97f2b910b79688de07811c6b" upstream="master"/>
-  <project groups="pdk-fs" name="platform/frameworks/opt/bitmap" path="frameworks/opt/bitmap" revision="e9850af1278e499e427d08dbf40244f3622bd6db" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/calendar" path="frameworks/opt/calendar" revision="1aea8315ebe9cca6e9462ab02e9f4caf20c8cd58" upstream="master"/>
-  <project groups="pdk-fs" name="platform/frameworks/opt/car/services" path="frameworks/opt/car/services" revision="5e43c79faa8422cd5a8eb4992160468b371573bb" upstream="master"/>
-  <project groups="pdk" name="platform/frameworks/opt/car/setupwizard" path="frameworks/opt/car/setupwizard" revision="4b6dc1b8fe513f3e737c98880067cd772167729b" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/chips" path="frameworks/opt/chips" revision="2b760228b90619c4923086c3f4a27f58c3ede8c6" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/colorpicker" path="frameworks/opt/colorpicker" revision="0632881b390d30b8dda5fdbaf0e6dce0d0b74917" upstream="master"/>
-  <project groups="pdk-fs" name="platform/frameworks/opt/net/ethernet" path="frameworks/opt/net/ethernet" revision="e7fc84790a85292826e3a3870e8a5f3f1bbc0c90" upstream="master"/>
-  <project groups="pdk" name="platform/frameworks/opt/net/ike" path="frameworks/opt/net/ike" revision="b9737f3d87d8065991d0f8638fa1a870dec90113" upstream="master"/>
-  <project groups="frameworks_ims,pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/net/ims" path="frameworks/opt/net/ims" revision="e4b4098e894437b6cf5603436500c66a27aa4ee5" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/net/voip" path="frameworks/opt/net/voip" revision="1f7f1a6160b0c5153d412a1517c3b9c55b22dab5" upstream="master"/>
-  <project groups="pdk" name="platform/frameworks/opt/net/wifi" path="frameworks/opt/net/wifi" revision="135b82217ac27b76dd88c098b39ce151903003c9" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/photoviewer" path="frameworks/opt/photoviewer" revision="57d829336ddca7b757c85a295b69680be598a0ca" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/setupwizard" path="frameworks/opt/setupwizard" revision="82f1008f9448ddc12ccd13db876050c139d4622a" upstream="master"/>
-  <project groups="pdk" name="platform/frameworks/opt/telephony" path="frameworks/opt/telephony" revision="88cbeedeae746dc907d2d4d18b5d61ab5f49aaa5" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/timezonepicker" path="frameworks/opt/timezonepicker" revision="740cf885774faa3bbd56fee2740537dabb1e4cf2" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/vcard" path="frameworks/opt/vcard" revision="d14c442443cbb4ba7947fc6ffa5cfcc198216fa1" upstream="master"/>
-  <project groups="pdk" name="platform/frameworks/rs" path="frameworks/rs" revision="575d2c05f55e00ed7d30b42b19451e87a7015693" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/wilhelm" path="frameworks/wilhelm" revision="5507cd8911b7b66cc05d7abd0b319c782097f7c7" upstream="master"/>
-  <project groups="pdk" name="platform/hardware/broadcom/libbt" path="hardware/broadcom/libbt" revision="dbe4e030154bb35b69eea4edde7fe9f225e89163" upstream="master"/>
-  <project groups="pdk,broadcom_wlan" name="platform/hardware/broadcom/wlan" path="hardware/broadcom/wlan" revision="be811e0b2d9751260c228b44da38da8a040e7536" upstream="master"/>
-  <project groups="pdk" name="platform/hardware/google/apf" path="hardware/google/apf" revision="1f847f05d801e15681242f02376992fdca4f4521" upstream="master"/>
-  <project groups="pdk" name="platform/hardware/google/av" path="hardware/google/av" revision="c533697b8df69a83aab6f5ae21c8bdf76bffe829" upstream="master"/>
-  <project groups="pdk,easel" name="platform/hardware/google/easel" path="hardware/google/easel" revision="af8a319569d4ec8ec0243a7d90ec5cab60ada7e0" upstream="master"/>
-  <project groups="pdk" name="platform/hardware/google/interfaces" path="hardware/google/interfaces" revision="ea081333724915b239bc6dc396a22ec35de0abab" upstream="master"/>
-  <project groups="generic_fs,pixel" name="platform/hardware/google/pixel" path="hardware/google/pixel" revision="4a2c84ca96fb8cde96accfb22f82d0666b6f8374" upstream="master"/>
-  <project groups="generic_fs,pixel" name="platform/hardware/google/pixel-sepolicy" path="hardware/google/pixel-sepolicy" revision="a3af99c63f21e27cba689f811c15c2b10f638fea" upstream="master"/>
-  <project groups="pdk" name="platform/hardware/interfaces" path="hardware/interfaces" revision="384eb8a2bb035a1e9bf0a56d17e51670f1b09d6d" upstream="master"/>
-  <project groups="invensense,pdk" name="platform/hardware/invensense" path="hardware/invensense" revision="a51c32c7d16d32462fcd2d3fc61474bb0ec56864" upstream="master"/>
-  <project groups="coral" name="platform/hardware/knowles/athletico/sound_trigger_hal" path="hardware/knowles/athletico/sound_trigger_hal" revision="81ebb76e64468c2cba36661ed5dd4ef74882acde" upstream="master"/>
-  <project groups="pdk" name="platform/hardware/libhardware" path="hardware/libhardware" revision="2d0682b212eb8939a9ce76e86b00b9b741893fc4" upstream="master"/>
-  <project groups="pdk" name="platform/hardware/libhardware_legacy" path="hardware/libhardware_legacy" revision="89e661c090b00a21a7748bc0ab01775b8c87618d" upstream="master"/>
-  <project groups="pdk" name="platform/hardware/nxp/nfc" path="hardware/nxp/nfc" revision="946fc3886b83d4eaff65d77d227d84b786a36acb" upstream="master"/>
-  <project groups="pdk" name="platform/hardware/nxp/secure_element" path="hardware/nxp/secure_element" revision="7a985ecc64e828520c6cc564d130b5a24ff59733" upstream="master"/>
-  <project groups="qcom,qcom_audio,pdk-qcom" name="platform/hardware/qcom/audio" path="hardware/qcom/audio" revision="79ec36fa8410d9644ae07d2ec25620edf832756f" upstream="master"/>
-  <project groups="pdk-qcom" name="platform/hardware/qcom/bootctrl" path="hardware/qcom/bootctrl" revision="4e5d4010484ae58b169f00d036efff78546a3def" upstream="master"/>
-  <project groups="qcom,pdk-qcom" name="platform/hardware/qcom/bt" path="hardware/qcom/bt" revision="78bcfe5b90bdf22ea4b6bcbe30121af123e38aa8" upstream="master"/>
-  <project groups="qcom_camera,pdk-qcom" name="platform/hardware/qcom/camera" path="hardware/qcom/camera" revision="f9bbbd1eccee123518e8a878080bf8c39b044960" upstream="master"/>
-  <project groups="qcom,pdk-qcom" name="platform/hardware/qcom/data/ipacfg-mgr" path="hardware/qcom/data/ipacfg-mgr" revision="da6adac8cfeae0562e48b263b46f1cfc604c6094" upstream="master"/>
-  <project groups="pdk-qcom,qcom,qcom_display" name="platform/hardware/qcom/display" path="hardware/qcom/display" revision="134394962fc46d68fc8f295aed23c932a59c67a4" upstream="master"/>
-  <project groups="qcom,qcom_gps,pdk-qcom" name="platform/hardware/qcom/gps" path="hardware/qcom/gps" revision="f0b810c44d21c958c729d3046179f535357e0298" upstream="master"/>
-  <project groups="qcom,qcom_keymaster,pdk-qcom" name="platform/hardware/qcom/keymaster" path="hardware/qcom/keymaster" revision="ecfe142948adf4f82083d7333b6c778f3993842b" upstream="master"/>
-  <project groups="qcom,pdk-qcom" name="platform/hardware/qcom/media" path="hardware/qcom/media" revision="dbe009e8f1554218dec34531540cc27794362f73" upstream="master"/>
-  <project groups="qcom_msm8960,pdk-qcom" name="platform/hardware/qcom/msm8960" path="hardware/qcom/msm8960" revision="c25a431842a26b5756b58a9d4a42c776e0457ba2" upstream="master"/>
-  <project groups="qcom_msm8994,pdk-qcom" name="platform/hardware/qcom/msm8994" path="hardware/qcom/msm8994" revision="8e0383f6f41a2c49461f381c8d066ea21b20c674" upstream="master"/>
-  <project groups="qcom_msm8996,pdk-qcom" name="platform/hardware/qcom/msm8996" path="hardware/qcom/msm8996" revision="f0e7ce67121940312eaffeda9c4add56d63bf4e1" upstream="master"/>
-  <project groups="qcom_msm8998,pdk-qcom" name="platform/hardware/qcom/msm8998" path="hardware/qcom/msm8998" revision="e504d3feeb25220780c1674dc870a1a45e0cf55b" upstream="master"/>
-  <project groups="qcom_msm8x09" name="platform/hardware/qcom/msm8x09" path="hardware/qcom/msm8x09" revision="c88c67109844def18fef4941e39bebb8f8981e39" upstream="master"/>
-  <project groups="qcom_msm8x26,pdk-qcom" name="platform/hardware/qcom/msm8x26" path="hardware/qcom/msm8x26" revision="85c1a5282ae28663335e55ce96a4c0487de6c578" upstream="master"/>
-  <project groups="qcom_msm8x27,pdk-qcom" name="platform/hardware/qcom/msm8x27" path="hardware/qcom/msm8x27" revision="8ff5c0057cbdecfa09410c1710ba043e191a2862" upstream="master"/>
-  <project groups="qcom_msm8x84,pdk-qcom" name="platform/hardware/qcom/msm8x84" path="hardware/qcom/msm8x84" revision="582b414269d8472d17eef65d8a8965aa8105042f" upstream="master"/>
-  <project groups="wahoo" name="platform/hardware/qcom/neuralnetworks/hvxservice" path="hardware/qcom/neuralnetworks/hvxservice" revision="2d513ce6b49fbc0577ab8ccff07ef5ac8df99a71" upstream="master"/>
-  <project groups="qcom,pdk-qcom" name="platform/hardware/qcom/power" path="hardware/qcom/power" revision="c9165f0cb184fcaf6888b7921b55033e8b50836c" upstream="master"/>
-  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/bt" path="hardware/qcom/sdm845/bt" revision="29c8a55bb6e521089ebd80a64afc893f8822aad2" upstream="master"/>
-  <project groups="generic_fs,vendor,qcom_sdm845" name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" path="hardware/qcom/sdm845/data/ipacfg-mgr" revision="ea3b50b135544a6566c2d1e14a913d895fee448a" upstream="master">
+  <project groups="pdk" name="platform/compatibility/cdd" path="compatibility/cdd" revision="0c38e67bb06570c7b7928cc6945c6d275f22cf97" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="cts,pdk-cw-fs,pdk-fs" name="platform/cts" path="cts" revision="35cfedab5d90d19570f89bdf12b3d166b6ef0a8e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/dalvik" path="dalvik" revision="1537e27bdc17e87c45e6269546f45ed7fbb91d19" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="developers,pdk" name="platform/developers/build" path="developers/build" revision="6a8a6e64206de0aa11d0221815ac3706f97fff24" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="developers" name="platform/developers/demos" path="developers/demos" revision="03814c35b8ee0a1284c667556260124d97466b28" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="developers" name="platform/developers/samples/android" path="developers/samples/android" revision="9083bced6874c606043ebfb36bb1f71f67090ecc" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="developers,pdk-cw-fs,pdk-fs" name="platform/development" path="development" revision="6e9e6a6c28cdf313f69fa61bd69ac41545fc3017" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/FP16" path="external/FP16" revision="71f087c388c9db78fb8fa4d6602784877a886055" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/FXdiv" path="external/FXdiv" revision="5432d142d5994d3e5f39df551ee2c3e1f5dcebd5" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/ImageMagick" path="external/ImageMagick" revision="a390d3bdbe5eaee0da5e5d7ab561ae50fdcedff4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/OpenCSD" path="external/OpenCSD" revision="e7cc1c910ed38e1e533467577422c3dbd58821f2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/Reactive-Extensions/RxCpp" path="external/Reactive-Extensions/RxCpp" revision="68b9bbe7851c0d5cc02629e13bc263d2462644a0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/XNNPACK" path="external/XNNPACK" revision="5261c034e1187ca8a1c36b2dfbc8d0fbe9c13a6b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/aac" path="external/aac" revision="13d520b193266a610f5ca6b07b0c0f039ddb21b5" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/adeb" path="external/adeb" revision="f061a94fecd30f063b7e02f47044e10c0bfbb13e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/adhd" path="external/adhd" revision="2b1e50dc351087a832e21130087468c36c5798b7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/android-clat" path="external/android-clat" revision="97bd0e95d7ca1a87144868c34b80bd78c4616b74" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/androidplot" path="external/androidplot" revision="b999712946d5141812fa2456e652db6b818d439e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/angle" path="external/angle" revision="e1f3ec6f7382646e4792fdd119174a33246d7d39" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/ant-glob" path="external/ant-glob" revision="45461635647e5481fa67473795782ce232e44fe1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/antlr" path="external/antlr" revision="f207c52043d762d9cfbfd87986b5194c855a318a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/apache-commons-bcel" path="external/apache-commons-bcel" revision="50e755197cd5de9d584414616d6d48877c92c649" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/apache-commons-compress" path="external/apache-commons-compress" revision="5334065cacdd3d1af2688d4617918ec0460708e1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/apache-commons-math" path="external/apache-commons-math" revision="f30081520947ace21933c4f6ade062152c9b99f3" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/apache-harmony" path="external/apache-harmony" revision="f5fd2de0db5c586a1242123977e387884d868d7e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/apache-http" path="external/apache-http" revision="d176d36489b58e75bced0d5234e713abb8c5a847" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/apache-xml" path="external/apache-xml" revision="95e1a12154051ee0aa624e784b5d2f1f4b2bd9f1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vendor" name="platform/external/arm-neon-tests" path="external/arm-neon-tests" revision="bc9bbf361c8cabbd4ae0a215de5871fad527915e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/arm-optimized-routines" path="external/arm-optimized-routines" revision="0290fa0b3675e5ede78fc5c66c204c77c3299202" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/arm-trusted-firmware" path="external/arm-trusted-firmware" revision="780068d4eec8e880d55d58eb348bee2d71580e83" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/external/autotest" path="external/autotest" revision="a91c1eb339eeaab10ef08685ebb24e2a7d744a6d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/avb" path="external/avb" revision="7560b4fc5e786261351afd975a2b53ae258fcfe0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/bc" path="external/bc" revision="e48fc23376fe54014a4b2ee03f6cfddb11f48704" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/bcc" path="external/bcc" revision="0bdd6b3a226e5e50dd245b76a9413a6903a73073" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/blktrace" path="external/blktrace" revision="549b1dd7d9d689543ab8c86ff6adc4313f02b8b3" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/boringssl" path="external/boringssl" revision="0dcd4e8262f521f08a8302051ad6c81489f05754" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/bouncycastle" path="external/bouncycastle" revision="1854476568c6f2feb9eef50343b7e2a18e072e35" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/brotli" path="external/brotli" revision="b4fe2652341b739dfab70d093525878090531831" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/bsdiff" path="external/bsdiff" revision="6037a9bba21af40c7850d48e7788b25ebcc37308" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/bzip2" path="external/bzip2" revision="ef2142980b09fa899806433fff413c67a81b94f6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/caliper" path="external/caliper" revision="89cb92050512ed307a9896a07444e7c12cf0a3ee" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/capstone" path="external/capstone" revision="f1f1cbc054db7021d4167a96b55783e087e1b7b4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/catch2" path="external/catch2" revision="a8f1a3dea29dbd45c1b7f3422c0aa29d5f06dbda" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/cblas" path="external/cblas" revision="61ee00692011385347a5dd1ad872556899a5cf7a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/cbor-java" path="external/cbor-java" revision="432de00e4b018966cf0aff3dd204eb4a97fd0de6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/chromium-libpac" path="external/chromium-libpac" revision="ae88e3df0e2d2779c1b8c7ff9a17ef34c0bf23e6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/chromium-trace" path="external/chromium-trace" revision="26d0b602b1501917a84e34ad331e22a4a27fe2fd" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/external/chromium-webview" path="external/chromium-webview" revision="a04f8d03177d2667299915b125bdce93422c9e2b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/clang" path="external/clang" revision="f482f355345a3e42e41be48861075aeef690a78d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/cldr" path="external/cldr" revision="bbe3f1a6ffdef81c1fe1d392529abcc7cbbd94b8" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/cn-cbor" path="external/cn-cbor" revision="d581c0ae70655e4c18ff00182867c81600f408a8" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/compiler-rt" path="external/compiler-rt" revision="54b43ff2d8e92841cb46f2162f4fa1489719ff27" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/conscrypt" path="external/conscrypt" revision="c08e870957cba9cda3c6e451fbc7fa76954b12c4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/cpu_features" path="external/cpu_features" revision="813aadc6c7ece543af4b8a7207e4e4b403f2d492" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/cpuinfo" path="external/cpuinfo" revision="fbbf17e168c56a99512f9db5241b80860dfcdb2c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/crcalc" path="external/crcalc" revision="405d67056bf4a5f9e46761a3909f0cdf866f5b6b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/cros/system_api" path="external/cros/system_api" revision="2e466f96bc18eae60093d55ae8eb800d61a7ac4e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/crosvm" path="external/crosvm" revision="2508eb3397a41100a6408f2fa69258c3508ec877" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/curl" path="external/curl" revision="9126f3ec9d6c9df6e7a64a72956b1603a0738a47" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/dagger2" path="external/dagger2" revision="3809f3dd127716a59f14536b19fe5cab0e0a445e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/external/deqp" path="external/deqp" revision="393a348317e8e94e06a4f17ed130d6c2d30839b3" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/external/deqp-deps/SPIRV-Headers" path="external/deqp-deps/SPIRV-Headers" revision="33de1aef825029c0cf7927a72df63ebe79745c6f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/external/deqp-deps/SPIRV-Tools" path="external/deqp-deps/SPIRV-Tools" revision="2e6244127648ea760172bf07ecf687a59ee7bd17" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/external/deqp-deps/glslang" path="external/deqp-deps/glslang" revision="91b452070b219d80a82d98deb46c1514dc67f4b8" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/desugar" path="external/desugar" revision="3041d69a3395243035260e72e56b43835c70a6cd" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/dexmaker" path="external/dexmaker" revision="d2a09b882a9db481a48d22887aa45af55ac1953d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/dlmalloc" path="external/dlmalloc" revision="3a9d0af27a9f8fe533931a9e7ca843fd8e5b54f1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/dng_sdk" path="external/dng_sdk" revision="bf24c2ce5160fc7a04d44dac8cd564c2d9ea62e5" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/dnsmasq" path="external/dnsmasq" revision="bfce4be5569c60687509a40c4f2304f2962182cb" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/doclava" path="external/doclava" revision="7102169baa03cabde1b2615f9300d64a0b9b1da6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/dokka" path="external/dokka" revision="ac5ec5dde25e5c9558b3fed5741cc9f097f6461a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="drm_hwcomposer,pdk-fs" name="platform/external/drm_hwcomposer" path="external/drm_hwcomposer" revision="dedb1edb343f7c3ca032f179d3020bb01c0dc070" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/drrickorang" path="external/drrickorang" revision="0d71c83b891b1eb88e25bb945244cb00a85b2b6e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/dtc" path="external/dtc" revision="c7db36e4961918d5f0715984f6d28484e635ece3" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/dynamic_depth" path="external/dynamic_depth" revision="eeaf88354ff22ff67f82a9cdc0fda4132c8da3a8" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/e2fsprogs" path="external/e2fsprogs" revision="2d8ca6d6ec8a3926cc490879aa46d6dd0e8f110f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/easymock" path="external/easymock" revision="afd503b419c6c25d6804e137f2642217f10ee980" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/eigen" path="external/eigen" revision="18d7fe6ad434c258583c33f0ac7d1c7837cd704b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/elfutils" path="external/elfutils" revision="14c6e51ec2f456affb25aebb7b844ed6e361fe61" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/emma" path="external/emma" revision="c2aa4d22fc24295761a9c588836531a7b3d3d519" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/error_prone" path="external/error_prone" revision="b4f4d485f957a0508434dfc60dd0ccf6df2c9c1e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/ethtool" path="external/ethtool" revision="861c56b1422927e74292bb6dab30690dfed53db5" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/expat" path="external/expat" revision="9060df1c8101801e0bebcddc13816ae435686019" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/f2fs-tools" path="external/f2fs-tools" revision="42383167940cb32ceb475817f6413d4538db561d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/fastrpc" path="external/fastrpc" revision="e517e6dfae809fc753bf93bb8fbe38b1c33b38d7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/fdlibm" path="external/fdlibm" revision="3eea558350ee7509b210f3bfa91bb9f318121e31" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/fec" path="external/fec" revision="7049b92008752b4f939425ad91bf2aea86133216" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/flac" path="external/flac" revision="3dccd10bfac7e896533f5bd3405b789d8bd700b9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/flatbuffers" path="external/flatbuffers" revision="420a0a2f2f9474aa5aaa0a877985401539edf1c9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/fmtlib" path="external/fmtlib" revision="a9d1870c85c52a9f64addd7a8115bc616c439525" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/fonttools" path="external/fonttools" revision="60158b797575946005c3ab704ec20f675500ef8e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/freetype" path="external/freetype" revision="0af6612e1b95d523f6120fa86af50a5c0c8297d4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/fsck_msdos" path="external/fsck_msdos" revision="406ddd07abea91fa8d29467862187123fc8e09e9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/fsverity-utils" path="external/fsverity-utils" revision="885c1e4382273e11a62368777c0ddb64dcdb4edf" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/gemmlowp" path="external/gemmlowp" revision="d2a4169edd6e76cc2d3c29c96a720d79c21b4ee7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/gflags" path="external/gflags" revision="f1557386763cb21d266f6ef90f58c074886b54f4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,qcom_msm8x26" name="platform/external/giflib" path="external/giflib" revision="341c85ed68d932afcdd4481d361d9c1e65b453e2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/glide" path="external/glide" revision="bd0082947a4c7b0058049c155d3c2517d462cc81" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/golang-protobuf" path="external/golang-protobuf" revision="e183852c920ef6c36d9fd89a8c4233e98241c776" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/google-benchmark" path="external/google-benchmark" revision="1eec37d671d2138824c8ca450985eebae7cc0f87" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/external/google-breakpad" path="external/google-breakpad" revision="05728773737deb58a10cdbe29750152c13e400bf" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/google-fonts/arbutus-slab" path="external/google-fonts/arbutus-slab" revision="6a62a3a7283256e86faac4b4830e224f64946838" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/google-fonts/arvo" path="external/google-fonts/arvo" revision="bca8c9b2d370ba24ac0280d674b063f647a038bd" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/google-fonts/carrois-gothic-sc" path="external/google-fonts/carrois-gothic-sc" revision="8c54a6b341ce312cb1ef44add56b5fb0183aaf69" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/google-fonts/coming-soon" path="external/google-fonts/coming-soon" revision="477b0ee78ac4bbdf6de0032e903eb4ade0c1de05" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/google-fonts/cutive-mono" path="external/google-fonts/cutive-mono" revision="9178eb37f91560f7f3135489e533101db23d0fff" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/google-fonts/dancing-script" path="external/google-fonts/dancing-script" revision="c2ee745ad605df8e37a181bce60350113228d091" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/google-fonts/lato" path="external/google-fonts/lato" revision="139c627f77933688eeda9c16a575c1421af08808" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/google-fonts/rubik" path="external/google-fonts/rubik" revision="4a650db6c054b9b328eb1364d217a82296143d25" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/google-fonts/source-sans-pro" path="external/google-fonts/source-sans-pro" revision="ea1024073315464fc4ce2c5c0fccaf2ace8e18ac" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/google-fonts/zilla-slab" path="external/google-fonts/zilla-slab" revision="11c07b19edec7867860296950b14cf7b687240bd" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/google-fruit" path="external/google-fruit" revision="83d0f1fed7aa7062f97731cfeb2f17ebbc2c1649" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/google-styleguide" path="external/google-styleguide" revision="5a3fcff118a07214cec8906e5a3e77574a1dee49" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/googletest" path="external/googletest" revision="739d078a704963f0d19345bc6a3491b8b8232b9c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/gptfdisk" path="external/gptfdisk" revision="b8884909ce1c3540c51772b531f8a75e168040ab" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,tradefed" name="platform/external/grpc-grpc" path="external/grpc-grpc" revision="0f6c0d1e46e36f97f21f844a6ec95f1310b6fc61" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,tradefed" name="platform/external/grpc-grpc-java" path="external/grpc-grpc-java" revision="9b4f1a6db99b7cb7d46320e25e32317853b500dc" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/guava" path="external/guava" revision="e4500bcb91dc065d442a3b7eeac47447d6507bc4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/guice" path="external/guice" revision="a0e72c4fb3f95862a7902e7d9e85920eefe67bf9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/gwp_asan" path="external/gwp_asan" revision="a99a3072ac2459c7885664b99899a7e91d44ac22" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/hamcrest" path="external/hamcrest" revision="03971a91bca428d436501f1da5ab91b02a81a216" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,qcom_msm8x26" name="platform/external/harfbuzz_ng" path="external/harfbuzz_ng" revision="56ce75a95141c3ac7055d744ffd9b93e35367b9f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/honggfuzz" path="external/honggfuzz" revision="4da5ca807ec753ef0dba496f8db65738084c42bb" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/hyphenation-patterns" path="external/hyphenation-patterns" revision="0e83a677bc1e5dda389f1750edfe69a6f34e42e5" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/icu" path="external/icu" revision="5b6839845fd1126344bc70fc3d71d6f033408c15" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/igt-gpu-tools" path="external/igt-gpu-tools" revision="423d2e3ba48d8c947b8282c4e0a5a6c5ffc38275" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/image_io" path="external/image_io" revision="135f7c04ae98ce694efcfc6d9a0d2bc38f4c3653" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/ims" path="external/ims" revision="1abbd5e32807a8dc91e469c61c36a4fc9764db7d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/iperf3" path="external/iperf3" revision="14813ef4a3d9e4cfb66be9d6b33799f81a0656c1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/iproute2" path="external/iproute2" revision="fa70aab53138a1dcc4ab038cfd6a186b68286d0c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/ipsec-tools" path="external/ipsec-tools" revision="21841d18260f3247c0189c5157169c862632f0ec" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/iptables" path="external/iptables" revision="55b98937a2de723b7a0e5f9be0c2e6ab15acb204" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/iputils" path="external/iputils" revision="579e2f654ccf730c840940bfa3289ae8460c83b1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/iw" path="external/iw" revision="e55a47ac749af802d894a1a715fa681af6c787e4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/jacoco" path="external/jacoco" revision="d6e4eb2f3e17ce62a2ae410aece3e8c2636ed64e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/jarjar" path="external/jarjar" revision="d6f27420440536c7650e47ddde630f5f93ca27fc" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/javaparser" path="external/javaparser" revision="49d8afb7998edffb82f8ba4388f607ec2c43136e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/javapoet" path="external/javapoet" revision="c679ce9933a802fc637e8f2d69c0ea25cf376f88" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/javasqlite" path="external/javasqlite" revision="c093f72b18ff45bd66c8884ef667399aa5891b9f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/jcommander" path="external/jcommander" revision="c4d97985b3787276d6b391510250246c9ca94541" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/jdiff" path="external/jdiff" revision="53fe6946d8aa7bcc259c2757ab0309f7762a9355" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/jemalloc" path="external/jemalloc" revision="e3ff6769f8262841c98245e21b96dc67536759dc" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/jemalloc_new" path="external/jemalloc_new" revision="94c497862b75d61a5ce4a2156d6ac417f9c51a8c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/jimfs" path="external/jimfs" revision="cef92d673c81daab4b0dad931591947c86e0dc8a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,tradefed,pdk-fs" name="platform/external/jline" path="external/jline" revision="478835d3c4603b43c28feb80912ff33f2c6811a6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/jsilver" path="external/jsilver" revision="241cd1b197ee8e520aa6b04f277c3b29a2ff0fe4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/jsmn" path="external/jsmn" revision="baeaf082cc45afa06562313a2f17b0e7c91d4629" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/jsoncpp" path="external/jsoncpp" revision="870657e4a28fc426a158254ed49c5f4cbdc690c0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/jsr305" path="external/jsr305" revision="7b129a25432c1a1a3d1919499d8e2f583c753b8d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/jsr330" path="external/jsr330" revision="4221d13d2c4079d3299c1d3265ed93564b84c78b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/junit" path="external/junit" revision="ed077a7e067d0b8508cf6b7502fa143f841be579" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/junit-params" path="external/junit-params" revision="ed4bc1eedea9e248f690ed682e4bd1b65863268d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/kernel-headers" path="external/kernel-headers" revision="655b1ac002f5892b2ef370ceb9e0faeed9bdf7ba" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/kmod" path="external/kmod" revision="21724ce2aa1bc3f69809f997b2658ed83476ac01" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/kotlinc" path="external/kotlinc" revision="869635edd36d0ee5860db3c6c781cbd3126922aa" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/kotlinx.coroutines" path="external/kotlinx.coroutines" revision="f5a650cd76b6b4c184715b80e7956e7ba7422583" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/ksoap2" path="external/ksoap2" revision="2e4343c72a45a2a5933288c71e968d6ab6bf6624" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libaom" path="external/libaom" revision="33cd4437e53a12210ec97a2c7f23f80b8923dbbe" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libavc" path="external/libavc" revision="748aa1e4597a2b0e4c20d30867879780648e0f6a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libbackup" path="external/libbackup" revision="be853756f8a215492b11ae545206d12b64d3a03c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libbrillo" path="external/libbrillo" revision="d4a88f4821ed402c6515d3cf5442a90c95c529e6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libcap" path="external/libcap" revision="2db20a0a41de7cf42cc78f4c8a9b0ef2ed47f6b7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libcap-ng" path="external/libcap-ng" revision="e17ed85e2a3b4691efd6975a02f8e56277cc93af" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libchrome" path="external/libchrome" revision="8cb08133c577a7f6b796fa3eae5e5950b4e59b3f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/external/libcups" path="external/libcups" revision="1bd22a1b5e939ab51a234c3f2e5a178a1522ab57" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libcxx" path="external/libcxx" revision="2d6d9ab848d7e0490dfdea52e5ec15beca9a74d8" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libcxxabi" path="external/libcxxabi" revision="9ab5390e62c8a2787bf6f9ad5be927e133c151bb" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libdaemon" path="external/libdaemon" revision="433dd14cb58a66737e158ad1331c02162a80f43f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libdivsufsort" path="external/libdivsufsort" revision="abb3a16c4986c5f7dda62580c4f53c1930d4d1b9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libdrm" path="external/libdrm" revision="e1e5fd5572088342ab7ba66694411b08a3ad7c6e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libepoxy" path="external/libepoxy" revision="ff18e5a9bed2e8ba1f9c6ea4f9dfaeb080959998" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libese" path="external/libese" revision="f5c8a1639e2ffa84327c8026342462a858e64f02" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libevent" path="external/libevent" revision="4b01342e43b8b4c74f7aa58a9ed3bede66a6e056" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libexif" path="external/libexif" revision="24eb5c6758b645317a6fa85cf6594556332218a5" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libffi" path="external/libffi" revision="ee0c7e65609748000dcf323c8cddb6a2b9b7d5fe" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libfuse" path="external/libfuse" revision="c92466fe1d1612825e16c604bff91408d015e0dd" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libgav1" path="external/libgav1" revision="7f6a1063bebabcc9fad0d191a6042034573f7f58" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libgsm" path="external/libgsm" revision="1321c574befc82fd21a8ac38d36e1da1f3ffb336" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libhevc" path="external/libhevc" revision="579f4d362b11772e33e29e19eef9b5bda322ec34" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libjpeg-turbo" path="external/libjpeg-turbo" revision="d45e9de55f69a08a9c39733e3c23206770efe669" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libkmsxx" path="external/libkmsxx" revision="c09def76c347eda08c3405fe5a4f238f2438aaa9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libldac" path="external/libldac" revision="93195ee38bd08ea8d9f87cbfa550635923f213de" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libmpeg2" path="external/libmpeg2" revision="a1ae85b3092a877d08954ec7949e0c0cf085cb02" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libnetfilter_conntrack" path="external/libnetfilter_conntrack" revision="a44a0c25fa5eb2575df464bd4d9e3e5c7da9ccf6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libnfnetlink" path="external/libnfnetlink" revision="ac537e1d43625a99d8b266a362f4735762a42b66" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libnl" path="external/libnl" revision="173d924eceaa33fe7f731dfc692dd1e1cace80f3" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libogg" path="external/libogg" revision="2f56a5cccbfdfb3b443123d57a78a00a25ebe3de" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libopus" path="external/libopus" revision="6ce1e4a7b5348fab143184357031c70bec8f337b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libpcap" path="external/libpcap" revision="83f31e5d5e7c2268becdf04f3f17a51956a2790c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libphonenumber" path="external/libphonenumber" revision="41e3b486d597b3519058729b54dc760b585ca5fa" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libpng" path="external/libpng" revision="7c18265dd9b2969e957a0029cf3a86736e2a8b9a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libprotobuf-mutator" path="external/libprotobuf-mutator" revision="42dad0bfc87bd87ceb8b88fbfa11f9491d18cf31" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libsrtp2" path="external/libsrtp2" revision="1904160d088401788daf6b5d1130819f087ff946" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libtextclassifier" path="external/libtextclassifier" revision="57002254c3c689c50f9691ff3a99c5943c50063a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libunwind" path="external/libunwind" revision="595f4a2c04419f3c004c39671a551868165bc1f5" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libunwind_llvm" path="external/libunwind_llvm" revision="98d90944b3ef000dd6716c57a480f52a6726749d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libusb" path="external/libusb" revision="e486a629e38d567d271f38f50deeccdac6b7fc62" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libutf" path="external/libutf" revision="385496803c2652ad5228e54c262052abc6420482" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libvpx" path="external/libvpx" revision="8d476e951e7ebf91bbb98f759763d3c264cd963f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libvterm" path="external/libvterm" revision="2caab416f758b648c4034e9f22cb7b76c37203f0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libxaac" path="external/libxaac" revision="a4398eccb889bef19a607fd8d8c8c91a3deeede1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/libxkbcommon" path="external/libxkbcommon" revision="c733e88d8ebad5105544b3e269fa29775c1b1103" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,libxml2" name="platform/external/libxml2" path="external/libxml2" revision="72ac6cf5b8ed69b2c05dcf5ba970b3fcdd4c1c4a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,libyuv" name="platform/external/libyuv" path="external/libyuv" revision="89330bce50a357e32dd12e28363cd7dc64f1924c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/external/linux-kselftest" path="external/linux-kselftest" revision="db3a9fa235b35199b31b6e056c5e853e017554fc" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/llvm" path="external/llvm" revision="c10415f4fb599cbb121fdd4919014b4801e9e0cc" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/lmfit" path="external/lmfit" revision="3d36ea54c2216475d5e21da31ee0db4af24ebed1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/external/ltp" path="external/ltp" revision="d4f7339199c6a97146c786542f8372f7425e159f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/lua" path="external/lua" revision="14d22e8befb9bf4c4f6eef84b23f7028d15af9e3" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/lz4" path="external/lz4" revision="478a1a22f0e71a162c3699265fa44be43914e4dd" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/lzma" path="external/lzma" revision="cb0b0185115eae47250b491cff5f8ad0dad75606" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/markdown" path="external/markdown" revision="41a03193095447f4ff110690171574ed8b721292" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/mdnsresponder" path="external/mdnsresponder" revision="2d7b4e7379ce5b27456539a9b720852b9bc2149f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/external/mesa3d" path="external/mesa3d" revision="71a3c6e1a0cdd6be31c003bff550d664750b2ed6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/mime-support" path="external/mime-support" revision="ff89528c1b7192f464f39643dfd0cb84c5f4dcfe" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/minigbm" path="external/minigbm" revision="51990ce15443fed0a9ca3136916fd80a5b1f2ea0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/minijail" path="external/minijail" revision="84ffabcf488bf0935f00930a9a23bbce1f34d79f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/mksh" path="external/mksh" revision="63d55d82e77906d4a8a3901938b17b261876765f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/mockftpserver" path="external/mockftpserver" revision="1f487440520b7264f9134079441bce0adcf05af0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/mockito" path="external/mockito" revision="9a71c9cc1945cc60ad886c253257f0f1ede5379c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/mockwebserver" path="external/mockwebserver" revision="deaedfdb8ca26ec22231727e076ae2cf4e4e944a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/modp_b64" path="external/modp_b64" revision="d7b108300ecb0b669d6be1653e77adef2f7cca4a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/mp4parser" path="external/mp4parser" revision="91052b1c78aaf57b0db28a0b1e4f7b91e5d8fda6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/ms-tpm-20-ref" path="external/ms-tpm-20-ref" revision="98e0d43362b19f5a9b3598b693c5d91f1e8acecf" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/mtpd" path="external/mtpd" revision="106b0e350ac2912c3ca0dae9896eddae5d0cd1c0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/nanohttpd" path="external/nanohttpd" revision="9e6fdd3de9cf7ebc3a16c614147a28e63e62485e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/nanopb-c" path="external/nanopb-c" revision="07c127e075f66a33ffc6dedfa490a2fd1b9d693c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/naver-fonts" path="external/naver-fonts" revision="37ba854a88b1721057585111c7a1d7e5fd02b556" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/neon_2_sse" path="external/neon_2_sse" revision="7dff91633c4faf01e78427a0d1626853d96289ab" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/neven" path="external/neven" revision="07b172807c1a4607997d1f72c62bbe9caa025aa2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/newfs_msdos" path="external/newfs_msdos" revision="6cbd5a634d77914c907cdc00b5bb9fdb1fbc438d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/nfacct" path="external/nfacct" revision="da41b2d4c2089f96a7fcb81a8b686046e635da7d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/nist-pkits" path="external/nist-pkits" revision="de4e73ff904513e82c5533e09bcadec488616ba9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/nist-sip" path="external/nist-sip" revision="d0a7687d3a0fff06ea6c1fe7d11cbff9864beb99" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pixel" name="platform/external/nos/host/generic" path="external/nos/host/generic" revision="584eecb1f669a76ab24b280c103e972096d2df00" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/noto-fonts" path="external/noto-fonts" revision="486f71253fd8dce3156f36f0007c81b4315405a3" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/oauth" path="external/oauth" revision="2f79a0fdace446afd17a6b539b391be92214fd47" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/objenesis" path="external/objenesis" revision="1595b2de78c5290bdcb425c293e0c6a08c9f060a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/oj-libjdwp" path="external/oj-libjdwp" revision="9c0694cb148807337b3bf9b26d5644e3e3190ad7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/okhttp" path="external/okhttp" revision="7ade36b9f28d6a35357449ffd4d4803081b82f62" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/one-true-awk" path="external/one-true-awk" revision="37da4decf06bbff96e8cea26300ff5314d6b3daa" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,tradefed" name="platform/external/opencensus-java" path="external/opencensus-java" revision="610a17c2139830070c0dc56540d35aeb64222ec7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/oss-fuzz" path="external/oss-fuzz" revision="0d80d30b2b23d5129a19f174ce94541b12677d37" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/owasp/sanitizer" path="external/owasp/sanitizer" revision="062866cd9bb19a038a7365a7bf7f4cdee2e3f441" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/parameter-framework" path="external/parameter-framework" revision="a15aee3613733ea43d1afe2b25c0ee6b37ebe8b4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/pcre" path="external/pcre" revision="5a8c54003e6070401460e269350bb355804eb45f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/pdfium" path="external/pdfium" revision="e17209343c448a816dc59579ed416a95136352b0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/perfetto" path="external/perfetto" revision="89b43b4ed35b63e22aac87ed108abeaa7f0c0891" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/piex" path="external/piex" revision="b693afb4579d0744585f1ff9d6eaa20e4044a6b0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/ply" path="external/ply" revision="0dc471014dfe6d1565c57403fefa47729c18e1e7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/ppp" path="external/ppp" revision="f39a656871ed774e290150e3d007d418858bdb27" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/proguard" path="external/proguard" revision="4049237427905fe053ec217c082ce222f9edc814" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/protobuf" path="external/protobuf" revision="247616f2154f29f8cd1894dec24452fafa9563fd" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/psimd" path="external/psimd" revision="72429076ab18d2249e22f80991a50dc0be8fb393" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/pthreadpool" path="external/pthreadpool" revision="ae9ca1488eebd5c06bb4d056e18fdc7025f7b26b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/puffin" path="external/puffin" revision="ce7d7051ea6cb48ad014f8f091a9d8eb795678cb" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/python/apitools" path="external/python/apitools" revision="e027b2ceb01acc71072baf7b8c24b0a8cb59eabe" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/python/asn1crypto" path="external/python/asn1crypto" revision="67a55d70b5793782d570553f94212d3d0e8b9fbc" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/python/cffi" path="external/python/cffi" revision="21570b8f71e3cf7f1597b30e87dc1e58196306c5" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/python/cpython2" path="external/python/cpython2" revision="edba983036eab94d6c8eb211198f5ae5a874b7b0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/python/cpython3" path="external/python/cpython3" revision="37ac67f501dc80fd96f51a6bf98d4ef32e2e580a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/python/cryptography" path="external/python/cryptography" revision="e892a62257eb19888144f842fd03eb70ccabe8bb" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/python/dateutil" path="external/python/dateutil" revision="40335301327f754f205eee4b7b417e21f9c3e118" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/external/python/enum34" path="external/python/enum34" revision="4b4e6198d4de0c94526c820e6a25d5d46d83237e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/python/funcsigs" path="external/python/funcsigs" revision="29a2df658e8890145edb72ebf82c30155d66c701" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/external/python/futures" path="external/python/futures" revision="89a8fe6ab75db54c27ab073acda54b57b3a1187b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/external/python/google-api-python-client" path="external/python/google-api-python-client" revision="112498337e4b2cb1f5fbce7341c39d3d4fa772ca" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/external/python/httplib2" path="external/python/httplib2" revision="661c9493f76e2dc46a026db304fff0c349877a5c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/python/ipaddress" path="external/python/ipaddress" revision="ec5fa84d0c78d8038e26c77f334b9a4aecb35d9a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/python/mock" path="external/python/mock" revision="3381fde74146dd5d07917b7ec8e74ecd1945d193" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/external/python/oauth2client" path="external/python/oauth2client" revision="447d07451b2e5cfd0f165c8f49f28ba9da66fcdc" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/external/python/pyasn1" path="external/python/pyasn1" revision="364883d819d55d173639d3747a204108c3582159" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/external/python/pyasn1-modules" path="external/python/pyasn1-modules" revision="eeb43cc103f86efb51a0be45c93198e8364511c7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/python/pybind11" path="external/python/pybind11" revision="9946bf3a509dc8c10255c1a64718624ecc537b0d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/python/pycparser" path="external/python/pycparser" revision="2d9dbc9f306462644b502c8e1f4d564659bf0a9c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/python/pyfakefs" path="external/python/pyfakefs" revision="76ea9f5c8da24f4b2ffba9147af1ea5158252c2e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/python/pyopenssl" path="external/python/pyopenssl" revision="437d7a3e9369b32c669c8451e9410a0278d2140c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/external/python/rsa" path="external/python/rsa" revision="cc30821f4245fcc2a8168e8b49cb066c651a13fa" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/external/python/setuptools" path="external/python/setuptools" revision="513ec3d6bb6f7786d02caf51720497a118b8f4be" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/external/python/six" path="external/python/six" revision="9cf9865a7e2cbb67f26c9574d72be7575e334b2d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/external/python/uritemplates" path="external/python/uritemplates" revision="8bbe7cd57d5ac0d5d64cfd25c729dc190a407ee9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/rappor" path="external/rappor" revision="24abc025df68928ce97749b18521c4dbfa3faaf7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/replicaisland" path="external/replicaisland" revision="9d7ae289b1769756044a0060f06b5264f992f4e6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/rmi4utils" path="external/rmi4utils" revision="eab13882ca581b5ef579eeeca311957f5fa2eada" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/external/robolectric-shadows" path="external/robolectric-shadows" revision="b035cad6ac8808d5ab350e7530e568ecc6313a6f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/roboto-fonts" path="external/roboto-fonts" revision="c83d9308a20aac7f872710c12a56d2a20cc9ddc7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/rootdev" path="external/rootdev" revision="2b38487945c95283b77047a5470aa750af02f847" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/rust/crates/bitflags" path="external/rust/crates/bitflags" revision="efaa09589f5e508e9dd325dfd83b66f7d80304bd" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/rust/crates/byteorder" path="external/rust/crates/byteorder" revision="38c3e288c6aae8e4fa4682a40f85bcf97eaa8f8e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/rust/crates/libc" path="external/rust/crates/libc" revision="fe4baf3e89866923d56b00b83f8857859bbe99dc" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/rust/crates/proc-macro2" path="external/rust/crates/proc-macro2" revision="d3e41e5eb0f2661531b2bf1ef7f6fc4f912f1417" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/rust/crates/quote" path="external/rust/crates/quote" revision="e174d73a7f7c80b98a22bfb2c4c6af4bed77ec86" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/rust/crates/remain" path="external/rust/crates/remain" revision="3095d1536defaeecd3bda0e10483589a2ebc1428" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/rust/crates/syn" path="external/rust/crates/syn" revision="63ebae0e99c74e1c9170a005b561f0994bb0a906" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/rust/crates/unicode-xid" path="external/rust/crates/unicode-xid" revision="a665ab8f120fc5449b2772d062afb77db3bed704" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/external/scapy" path="external/scapy" revision="2c6d26c6fc374a6b26b012ff4523a24e903d8329" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/scrypt" path="external/scrypt" revision="d6114db148b1ededd120de0cf2d1fc73ba1611ac" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/scudo" path="external/scudo" revision="6a8384a4f5362728cd520107719b182188dfa098" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/seccomp-tests" path="external/seccomp-tests" revision="f109fb9e5705801c4ab8400df9cc9d68d8132022" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/selinux" path="external/selinux" revision="8cd947563158ed698957654e6370a38ed90da825" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/setupcompat" path="external/setupcompat" revision="17dbf182a83d7fcd6c6802ea17138fead2d1b7de" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/setupdesign" path="external/setupdesign" revision="688e6f06f084d0d92e989b7dfad68c24aeef625f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,qcom_msm8x26" name="platform/external/sfntly" path="external/sfntly" revision="bc071c31d8c1c6b263e323fa777e556e672b25c5" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/shaderc/spirv-headers" path="external/shaderc/spirv-headers" revision="bf179e4aa294d6abaf62296f233638101fd159e1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/shflags" path="external/shflags" revision="6d6812d19da2747fdbee25421af1bd3583d75bf0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,qcom_msm8x26" name="platform/external/skia" path="external/skia" revision="d5e0cd82dc9250515e5910677c26b48a9111604d" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="cts" name="platform/external/skqp" path="external/skqp" revision="2ec7447d4401ecd7dd039568a581205543415939" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/sl4a" path="external/sl4a" revision="a89b5fd86a85f6b8143a75b8d26664d5bd90a2f2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/slf4j" path="external/slf4j" revision="4cd3f35de15e9270f3d5822c3f04a7c2b02189ea" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/smali" path="external/smali" revision="b45eb8f09a2f77cb8a522b04b481d69304c55117" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/snakeyaml" path="external/snakeyaml" revision="5df2ff5ed7c5eebfaff21a8299019e21f648b0f6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/sonic" path="external/sonic" revision="043398f5c456fc78cd8f5f2057e3a2e767eebfca" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/sonivox" path="external/sonivox" revision="eface7c316660a746092378f78f555a7b4e5cce8" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/speex" path="external/speex" revision="9284f2c6bc7eb98db40ee32bb78c682943bd280b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/sqlite" path="external/sqlite" revision="5df6d01fec036b0e6954b4e0e79adbea982a3020" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/squashfs-tools" path="external/squashfs-tools" revision="26929f59a759b06cb01c539ba45630958a8e3a76" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/strace" path="external/strace" revision="92f5c658da5d0044b11d859490128811be5a69e2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/stressapptest" path="external/stressapptest" revision="d621bdcd9a15346a0c9a7234deebb82972925792" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/external/subsampling-scale-image-view" path="external/subsampling-scale-image-view" revision="5fb46aa47bd8d0ca763b7f17033a6f842e57d4f9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/swiftshader" path="external/swiftshader" revision="aff33406dc766eb794ff606931bb17203f389701" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/tagsoup" path="external/tagsoup" revision="80c9aa0ff8916d26f163e7bad20b42616e42ffb4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/tcpdump" path="external/tcpdump" revision="f50b8b00f4d40eaaeb7e0e3a398d441d27e63d54" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/tensorflow" path="external/tensorflow" revision="ec63214f098a2bfc87b628219ad0718750d4e930" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/testng" path="external/testng" revision="74aac3e648e789b5f462bd42debc34a16507dbad" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/tinyalsa" path="external/tinyalsa" revision="7a9faa352dcee96bf2617d6dfa72ac4d5b550a7e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/tinycompress" path="external/tinycompress" revision="0d22775e991f172e0215ec098812f9664ea99eae" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/tinyxml" path="external/tinyxml" revision="354bbb9275d67a3dde9f1b6aa0464b60e53585c9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/tinyxml2" path="external/tinyxml2" revision="2b0e573d9f7b2148ef6ca85ad629cd1c2f406b87" upstream="refs/tags/android-r-preview-2"/>
+  <project name="platform/external/toolchain-utils" path="external/toolchain-utils" revision="c6166ac212048a5a83f5e450377088648c27e048" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/toybox" path="external/toybox" revision="320b7269bab7bbe7f88e80dd1aff6cecde25da63" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/tpm2-tss" path="external/tpm2-tss" revision="1365217e0129aa876e3d55789a3776183d478fbf" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/tremolo" path="external/tremolo" revision="4796b31d95d7f3f9bc5ca611aaa7efc80b0224a2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/turbine" path="external/turbine" revision="05598c0046e176a2057b3eed7ef9186a3cacd360" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/u-boot" path="external/u-boot" revision="685955f3d2c70ee6ba7e4415a458d669fb9c28a1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/ukey2" path="external/ukey2" revision="cd9c844bd676ff9ff69a74bc49e157149a7f0918" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/unicode" path="external/unicode" revision="76611169d15eb196b4adcdbac2c795a9cfaf781f" upstream="refs/tags/android-r-preview-2"/>
+  <project name="platform/external/universal-tween-engine" path="external/universal-tween-engine" revision="507b8885296104d7efe1bc16efbc07e2d22ef66d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/v4l2_codec2" path="external/v4l2_codec2" revision="b260c87aeab18435d2f63b52f7e12d5c04f13283" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/v8" path="external/v8" revision="850df249e17efd8857463449eab5d52152b23c99" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vboot,pdk-fs" name="platform/external/vboot_reference" path="external/vboot_reference" revision="df6d6b6e5280520b096fb1f565b758948bc872ee" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/virglrenderer" path="external/virglrenderer" revision="55e81ab18eda2cf4724bab631975346bf5e87585" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/vixl" path="external/vixl" revision="24c0a1eebd3409e415c4dccca1216b41f819aad4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/vogar" path="external/vogar" revision="9a9a89642d428d43b13ece05e349aa0d54d11a1e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/volley" path="external/volley" revision="ab93ab6a714a5529afe10502f8065a0eb7fa3f87" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/vulkan-headers" path="external/vulkan-headers" revision="4706e793a3e24e211244dc48a5049cb8f767c3e9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/vulkan-validation-layers" path="external/vulkan-validation-layers" revision="7a051caedfe620bf590741053be4913cd8508751" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/walt" path="external/walt" revision="53c47a96bc0d6129d3dad8219a9a1a793c3da963" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/wayland" path="external/wayland" revision="fe6a8acb93c9f6c345a0637bfe91c09576b0277b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/wayland-protocols" path="external/wayland-protocols" revision="d5f2093d3411bdf04b25ec92b622282448473c78" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,qcom_msm8x26" name="platform/external/webp" path="external/webp" revision="c15a3524ca533d266acaac6aa38e14ac9b3fd30a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/webrtc" path="external/webrtc" revision="7856f35eded86652026789af0069e6402a1bbbb8" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/wpa_supplicant_8" path="external/wpa_supplicant_8" revision="05994afb607f792fba21c7e19b3fd1319a4ba992" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/wycheproof" path="external/wycheproof" revision="d3ed1708ab87b1f922d8c4f8127e08c3b97efd17" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/xmp_toolkit" path="external/xmp_toolkit" revision="44d7e4d00ef6da63a75bf3a4f9296872cc4d2ac1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/xz-embedded" path="external/xz-embedded" revision="51923a98b0af813e3db6a027d64471ee8710a4f2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/xz-java" path="external/xz-java" revision="bd7892bb8927360cd34805bc332039154a2110e0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,projectarch,pdk" name="platform/external/yapf" path="external/yapf" revision="45d923c40605a71867d174abcd04a1db76945651" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/zlib" path="external/zlib" revision="7dfceb664ec662810451feb60912bdf8068ea81a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/zopfli" path="external/zopfli" revision="7723d6077849ae5c66e105b232ddfbfc11faa09b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/external/zxing" path="external/zxing" revision="65193280855e46d11bf5b44f1a7e49ec0c7bd57e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/frameworks/av" path="frameworks/av" revision="bc0f22e33fa5adc5a8873489a5270ba93f94b5a1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/base" path="frameworks/base" revision="5b5bd31eb39480c419446b012b32d02b2f88bc7c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/frameworks/compile/libbcc" path="frameworks/compile/libbcc" revision="72df1bfdec830469932e330ca636bd6245aefa5f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/frameworks/compile/mclinker" path="frameworks/compile/mclinker" revision="f44921e7d4a53e60816df832636457f52eb22f5e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/frameworks/compile/slang" path="frameworks/compile/slang" revision="39dd076e4ffb489ab396a99c473dd40509e52977" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/ex" path="frameworks/ex" revision="e27051b33ccc6ff9e7ce3f883147215fecd3badf" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/frameworks/hardware/interfaces" path="frameworks/hardware/interfaces" revision="31c9f78b315d76c664203e6dad4048d2e1538ad8" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/layoutlib" path="frameworks/layoutlib" revision="595041b399969b67059d842056955b25003413bd" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/libs/net" path="frameworks/libs/net" revision="029a7f0dc038e002087fd9846873aa08c51c2d86" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/minikin" path="frameworks/minikin" revision="ccb441309e11b0abe0b5b7c166baddf265705532" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/frameworks/ml" path="frameworks/ml" revision="8dcf6fc311a7434abb26420d5c9b0aaf0b78fbca" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/multidex" path="frameworks/multidex" revision="85015412f25c08bb7adfe12050f742f344b1ada2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/frameworks/native" path="frameworks/native" revision="8ba800fd3d9ba2389d911c6e6b891e2cd9df866e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/frameworks/opt/bitmap" path="frameworks/opt/bitmap" revision="e9850af1278e499e427d08dbf40244f3622bd6db" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/calendar" path="frameworks/opt/calendar" revision="1aea8315ebe9cca6e9462ab02e9f4caf20c8cd58" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/frameworks/opt/car/services" path="frameworks/opt/car/services" revision="a99bb6d755a4cadf28d9721998c81a2eb9695027" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/frameworks/opt/car/setupwizard" path="frameworks/opt/car/setupwizard" revision="4edad3bb73918b5d4c4d9b29e7558f2181c527e6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/chips" path="frameworks/opt/chips" revision="558c496c8f51ee586d0f0cf0e0371c25c7ceca31" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/colorpicker" path="frameworks/opt/colorpicker" revision="7890ecd4bc418a422f02c0ab32406049b9117707" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/frameworks/opt/net/ethernet" path="frameworks/opt/net/ethernet" revision="e260e8593a6f6db92d3da4c965100585e6ed8ae7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/frameworks/opt/net/ike" path="frameworks/opt/net/ike" revision="e649e5dc38220283387c9c995ec266ed5163e496" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="frameworks_ims,pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/net/ims" path="frameworks/opt/net/ims" revision="c9d85cf60a882157b6924cdb0e229bf869792125" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/net/voip" path="frameworks/opt/net/voip" revision="4fd8a47d3ea5670371bd7eb8a7df12b1a9e09d43" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/frameworks/opt/net/wifi" path="frameworks/opt/net/wifi" revision="363919bc936ff2354672015c3357056c666b7485" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/photoviewer" path="frameworks/opt/photoviewer" revision="80dca034d73543634c9363a4d89603039797d17b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/setupwizard" path="frameworks/opt/setupwizard" revision="481c220b0b15b5ab5808e4f0d648333c9b772307" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/frameworks/opt/telephony" path="frameworks/opt/telephony" revision="50f500bd2f52064c7dce426827f54f429db00741" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/timezonepicker" path="frameworks/opt/timezonepicker" revision="7330b31178d3ca509bf710bf435ed85785b4e8ea" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/vcard" path="frameworks/opt/vcard" revision="60f1b62e68cb324b66d24580660e7dc5478d3305" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/frameworks/rs" path="frameworks/rs" revision="b177df2af4f8771622f3a8567ae5b7d884e26ec6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/wilhelm" path="frameworks/wilhelm" revision="1ae27fa06db35ee105063075119f0fcac613867d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/hardware/broadcom/libbt" path="hardware/broadcom/libbt" revision="40c99d7f10f7ca533de1dc4c0f21c921c8a7ccce" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,broadcom_wlan" name="platform/hardware/broadcom/wlan" path="hardware/broadcom/wlan" revision="b0a55cf0ceda7d42763c05c3f71fbe5b07c74c33" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/hardware/google/apf" path="hardware/google/apf" revision="1cc9d2f7932f09865812e25a29cc5f708db609bf" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/hardware/google/av" path="hardware/google/av" revision="f48d6708df1c1cc6eb71ecfa7c3be7048d85dd91" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,easel" name="platform/hardware/google/easel" path="hardware/google/easel" revision="c0289b1adae580846436ef2fabeb46c3a4cbf840" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/hardware/google/interfaces" path="hardware/google/interfaces" revision="35ee1140254be6d8eb5bb73c6d543c2da01e7984" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="generic_fs,pixel" name="platform/hardware/google/pixel" path="hardware/google/pixel" revision="56ed76601d2fa5f1a1e6f7f24d79975a69f43a39" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="generic_fs,pixel" name="platform/hardware/google/pixel-sepolicy" path="hardware/google/pixel-sepolicy" revision="a3af99c63f21e27cba689f811c15c2b10f638fea" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/hardware/interfaces" path="hardware/interfaces" revision="775bd7cb9a5faaca03893bea3b5d7c83bf94a9ea" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="invensense,pdk" name="platform/hardware/invensense" path="hardware/invensense" revision="a51c32c7d16d32462fcd2d3fc61474bb0ec56864" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="coral" name="platform/hardware/knowles/athletico/sound_trigger_hal" path="hardware/knowles/athletico/sound_trigger_hal" revision="3c287d5a139ee9bc6bf130f46ffeb8660938fe96" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/hardware/libhardware" path="hardware/libhardware" revision="353924555ed8dfdea437d7f5833573963e0755b4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/hardware/libhardware_legacy" path="hardware/libhardware_legacy" revision="f2a03b676273c57b01e1ac5bc45fd8ee0f73fdaa" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/hardware/nxp/nfc" path="hardware/nxp/nfc" revision="1a15c61d2f880737c581f3ff6cd53266fd7c20db" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/hardware/nxp/secure_element" path="hardware/nxp/secure_element" revision="415b9c170f8f17d42fca196b9e495ef9e305370b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom,qcom_audio,pdk-qcom" name="platform/hardware/qcom/audio" path="hardware/qcom/audio" revision="2d4e92a7f5631a7344f33e760665cc8453ab84db" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-qcom" name="platform/hardware/qcom/bootctrl" path="hardware/qcom/bootctrl" revision="4e5d4010484ae58b169f00d036efff78546a3def" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom,pdk-qcom" name="platform/hardware/qcom/bt" path="hardware/qcom/bt" revision="60cd73f453bb6d4920cf2d2aa3b0f455a404de04" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_camera,pdk-qcom" name="platform/hardware/qcom/camera" path="hardware/qcom/camera" revision="9ddd2b5c8bd6b7c2abaaafa0230f2a6a2ee7bede" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom,pdk-qcom" name="platform/hardware/qcom/data/ipacfg-mgr" path="hardware/qcom/data/ipacfg-mgr" revision="afb3ff1954f9cfdb3cb30c5b8ceead63bffdb3d9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-qcom,qcom,qcom_display" name="platform/hardware/qcom/display" path="hardware/qcom/display" revision="5b3e1c2cb842cd5097706bead8828ae359b4fe3f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom,qcom_gps,pdk-qcom" name="platform/hardware/qcom/gps" path="hardware/qcom/gps" revision="87f7523616fbe4dc383e5d8f1e240f235530cdd4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom,qcom_keymaster,pdk-qcom" name="platform/hardware/qcom/keymaster" path="hardware/qcom/keymaster" revision="ecfe142948adf4f82083d7333b6c778f3993842b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom,pdk-qcom" name="platform/hardware/qcom/media" path="hardware/qcom/media" revision="ff39d325a6d1688575fddebd3a4665d5c4d4c4d1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_msm8960,pdk-qcom" name="platform/hardware/qcom/msm8960" path="hardware/qcom/msm8960" revision="c25a431842a26b5756b58a9d4a42c776e0457ba2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_msm8994,pdk-qcom" name="platform/hardware/qcom/msm8994" path="hardware/qcom/msm8994" revision="8e0383f6f41a2c49461f381c8d066ea21b20c674" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_msm8996,pdk-qcom" name="platform/hardware/qcom/msm8996" path="hardware/qcom/msm8996" revision="f0e7ce67121940312eaffeda9c4add56d63bf4e1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_msm8998,pdk-qcom" name="platform/hardware/qcom/msm8998" path="hardware/qcom/msm8998" revision="e504d3feeb25220780c1674dc870a1a45e0cf55b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_msm8x09" name="platform/hardware/qcom/msm8x09" path="hardware/qcom/msm8x09" revision="c88c67109844def18fef4941e39bebb8f8981e39" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_msm8x26,pdk-qcom" name="platform/hardware/qcom/msm8x26" path="hardware/qcom/msm8x26" revision="85c1a5282ae28663335e55ce96a4c0487de6c578" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_msm8x27,pdk-qcom" name="platform/hardware/qcom/msm8x27" path="hardware/qcom/msm8x27" revision="8ff5c0057cbdecfa09410c1710ba043e191a2862" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_msm8x84,pdk-qcom" name="platform/hardware/qcom/msm8x84" path="hardware/qcom/msm8x84" revision="582b414269d8472d17eef65d8a8965aa8105042f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="wahoo" name="platform/hardware/qcom/neuralnetworks/hvxservice" path="hardware/qcom/neuralnetworks/hvxservice" revision="09fd7dd7e4475a5e8d6852fe76099bcdb6f62b79" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom,pdk-qcom" name="platform/hardware/qcom/power" path="hardware/qcom/power" revision="c9165f0cb184fcaf6888b7921b55033e8b50836c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/bt" path="hardware/qcom/sdm845/bt" revision="29c8a55bb6e521089ebd80a64afc893f8822aad2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="generic_fs,vendor,qcom_sdm845" name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" path="hardware/qcom/sdm845/data/ipacfg-mgr" revision="a82a6f86c4654775a66de52af4c4e42e118b51e6" upstream="refs/tags/android-r-preview-2">
     <linkfile dest="hardware/qcom/sdm845/Android.mk" src="os_pickup.mk"/>
     <linkfile dest="hardware/qcom/sdm845/Android.bp" src="os_pickup.bp"/>
   </project>
-  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/display" path="hardware/qcom/sdm845/display" revision="6189dc7a9b07305c00aac5c1467f413d64c5fe96" upstream="master"/>
-  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/gps" path="hardware/qcom/sdm845/gps" revision="44441b5d76f4d549c0860fea724da1fc65d7f6c4" upstream="master"/>
-  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/media" path="hardware/qcom/sdm845/media" revision="e65f94797ccf4e1ad1778aa0c67a37df29937605" upstream="master"/>
-  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/thermal" path="hardware/qcom/sdm845/thermal" revision="6a8568c80ac10888281bc806fd60f37a84b0cfa0" upstream="master"/>
-  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/vr" path="hardware/qcom/sdm845/vr" revision="0e06489f538d99656ba2594d1d1aa6f24ba825f4" upstream="master"/>
-  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/data/ipacfg-mgr" path="hardware/qcom/sm8150/data/ipacfg-mgr" revision="69158dfcc6314e3eee6d08f31f9f70292a7a0e1f" upstream="master">
+  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/display" path="hardware/qcom/sdm845/display" revision="fed335836c01838cdb8b1344d2ca9579978ec2bd" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/gps" path="hardware/qcom/sdm845/gps" revision="2175c408dc60a6cf22a869b3829d8d0ba6cf957d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/media" path="hardware/qcom/sdm845/media" revision="507841ed486153fd14cbc1f4a9a6ffad12385254" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/thermal" path="hardware/qcom/sdm845/thermal" revision="5c1c45ebedbce6edc86159b4e97d980759552285" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/vr" path="hardware/qcom/sdm845/vr" revision="0e06489f538d99656ba2594d1d1aa6f24ba825f4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/data/ipacfg-mgr" path="hardware/qcom/sm8150/data/ipacfg-mgr" revision="5c50b64f697d7ac4661cd5f69ccc5186eb3a25d0" upstream="refs/tags/android-r-preview-2">
     <linkfile dest="hardware/qcom/sm8150/Android.mk" src="os_pickup.mk"/>
     <linkfile dest="hardware/qcom/sm8150/Android.bp" src="os_pickup.bp"/>
   </project>
-  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/display" path="hardware/qcom/sm8150/display" revision="5076efba893d80e210a0eeb918fe150543d243bb" upstream="master"/>
-  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/gps" path="hardware/qcom/sm8150/gps" revision="0a99a569440066892ff8579dbcff306cc60b6c2a" upstream="master"/>
-  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/media" path="hardware/qcom/sm8150/media" revision="6c275b2b5afabe85c09692094bf953c8ba3a6508" upstream="master"/>
-  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/thermal" path="hardware/qcom/sm8150/thermal" revision="ae363bd3d316f252056d3235d00c7e6b0dbf5465" upstream="master"/>
-  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/vr" path="hardware/qcom/sm8150/vr" revision="83c0155ec713872c7096a7610683e0c99e1f9803" upstream="master"/>
-  <project groups="qcom_wlan,pdk-qcom" name="platform/hardware/qcom/wlan" path="hardware/qcom/wlan" revision="e370a751488e6d9075d2bce63e3db579cf5fcfd7" upstream="master"/>
-  <project groups="pdk" name="platform/hardware/ril" path="hardware/ril" revision="02ed800d62556cbf95666373d288efdd9ef090e7" upstream="master"/>
-  <project groups="pdk" name="platform/hardware/st/nfc" path="hardware/st/nfc" revision="75437f9260e6ff90103f41d1658623fb18aca94f" upstream="master"/>
-  <project groups="pdk" name="platform/hardware/st/secure_element" path="hardware/st/secure_element" revision="584b337f7407afae553c74ff500f8a877f8c38cf" upstream="master"/>
-  <project groups="pdk" name="platform/hardware/ti/am57x" path="hardware/ti/am57x" revision="eebe4a55620d72dcf27a259d4445566745115aa3" upstream="master"/>
-  <project groups="pdk" name="platform/libcore" path="libcore" revision="94b823083de9a5427883e600381e0370fba09656" upstream="master"/>
-  <project groups="pdk" name="platform/libnativehelper" path="libnativehelper" revision="1a73a38d139ce6bd0c96041178bfe6e8e4c54956" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/BasicSmsReceiver" path="packages/apps/BasicSmsReceiver" revision="5e73cf41894b844517ae51d221ee706e866c31b6" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/Bluetooth" path="packages/apps/Bluetooth" revision="ef2d2a3dc33aa76b2e862ac9a8f718354e8f8223" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Browser2" path="packages/apps/Browser2" revision="37652f79d1a115bc2d920a68ad6846a23107c660" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Calendar" path="packages/apps/Calendar" revision="161ed60830a383dddd59d75d7666b4002a878f1f" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Camera2" path="packages/apps/Camera2" revision="14c5d4f7b7180b3611f23244be108fb5cf34a543" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Cluster" path="packages/apps/Car/Cluster" revision="85003cbf4711464e6a174a618965abdfa724b4e1" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Dialer" path="packages/apps/Car/Dialer" revision="da59ae6f14113e4c2783e7a39b5b533c8005eed2" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Hvac" path="packages/apps/Car/Hvac" revision="7969a3cf34a69642101c0412ecc1221600233a34" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/LatinIME" path="packages/apps/Car/LatinIME" revision="2dd68ad63f3992846de3cfb4a51b17a5a4319295" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Launcher" path="packages/apps/Car/Launcher" revision="613414339cc0871a5bd2b17768bd3e941da10015" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/LensPicker" path="packages/apps/Car/LensPicker" revision="bd6c67549a9ea992fbae4e439bfa889b2b63110a" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/LinkViewer" path="packages/apps/Car/LinkViewer" revision="3d4efda0c66429ce9d9a6bdfd231b46b2b685004" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/LocalMediaPlayer" path="packages/apps/Car/LocalMediaPlayer" revision="5d49ef72dc25db83ad4bc345c791694ee11ed4e0" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Media" path="packages/apps/Car/Media" revision="d175bede5dea35ad6ffcd336ec16fc0ce8e0cdec" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Messenger" path="packages/apps/Car/Messenger" revision="61a69a423e0f9df200f02ea7f81cba8d35ed682d" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Notification" path="packages/apps/Car/Notification" revision="93f33e3d4412cec4fefed62ec47f9f35f8f0d134" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Overview" path="packages/apps/Car/Overview" revision="18069cf7b505946bdf5d1eb3566c7c8f201b1b9d" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Radio" path="packages/apps/Car/Radio" revision="48701da01bdec6812ec7988e83a26bb2117f046c" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Settings" path="packages/apps/Car/Settings" revision="b8b97a6aa4df8f33d5acf37322e63c28cdefc366" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Stream" path="packages/apps/Car/Stream" revision="65fcbceb6cadefcd715b7b61c0d08c8279408343" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/SystemUpdater" path="packages/apps/Car/SystemUpdater" revision="43729fbb2cf86a3f996332cd4bdd998d8a253243" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/externallibs" path="packages/apps/Car/externallibs" revision="bc16257053938c32c75d502cd990b4fec5a76be8" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/libs" path="packages/apps/Car/libs" revision="7cc65e9bc4b8deb6166c923715bf85950a2297b5" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/tests" path="packages/apps/Car/tests" revision="d8894ee30094fc503ca16ba3d39f1806ea9899b3" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/CarrierConfig" path="packages/apps/CarrierConfig" revision="bc35a64474eb48dc864886089e5af05f54aa4b06" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/CellBroadcastReceiver" path="packages/apps/CellBroadcastReceiver" revision="75a95740893d03fa759a6ba5de2b88db869fb69b" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/CertInstaller" path="packages/apps/CertInstaller" revision="df26c4042e61e07cbbb63a863bd396d299946655" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Contacts" path="packages/apps/Contacts" revision="e88ebe6960bd0071f35346d190a6754672c926a1" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/DeskClock" path="packages/apps/DeskClock" revision="6099fb9b715adc186c9aad6be38f09fbf49f8a42" upstream="master"/>
-  <project groups="pdk" name="platform/packages/apps/DevCamera" path="packages/apps/DevCamera" revision="237c1d87932ba2891a886609642003ccda59a791" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Dialer" path="packages/apps/Dialer" revision="80a6f0558b9ad4264b0c47de386aecc62e9f4525" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/DocumentsUI" path="packages/apps/DocumentsUI" revision="3aa3fb5e73473cd11a454dd49d9cd47e497dd856" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/EmergencyInfo" path="packages/apps/EmergencyInfo" revision="a487b0f778ae514bfdaf2102d7996969fcebf542" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Gallery" path="packages/apps/Gallery" revision="14627b110153b054a7c5b1f4187d3012f7da83b5" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Gallery2" path="packages/apps/Gallery2" revision="5030445fd73638e60883b0a53bf0855eb5633c09" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/HTMLViewer" path="packages/apps/HTMLViewer" revision="0e521ae9aa2c8b1b3d30870ec9662affef4b61a7" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/KeyChain" path="packages/apps/KeyChain" revision="10d8e6489c44d49859ad61c0e58ee33a1879bf95" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Launcher3" path="packages/apps/Launcher3" revision="ca891c7a2200cd623562fe9f2e644c054d1842a5" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/LegacyCamera" path="packages/apps/LegacyCamera" revision="b0841adc859c8ab1fe37f7577edc9299e0b20773" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/ManagedProvisioning" path="packages/apps/ManagedProvisioning" revision="9bc4829b4a32945fa04f7f6c90cbecb2ab48dcc8" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Messaging" path="packages/apps/Messaging" revision="8f27830d2d0d720a08b29fa8f9afeeb89fc738c5" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Music" path="packages/apps/Music" revision="922216b0b0a57e56663dd480f908589cb8e5159d" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/MusicFX" path="packages/apps/MusicFX" revision="a7861dc74e09eea6ebd8448ca09104429e5fe684" upstream="master"/>
-  <project groups="apps_nfc,pdk-fs" name="platform/packages/apps/Nfc" path="packages/apps/Nfc" revision="3224733e0a511da46c031c9df11168aa173cfa0f" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/OneTimeInitializer" path="packages/apps/OneTimeInitializer" revision="737b0d2daabf33a458ed754e045b2f0e2b65da70" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/PackageInstaller" path="packages/apps/PermissionController" revision="86e134ea08aad5b27b3bb21fcb32ee6da4bd1083" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/PhoneCommon" path="packages/apps/PhoneCommon" revision="94b334ac0ffef4a66e403d07c17130ee5a3fea5d" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Protips" path="packages/apps/Protips" revision="277f2db1a9099d5aaf96d4f3ca8daaeeeeef4e6f" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Provision" path="packages/apps/Provision" revision="24df85c79c7b058d67c4c36335816ebedb179911" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/QuickSearchBox" path="packages/apps/QuickSearchBox" revision="5fd7ab4b450b89cd2322949f52866f6fef70a884" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/SafetyRegulatoryInfo" path="packages/apps/SafetyRegulatoryInfo" revision="e1ce24d12091ef004e42b2dac8d4b8bca4248964" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/SampleLocationAttribution" path="packages/apps/SampleLocationAttribution" revision="414210769cbe3ab244ec4af9eef1648e4933f863" upstream="master"/>
-  <project groups="apps_se,pdk-fs" name="platform/packages/apps/SecureElement" path="packages/apps/SecureElement" revision="ccf7c818c450a1fd40cac47bde54f445aaf3b3a4" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Settings" path="packages/apps/Settings" revision="c8e4d7953e83c1f07d72ce573dce8c34c316428c" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/SettingsIntelligence" path="packages/apps/SettingsIntelligence" revision="afbeaac562915ce2a4acacdf28e83b28f33f7469" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/SoundRecorder" path="packages/apps/SoundRecorder" revision="30b3ba89e435bc2d0b686cab2f2c0d5a33c8fbeb" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/SpareParts" path="packages/apps/SpareParts" revision="f3d46ceeecd71c5555939f32643c18c78ae7909f" upstream="master"/>
-  <project groups="apps_stk,pdk-fs" name="platform/packages/apps/Stk" path="packages/apps/Stk" revision="4f5cc5e43da1ca2df851cf12f1408fcb846cb840" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/StorageManager" path="packages/apps/StorageManager" revision="a7a82f54a0c04f0a0093108ddecf0b16861ac1dc" upstream="master"/>
-  <project groups="pdk" name="platform/packages/apps/TV" path="packages/apps/TV" revision="2a26b36b3b20de9bfa1e47ad2e10938cf09649f8" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Tag" path="packages/apps/Tag" revision="543d67b319ceb05d68de3e83461228a620657844" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Terminal" path="packages/apps/Terminal" revision="4d4e9490fdd512668ac0d47764f3eeb19504a6d2" upstream="master"/>
-  <project groups="pdk" name="platform/packages/apps/Test/connectivity" path="packages/apps/Test/connectivity" revision="f978694598321584f30eac04b997c67dd9a73c63" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/ThemePicker" path="packages/apps/ThemePicker" revision="1a1c3c55d2151761956e704196088cc6b0e825d8" upstream="master"/>
-  <project groups="pdk" name="platform/packages/apps/TimeZoneData" path="packages/apps/TimeZoneData" revision="2334006fcea08874427888ff7f75026231408926" upstream="master"/>
-  <project groups="pdk" name="platform/packages/apps/TimeZoneUpdater" path="packages/apps/TimeZoneUpdater" revision="5afedc6761eaf25fd95f91d219c9e385022a55d3" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Traceur" path="packages/apps/Traceur" revision="c0367ddf88bdba261faa4ca0027c7285d42f7f84" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/TvSettings" path="packages/apps/TvSettings" revision="24bca161cd9ac9bbfa592ef277d574908044332d" upstream="master"/>
-  <project name="platform/packages/apps/UniversalMediaPlayer" path="packages/apps/UniversalMediaPlayer" revision="287097108b913837ba76565ab07cbcb7ceb6ea1c" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/WallpaperPicker" path="packages/apps/WallpaperPicker" revision="85377120783aec2a91567bd619e557911b7fc8c8" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/apps/WallpaperPicker2" path="packages/apps/WallpaperPicker2" revision="54e964b29ce87555c08383732823c13e5c4938dd" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/inputmethods/LatinIME" path="packages/inputmethods/LatinIME" revision="c3eafcb75631a52b32ea6785ba7791486770ad2b" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/inputmethods/LeanbackIME" path="packages/inputmethods/LeanbackIME" revision="7e131e7ebd515c5eaf7e946d8e1ffad82440f00c" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/packages/modules/ArtPrebuilt" path="packages/modules/ArtPrebuilt" revision="491a40e7de77dac8666f05aab45e6e71e57ceb49" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/CaptivePortalLogin" path="packages/modules/CaptivePortalLogin" revision="262af25e5d8b9d4d7811fac518f44945ac781535" upstream="master"/>
-  <project groups="pdk" name="platform/packages/modules/CellBroadcastService" path="packages/modules/CellBroadcastService" revision="75ebf6313e435d31ff520ca8ac1305199c53d350" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/Cronet" path="packages/modules/Cronet" revision="71cda2822314e1fdeb5b5b0e468b747b1eae99d9" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/DnsResolver" path="packages/modules/DnsResolver" revision="0452b8cf515b25e76321ba0ca337fafbc58b5506" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/ExtServices" path="packages/modules/ExtServices" revision="e9b2379626175bf8ec57a1c2ddd633394a5e8401" upstream="master"/>
-  <project groups="pdk" name="platform/packages/modules/ModuleMetadata" path="packages/modules/ModuleMetadata" revision="bf198f3182e53f3d1dc9d061f558656e59f5d4c8" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/NetworkPermissionConfig" path="packages/modules/NetworkPermissionConfig" revision="e9c83053acbd9bc9a06cb4f11aefc099dc338eab" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/NetworkStack" path="packages/modules/NetworkStack" revision="d22d5b2870ccea8de9842dc728421ca235053d6c" upstream="master"/>
-  <project name="platform/packages/modules/TestModule" path="packages/modules/TestModule" revision="3523a2f0f9b12d4e60374af63aae14f75a2b4c10" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/vndk" path="packages/modules/vndk" revision="8c7268c01a6d848d41b136037fcf5a318cfbcd48" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/providers/ApplicationsProvider" path="packages/providers/ApplicationsProvider" revision="33d26f5eedb3d3011762ce5b2de66e931bf64b35" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/providers/BlockedNumberProvider" path="packages/providers/BlockedNumberProvider" revision="ce181397897d95bda91283cbf313a8c8637ffd12" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/providers/BookmarkProvider" path="packages/providers/BookmarkProvider" revision="66d866abdf7184af7a98edce18012fc33c41b623" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/CalendarProvider" path="packages/providers/CalendarProvider" revision="09ab3154bcacc71a957f51d36a891dd5ad1af149" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/providers/CallLogProvider" path="packages/providers/CallLogProvider" revision="b17d05f2f416a4992e08184935a729b5e88e1fc2" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/ContactsProvider" path="packages/providers/ContactsProvider" revision="fea45a27db8fbec2ec263dbbbe3c1abd55d2f2c3" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/DownloadProvider" path="packages/providers/DownloadProvider" revision="f50989352fa4934ad2a3b9a627acc14d72af08ce" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/MediaProvider" path="packages/providers/MediaProvider" revision="5728efac3df713f412121e837769060c0799ced7" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/providers/PartnerBookmarksProvider" path="packages/providers/PartnerBookmarksProvider" revision="9c3b541b4357011de2047a2e24f92a63c6d8d8a0" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/TelephonyProvider" path="packages/providers/TelephonyProvider" revision="5ee4165a58d62c5ba2ec694d03e2ba213795c61f" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/providers/TvProvider" path="packages/providers/TvProvider" revision="6e37df0f8aeaa5cb90217f2c8d67d1bd455ad7ee" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/UserDictionaryProvider" path="packages/providers/UserDictionaryProvider" revision="4848226fab553b950b57b4960b5de580caf0a41c" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/screensavers/Basic" path="packages/screensavers/Basic" revision="bab9819b214e77a1e3c36e2dc478d60aa43a6382" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/screensavers/PhotoTable" path="packages/screensavers/PhotoTable" revision="9d48201be3f7857d981b00986d597424a7f67041" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/AlternativeNetworkAccess" path="packages/services/AlternativeNetworkAccess" revision="43138a18a64d63ae8536fe4e43ed210ea3d45d30" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/BuiltInPrintService" path="packages/services/BuiltInPrintService" revision="90447e7df74298299fba78a11105c1a39a6aa0ee" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Car" path="packages/services/Car" revision="1f7f2194672b574c7018399830ad18f57b53166a" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Mms" path="packages/services/Mms" revision="9bcf79ca832c7da84d76e6f89f185c617d271e4d" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Telecomm" path="packages/services/Telecomm" revision="5fd330f8437d7effa907a895978ce610570bbecc" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Telephony" path="packages/services/Telephony" revision="5240b22e1edefc156bfb74a4e020d63b38fb6608" upstream="master"/>
-  <project groups="pdk-fs" name="platform/packages/wallpapers/LivePicker" path="packages/wallpapers/LivePicker" revision="664442ea358d099804b9d9fff75923d05144b0fd" upstream="master"/>
-  <project groups="pdk" name="platform/pdk" path="pdk" revision="e6b849a6b99d2e2a3e57d149f39f645cf2e9a736" upstream="master"/>
-  <project groups="pdk-fs,pdk-cw-fs,cts" name="platform/platform_testing" path="platform_testing" revision="03ccb566aa6295cbc09b000541080edb4c7eccec" upstream="master"/>
-  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/abi-dumps/ndk" path="prebuilts/abi-dumps/ndk" revision="f070e958c3bff9f4bd3b45022109c88810d89c03" upstream="master"/>
-  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/abi-dumps/platform" path="prebuilts/abi-dumps/platform" revision="7a0f71a70ff4ea9e5b4ceb97749af1e2619b37f5" upstream="master"/>
-  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/abi-dumps/vndk" path="prebuilts/abi-dumps/vndk" revision="70ad78f6c228cfd48329b358ce1912769313bd02" upstream="master"/>
-  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/android-emulator" path="prebuilts/android-emulator" revision="27dfcd014fa045e0775505bee0a7703ba777a2fe" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/asuite" path="prebuilts/asuite" revision="0489a64c61b66cc7cb6685c19a289bc15e9fc017" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/build-tools" path="prebuilts/build-tools" revision="78ae13f38c920a32db8a9c57ceae247a9faead0d" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/bundletool" path="prebuilts/bundletool" revision="01648ca9bfe0ff359452d474144e323304c78ca2" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/checkcolor" path="prebuilts/checkcolor" revision="3b8d4bd627d5503df912222d2fc1708bbafc756d" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/checkstyle" path="prebuilts/checkstyle" revision="b770c451762c8efb1dcf93fa9a14ad42bc550e30" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/clang-tools" path="prebuilts/clang-tools" revision="d9fe13dddce4b2412c5b4e09a52c0c35fd2e3893" upstream="master"/>
-  <project clone-depth="1" groups="pdk,darwin" name="platform/prebuilts/clang/host/darwin-x86" path="prebuilts/clang/host/darwin-x86" revision="a19265e4bc3e6695fc406dda4b30488032d27329" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/clang/host/linux-x86" path="prebuilts/clang/host/linux-x86" revision="4ca031977e25dc948c4f5bdf941a77e39f43fb37" upstream="master"/>
-  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/devtools" path="prebuilts/devtools" revision="bc11a72a91685bb0a35e7ecf10ffcba4e07558bd" upstream="master"/>
-  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/fuchsia_sdk" path="prebuilts/fuchsia_sdk" revision="12c41f24a38aefda3c5dda0dd513945b616cd765" upstream="master"/>
-  <project clone-depth="1" groups="pdk,darwin,arm" name="platform/prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9" path="prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9" revision="8870276337d5e4fd6cd9af12d8249211b62f8c0b" upstream="master"/>
-  <project clone-depth="1" groups="pdk,darwin,arm" name="platform/prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9" path="prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9" revision="d71b4832d68d31aa93d1817a46b81dff35416a40" upstream="master"/>
-  <project clone-depth="1" groups="pdk,darwin" name="platform/prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1" path="prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1" revision="324e47fb5c8ab208c31e8551ac5e95043c20b095" upstream="master"/>
-  <project clone-depth="1" groups="pdk,darwin,mips" name="platform/prebuilts/gcc/darwin-x86/mips/mips64el-linux-android-4.9" path="prebuilts/gcc/darwin-x86/mips/mips64el-linux-android-4.9" revision="3ca8483f7628e39a427ad89e447f088aeb7fe5d7" upstream="master"/>
-  <project clone-depth="1" groups="pdk,darwin,x86" name="platform/prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9" path="prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9" revision="c3205fa6859d299557c34fac6d5ba912e1a92e36" upstream="master"/>
-  <project clone-depth="1" groups="pdk,linux,arm" name="platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" revision="b4a601fe7b1702b155a60b97e6fc89aa0b10f08c" upstream="master"/>
-  <project clone-depth="1" groups="pdk,linux,arm" name="platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9" path="prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9" revision="2e141d2c73179ec9997170e4c2fe2e282f4d146b" upstream="master"/>
-  <project clone-depth="1" groups="pdk,linux" name="platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" revision="f26a67a6c141c94f84bd497f2c317dd1658fe99a" upstream="master"/>
-  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8" path="prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8" revision="da4951908cf7fcaeff9e041d9f244c8921e8c803" upstream="master"/>
-  <project clone-depth="1" groups="pdk,linux,mips" name="platform/prebuilts/gcc/linux-x86/mips/mips64el-linux-android-4.9" path="prebuilts/gcc/linux-x86/mips/mips64el-linux-android-4.9" revision="ed0bad798ddbe09c7d89555b75974863458166fb" upstream="master"/>
-  <project clone-depth="1" groups="pdk,linux,x86" name="platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" path="prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" revision="53448c04ae904f7a978f35b4fa0564364413c662" upstream="master"/>
-  <project clone-depth="1" groups="darwin,pdk" name="platform/prebuilts/gdb/darwin-x86" path="prebuilts/gdb/darwin-x86" revision="e2a5df212edc8c9e00127a27f918ab25f506bb30" upstream="master"/>
-  <project clone-depth="1" groups="linux,pdk" name="platform/prebuilts/gdb/linux-x86" path="prebuilts/gdb/linux-x86" revision="478a6310c41b5fc3db8f714982684758b5e16e82" upstream="master"/>
-  <project clone-depth="1" groups="darwin,pdk,tradefed" name="platform/prebuilts/go/darwin-x86" path="prebuilts/go/darwin-x86" revision="1a68b8d2b99293ce55cd444bb764abdd29100463" upstream="master"/>
-  <project clone-depth="1" groups="linux,pdk,tradefed" name="platform/prebuilts/go/linux-x86" path="prebuilts/go/linux-x86" revision="537e2072e1affb379b4da1ecfbcb41a270544d1a" upstream="master"/>
-  <project clone-depth="1" groups="pdk,pdk-cw-fs,pdk-fs" name="platform/prebuilts/gradle-plugin" path="prebuilts/gradle-plugin" revision="2c90687d5c48ad7cd5abb4b19ce92f2b088fef2b" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/jdk/jdk11" path="prebuilts/jdk/jdk11" revision="38b397ddfe0c3339623cec843c810bd938de9a89" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/jdk/jdk8" path="prebuilts/jdk/jdk8" revision="74e4f1844dfa9b8df9e0fe2ff34a2ecc24d52b07" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/jdk/jdk9" path="prebuilts/jdk/jdk9" revision="3447ef32fa4961229942fa345c8707c7f9e00246" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/ktlint" path="prebuilts/ktlint" revision="610ca1db29493fdcd3789d8093a6bc96f3bf000b" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/manifest-merger" path="prebuilts/manifest-merger" revision="c61778dd7fdef4194cf8592f9d4a7ead9bb16811" upstream="master"/>
-  <project clone-depth="1" groups="pdk-cw-fs,pdk-fs" name="platform/prebuilts/maven_repo/android" path="prebuilts/maven_repo/android" revision="c78944d200cb347e366b1e9adfc0f7ebfe5d8a24" upstream="master"/>
-  <project clone-depth="1" groups="pdk-cw-fs,pdk-fs" name="platform/prebuilts/maven_repo/bumptech" path="prebuilts/maven_repo/bumptech" revision="a287cd13b51f44084b8bdb5134f2ae21bc75ae3a" upstream="master"/>
-  <project clone-depth="1" name="platform/prebuilts/maven_repo/google-play-service-client-libraries-3p" path="prebuilts/maven_repo/google-play-service-client-libraries-3p" revision="427e6e2267fd43142ddbd1a87268e0112ddb9b11" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/misc" path="prebuilts/misc" revision="17e050632085face44b5646052bc3e50ab166942" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/module_sdk/art" path="prebuilts/module_sdk/art" revision="0a68152386e56eab7fce3813aca01301e197b17b" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/ndk" path="prebuilts/ndk" revision="878a55981d45148b94e7c13a4fa99283fc5b72c8" upstream="master"/>
-  <project clone-depth="1" groups="darwin,pdk,pdk-cw-fs,pdk-fs" name="platform/prebuilts/python/darwin-x86/2.7.5" path="prebuilts/python/darwin-x86/2.7.5" revision="0c5958b1636c47ed7c284f859c8e805fd06a0e63" upstream="master"/>
-  <project clone-depth="1" groups="linux,pdk,pdk-cw-fs,pdk-fs" name="platform/prebuilts/python/linux-x86/2.7.5" path="prebuilts/python/linux-x86/2.7.5" revision="53add29eb7b4eaa9e128e3ec84eac9e65cf4c986" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/qemu-kernel" path="prebuilts/qemu-kernel" revision="3204849eb2b3cb9f144fbeededab803a53893d64" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/r8" path="prebuilts/r8" revision="244c006750d8f5a2b061d2600d1d567e4f7f815d" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/remoteexecution-client" path="prebuilts/remoteexecution-client" revision="753b0b68cb71d8b4185e6a677f5b52b082becc58" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/runtime" path="prebuilts/runtime" revision="ce1159f30c37d77f605e34a32303d319c5f5e930" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/rust" path="prebuilts/rust" revision="13cef98f0801f414884ec73627a6132fb686fb78" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/sdk" path="prebuilts/sdk" revision="09debd45744051129cdc385cc627345965277664" upstream="master"/>
-  <project clone-depth="1" groups="pdk,tools" name="platform/prebuilts/tools" path="prebuilts/tools" revision="7489db78ef99882743dc017601c58997dc1d4dfd" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/vndk/v27" path="prebuilts/vndk/v27" revision="55f3d3decf38fdffbfbacdc4fc06f62e359ac6b1" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/vndk/v28" path="prebuilts/vndk/v28" revision="4232fc6eedd7282b9449cab06b0207925c67bb8a" upstream="master"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/vndk/v29" path="prebuilts/vndk/v29" revision="f7273cd11faf2c5899d878d534cb6917de86dbf3" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/sdk" path="sdk" revision="3bbeaa3d2614c7640bb851630c1ff5827b90a1b8" upstream="master">
+  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/display" path="hardware/qcom/sm8150/display" revision="c81971c53ae7f375919de20a9562d568aa2ba02d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/gps" path="hardware/qcom/sm8150/gps" revision="84f7ef4712ea508a15bb5a725bd4d2d7dc80f8df" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/media" path="hardware/qcom/sm8150/media" revision="4aa3dcb2b9000c4b1414aeee80b65a6c8b62b7e9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/thermal" path="hardware/qcom/sm8150/thermal" revision="015a5444dae8fed21ebbc23878c5c460ab10ee45" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/vr" path="hardware/qcom/sm8150/vr" revision="83c0155ec713872c7096a7610683e0c99e1f9803" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="qcom_wlan,pdk-qcom" name="platform/hardware/qcom/wlan" path="hardware/qcom/wlan" revision="db4bd178589558fdf63c7ce52b754c7219568d82" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/hardware/ril" path="hardware/ril" revision="1f9ebb19717e5a1d2dee987ed0edf62b00967cc9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/hardware/st/nfc" path="hardware/st/nfc" revision="e66bed746f3d685cb3df9cfc61beec5ed9b35080" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/hardware/st/secure_element" path="hardware/st/secure_element" revision="7efa833cdaf48eebccefc174ace67756e82e050f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/hardware/ti/am57x" path="hardware/ti/am57x" revision="2fb5135b44a11ea3b586d7cbf1d6bb99940c6044" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/libcore" path="libcore" revision="66083558ed9321e68afda9d91f4f1e8a714e617f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/libnativehelper" path="libnativehelper" revision="209c218d24857894cd28f9b5a29c7b047a7fb4f3" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/BasicSmsReceiver" path="packages/apps/BasicSmsReceiver" revision="eba2cfeb735825fd433cedf46b5c15913ab58543" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/Bluetooth" path="packages/apps/Bluetooth" revision="1a78b17f01e3d2e918c8e95bd918050f0fe096e9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Browser2" path="packages/apps/Browser2" revision="37652f79d1a115bc2d920a68ad6846a23107c660" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Calendar" path="packages/apps/Calendar" revision="dba170b33f5e5b607bd2d98b3f5bbda9bb68ad0e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Camera2" path="packages/apps/Camera2" revision="1eecb545d05126c250a686227ca0d10b8ef20e22" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/Cluster" path="packages/apps/Car/Cluster" revision="201a0667b38db0ef2c09bf1dac216d5983501898" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/Dialer" path="packages/apps/Car/Dialer" revision="531786268d2800ebb4e476a33109e32835a99b2d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/Hvac" path="packages/apps/Car/Hvac" revision="383d6caa20abadef0810676685e952af7a3ef1a9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/LatinIME" path="packages/apps/Car/LatinIME" revision="3cf79c7e126dcc52a99ea6f2932717d6917df665" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/Launcher" path="packages/apps/Car/Launcher" revision="c1b369808c4fa5101ab7f66447fbcaa2ff893e46" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/LensPicker" path="packages/apps/Car/LensPicker" revision="577467677743ead552d45ec88688e14ac2c11066" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/LinkViewer" path="packages/apps/Car/LinkViewer" revision="f21549ef464c73d389e70fffd49568be4045d1aa" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/LocalMediaPlayer" path="packages/apps/Car/LocalMediaPlayer" revision="2c0d6f6e6615cffd5a386e04929de9433bb4ab8e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/Media" path="packages/apps/Car/Media" revision="949f991f36c8ef12d582f4efc57e83bb7e20d00d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/Messenger" path="packages/apps/Car/Messenger" revision="119d567a09ed591a08036f670684afe62834ee1c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/Notification" path="packages/apps/Car/Notification" revision="b6b77ef7b1828eed7ebf6219f5270f29b3c1626a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/Overview" path="packages/apps/Car/Overview" revision="18069cf7b505946bdf5d1eb3566c7c8f201b1b9d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/Radio" path="packages/apps/Car/Radio" revision="09bd54bc606d7a8545a713e4531dded9ed7f96aa" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/Settings" path="packages/apps/Car/Settings" revision="08b430cd07bd36b8d6088347bc3a98b66394f1a2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/Stream" path="packages/apps/Car/Stream" revision="65fcbceb6cadefcd715b7b61c0d08c8279408343" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/SystemUpdater" path="packages/apps/Car/SystemUpdater" revision="ad64abe7c7ada0deca3d861a68d72ca770b333ff" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/libs" path="packages/apps/Car/libs" revision="b060f81aa18c7a86df6e0372d476eba0837c8c2f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Car/tests" path="packages/apps/Car/tests" revision="614c639c73544813d59ee0490a2b934cae7210b5" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/CarrierConfig" path="packages/apps/CarrierConfig" revision="11cd811e5440615bd94b5f633b545c540a64e8a2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/CellBroadcastReceiver" path="packages/apps/CellBroadcastReceiver" revision="5582bbbad446f36039d0590b35dbacb35e03d2ad" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/CertInstaller" path="packages/apps/CertInstaller" revision="dc69e17d4f15525c8ba3d3edfef8446139e7c7fd" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Contacts" path="packages/apps/Contacts" revision="6b25dfb8823b9a702c168bcaa5f819b00f6af030" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/DeskClock" path="packages/apps/DeskClock" revision="81665216b1b4332dff01cd0639aaa7a827942e0b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/packages/apps/DevCamera" path="packages/apps/DevCamera" revision="451c252993bad8bda17ae8e9224b863eca7e4668" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Dialer" path="packages/apps/Dialer" revision="9cbdb82e0d061084cc9c6cf8e80768711350a541" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/DocumentsUI" path="packages/apps/DocumentsUI" revision="c4d16b31985ceea7ea4a2b6511050b62b9d3aae0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/EmergencyInfo" path="packages/apps/EmergencyInfo" revision="3cca84dff99da9b8fcfad5d3edecd33131b2a2d8" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Gallery" path="packages/apps/Gallery" revision="391d25e4a27dd73f38a5bc20d96717360e09626f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Gallery2" path="packages/apps/Gallery2" revision="dd8c3a44c794023394750778a0b9287dd281f220" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/HTMLViewer" path="packages/apps/HTMLViewer" revision="10a42cbd4d9993c7da4cbe15c2f20e7e145e8b3b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/KeyChain" path="packages/apps/KeyChain" revision="7704eee9d1604a25d3bfab2c2cb14f17e7ff8226" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Launcher3" path="packages/apps/Launcher3" revision="83fce3a3c634fd6dd9cc6aaedd30fbb14f713e18" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/LegacyCamera" path="packages/apps/LegacyCamera" revision="8a3c835ccadf8e1978f0b87cdfd86d3c5c73040b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/ManagedProvisioning" path="packages/apps/ManagedProvisioning" revision="189515d52354cb72336c3e3d1d709f041c350e2d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Messaging" path="packages/apps/Messaging" revision="f19e916a0d4ffd95e36c5203f5e04887e47a087e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Music" path="packages/apps/Music" revision="17f7086ed297f7b067571cd1ba4cee042f4b8d44" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/MusicFX" path="packages/apps/MusicFX" revision="c7ce7324e34c37f10d68563eaf28057185ae4487" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="apps_nfc,pdk-fs" name="platform/packages/apps/Nfc" path="packages/apps/Nfc" revision="3338647f4bd90bda21f14b918c7dd6dc3b0f8f5c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/OneTimeInitializer" path="packages/apps/OneTimeInitializer" revision="737b0d2daabf33a458ed754e045b2f0e2b65da70" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/PackageInstaller" path="packages/apps/PermissionController" revision="8ccc0d9973bf7173f4da21b62a9f6f0f3ecef582" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/PhoneCommon" path="packages/apps/PhoneCommon" revision="55752cad3b0b8694d3ff3fd312a7e3ca7c7803a8" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Protips" path="packages/apps/Protips" revision="277f2db1a9099d5aaf96d4f3ca8daaeeeeef4e6f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Provision" path="packages/apps/Provision" revision="7623fb5bc7c81b6b1f4d0ac498a256b31ca3988a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/QuickSearchBox" path="packages/apps/QuickSearchBox" revision="5fd7ab4b450b89cd2322949f52866f6fef70a884" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/SafetyRegulatoryInfo" path="packages/apps/SafetyRegulatoryInfo" revision="ee11b572bcdbcaaae96c32bafc0fd5b3122ddb90" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/SampleLocationAttribution" path="packages/apps/SampleLocationAttribution" revision="414210769cbe3ab244ec4af9eef1648e4933f863" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="apps_se,pdk-fs" name="platform/packages/apps/SecureElement" path="packages/apps/SecureElement" revision="d87a6d2ea638759849ad7b7da12ae79664c9f054" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Settings" path="packages/apps/Settings" revision="177ce8f0171d21067af478d8ece9c510ad4f9dc1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/SettingsIntelligence" path="packages/apps/SettingsIntelligence" revision="093fef6b5cdff666c92c9a3cad7a79408c2499c9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/SoundRecorder" path="packages/apps/SoundRecorder" revision="9a077af94ced8144ec87ec758c378da9b30274fa" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/SpareParts" path="packages/apps/SpareParts" revision="f3d46ceeecd71c5555939f32643c18c78ae7909f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="apps_stk,pdk-fs" name="platform/packages/apps/Stk" path="packages/apps/Stk" revision="d5ecab587493e3ca973f733bbd43437fffae373c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/StorageManager" path="packages/apps/StorageManager" revision="02a1b39c931f6dcba726e958828b7c634b87a914" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/packages/apps/TV" path="packages/apps/TV" revision="c2f5cf30d34099f33c9f8ca3e1bca2db2cab8bed" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Tag" path="packages/apps/Tag" revision="2b4278b9a4c3b4ca3521acdc1cc3ab24447b4bad" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Terminal" path="packages/apps/Terminal" revision="4d4e9490fdd512668ac0d47764f3eeb19504a6d2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/packages/apps/Test/connectivity" path="packages/apps/Test/connectivity" revision="4ca008b37a6273463818432584fa6f437671bacb" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/ThemePicker" path="packages/apps/ThemePicker" revision="91fbf0a0a13b42bb750e030dcc77c5e33ca4c45a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/packages/apps/TimeZoneData" path="packages/apps/TimeZoneData" revision="fe56ba08845f1d6d7aa5edb6efde71e6fe31c8f1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/packages/apps/TimeZoneUpdater" path="packages/apps/TimeZoneUpdater" revision="409af215603faf242cfa66d61125b7f40e32e69f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/Traceur" path="packages/apps/Traceur" revision="81bc752ebb3e943fe8908ea7bbbb9bed7f49d6a2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/TvSettings" path="packages/apps/TvSettings" revision="ef324dc7ebd668ea86f065b3e242083d62a9e3f8" upstream="refs/tags/android-r-preview-2"/>
+  <project name="platform/packages/apps/UniversalMediaPlayer" path="packages/apps/UniversalMediaPlayer" revision="73aa04b4639688674712d18b65b3121a7f49e20a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/WallpaperPicker" path="packages/apps/WallpaperPicker" revision="3252a805b696085ec0667449415e7cb93422d7aa" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/apps/WallpaperPicker2" path="packages/apps/WallpaperPicker2" revision="ef69302aa0f4a933f01106734f96d2540487e39b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/inputmethods/LatinIME" path="packages/inputmethods/LatinIME" revision="fc2bc1053014d88a1052fcec9b206845bcf5ab4e" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/inputmethods/LeanbackIME" path="packages/inputmethods/LeanbackIME" revision="e61d19e1b6695d83d77516061934bfbbe1bfbfd4" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/packages/modules/ArtPrebuilt" path="packages/modules/ArtPrebuilt" revision="491a40e7de77dac8666f05aab45e6e71e57ceb49" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/CaptivePortalLogin" path="packages/modules/CaptivePortalLogin" revision="d7985142ab683cdbffb2b1636b2be9b52ec5cfa3" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/packages/modules/CellBroadcastService" path="packages/modules/CellBroadcastService" revision="65ba9fdbfbe87eb320c3aa66d721736dc1802aa2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/Cronet" path="packages/modules/Cronet" revision="436325eb5c8fbe70975fe0546afe88d5288ff3ec" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/DnsResolver" path="packages/modules/DnsResolver" revision="361bf8b3e0465cc8b87b8a6960b73b1cb9f202d1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/ExtServices" path="packages/modules/ExtServices" revision="24702c49bd002df93a34ce6b2b375a5de3d62518" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/packages/modules/ModuleMetadata" path="packages/modules/ModuleMetadata" revision="bf198f3182e53f3d1dc9d061f558656e59f5d4c8" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/NetworkPermissionConfig" path="packages/modules/NetworkPermissionConfig" revision="83bdb339c9e5781eb9f37209e8ec58d000081fb5" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/NetworkStack" path="packages/modules/NetworkStack" revision="3fdd605b8e26a764dc1eab7aa0de7a8e884561c9" upstream="refs/tags/android-r-preview-2"/>
+  <project name="platform/packages/modules/TestModule" path="packages/modules/TestModule" revision="3523a2f0f9b12d4e60374af63aae14f75a2b4c10" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/vndk" path="packages/modules/vndk" revision="90677a3e0a3617fabc2e632c717872e56c026ef9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/providers/BlockedNumberProvider" path="packages/providers/BlockedNumberProvider" revision="4e72370ad033e4754ba71520a01dc9743b4cc59f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/providers/BookmarkProvider" path="packages/providers/BookmarkProvider" revision="66d866abdf7184af7a98edce18012fc33c41b623" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/CalendarProvider" path="packages/providers/CalendarProvider" revision="305f57acae3db551f90971ed7c635fea7647ed66" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/providers/CallLogProvider" path="packages/providers/CallLogProvider" revision="b17d05f2f416a4992e08184935a729b5e88e1fc2" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/ContactsProvider" path="packages/providers/ContactsProvider" revision="c6e8d21247c1ebf745833ed8ea9d5e7af539395a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/DownloadProvider" path="packages/providers/DownloadProvider" revision="3ebb0957aeb2e11f11ae19dc868130bc70daaae8" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/MediaProvider" path="packages/providers/MediaProvider" revision="84ad2d4e371dca6809b5a9d1d62fb4081bd09d81" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/providers/PartnerBookmarksProvider" path="packages/providers/PartnerBookmarksProvider" revision="9c3b541b4357011de2047a2e24f92a63c6d8d8a0" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/TelephonyProvider" path="packages/providers/TelephonyProvider" revision="1fc9a4694f60cd04b3ae29df9b549a76240955a1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/providers/TvProvider" path="packages/providers/TvProvider" revision="0c3aa5356b0a385b1bc74bd8a14d22943100f293" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/UserDictionaryProvider" path="packages/providers/UserDictionaryProvider" revision="2150129aba45306e8414fbd1088086bc5ced1691" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/screensavers/Basic" path="packages/screensavers/Basic" revision="c8c79a5cc2d34ffc8f1caaee96f2acf26990f3ff" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/screensavers/PhotoTable" path="packages/screensavers/PhotoTable" revision="3996832dee995b9570279d5d448eac7f5341d890" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/AlternativeNetworkAccess" path="packages/services/AlternativeNetworkAccess" revision="27bb99ed09b02550ddacc80e1790ea1a06039172" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/BuiltInPrintService" path="packages/services/BuiltInPrintService" revision="63a08c4baff048870e8fb32f09e56e67d46b5938" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Car" path="packages/services/Car" revision="d92dbcf817c50b5a8b193ff024f8ea67db62e9a7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Mms" path="packages/services/Mms" revision="20ea0d453647812b6aef981af279c1064f4f0a5c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Telecomm" path="packages/services/Telecomm" revision="e2c6f6798fbf7d23387a76eaae720ad4c5f38cd3" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Telephony" path="packages/services/Telephony" revision="67be8c1973a96ed1a56e0baa6b7bcb8a682dc746" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs" name="platform/packages/wallpapers/LivePicker" path="packages/wallpapers/LivePicker" revision="b9c3420f97fca7f83ab2bb6880c145541508fad3" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/pdk" path="pdk" revision="59deedc9c468ce8ae0f10e9c30742fd6f3ac82b7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-fs,pdk-cw-fs,cts" name="platform/platform_testing" path="platform_testing" revision="c625f5c792f10144d142e959d2bee308beafff46" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/abi-dumps/ndk" path="prebuilts/abi-dumps/ndk" revision="6adfc3ebeda6a5e80cea7cec249188f0b6e5d5b9" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/abi-dumps/platform" path="prebuilts/abi-dumps/platform" revision="4d2645a962ad6a3d5d9b13e66a13d8bc93195b6b" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/abi-dumps/vndk" path="prebuilts/abi-dumps/vndk" revision="f0f548cc48d18c9e07e6dd6675340f83cc12bf0b" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/android-emulator" path="prebuilts/android-emulator" revision="5b8315ad2903b941d436dc53d6560440983247f1" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/asuite" path="prebuilts/asuite" revision="eeb9d4f086eef086bf6bf2ec7b920f2ce98dbb7a" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/build-tools" path="prebuilts/build-tools" revision="6327989d4a9236f59b0db23d43dfeab8ab304d92" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/bundletool" path="prebuilts/bundletool" revision="9ff8e33f4be34cf9f0bfbfb618f9b60d26cfd66e" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/checkcolor" path="prebuilts/checkcolor" revision="f61c4b89ebb01a5841dee71a534e9d602b9a7377" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/checkstyle" path="prebuilts/checkstyle" revision="2e69c77cd636a442ea9f13c5b256cb0ae773efaf" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/clang-tools" path="prebuilts/clang-tools" revision="58d9f7e35de5e35249747223c1acc573d6c08581" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk,darwin" name="platform/prebuilts/clang/host/darwin-x86" path="prebuilts/clang/host/darwin-x86" revision="a7cc8f166048f3570c3296d3bbc63765789e8c1a" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/clang/host/linux-x86" path="prebuilts/clang/host/linux-x86" revision="99a57e03ec6100787d672d09690b0cdd1ce86931" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/devtools" path="prebuilts/devtools" revision="bc11a72a91685bb0a35e7ecf10ffcba4e07558bd" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/fuchsia_sdk" path="prebuilts/fuchsia_sdk" revision="12c41f24a38aefda3c5dda0dd513945b616cd765" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk,darwin,arm" name="platform/prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9" path="prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9" revision="b9c851f0e94537656849e1c839020459250bb274" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk,darwin,arm" name="platform/prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9" path="prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9" revision="24f28106e56e066850673590024592b17468fb32" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk,darwin" name="platform/prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1" path="prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1" revision="b616fc20ee024ace07f39b13a1f5a2bbdb67f8f7" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk,darwin,mips" name="platform/prebuilts/gcc/darwin-x86/mips/mips64el-linux-android-4.9" path="prebuilts/gcc/darwin-x86/mips/mips64el-linux-android-4.9" revision="03335dbecf7acbe1abbf77cb6f148498b5f25133" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk,darwin,x86" name="platform/prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9" path="prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9" revision="5f6784551ded13db5cb9894acc9ec2a1090cb65c" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk,linux,arm" name="platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" revision="2db20c200c5fae57489ffbfce40dc501e8fb0722" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk,linux,arm" name="platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9" path="prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9" revision="5dda5880238707c790ead9be6dde1d5fe79cce09" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk,linux" name="platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" revision="4533a4d0efa68949dc3c0dfec00214feaddd6c7b" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8" path="prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8" revision="3cbae8d4e0140abbfa0e120567ef1d5b24b3f8d2" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk,linux,mips" name="platform/prebuilts/gcc/linux-x86/mips/mips64el-linux-android-4.9" path="prebuilts/gcc/linux-x86/mips/mips64el-linux-android-4.9" revision="c3db20db1154efe9ae3460f40f654783f79c7e97" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk,linux,x86" name="platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" path="prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" revision="516fb636454e34e39c2ee7729183b07194bfe7c0" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="darwin,pdk" name="platform/prebuilts/gdb/darwin-x86" path="prebuilts/gdb/darwin-x86" revision="284b55fac5598bcd1f986e69b7556befdd663c53" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="linux,pdk" name="platform/prebuilts/gdb/linux-x86" path="prebuilts/gdb/linux-x86" revision="9453bfa625bc14025e6aa50dc296dd82ebbfb8c6" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="darwin,pdk,tradefed" name="platform/prebuilts/go/darwin-x86" path="prebuilts/go/darwin-x86" revision="3d0e53b900fd8e721733b7d54a1acef694a47333" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="linux,pdk,tradefed" name="platform/prebuilts/go/linux-x86" path="prebuilts/go/linux-x86" revision="3affa1d2632b48f9589ab4c91ca1b825d7c73a87" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk,pdk-cw-fs,pdk-fs" name="platform/prebuilts/gradle-plugin" path="prebuilts/gradle-plugin" revision="87ea0d25547bb9461641dd137f9f82ae6a31dd92" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/jdk/jdk11" path="prebuilts/jdk/jdk11" revision="bffdb0223ff2898246bbd14a6b17d8920ac600de" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/jdk/jdk8" path="prebuilts/jdk/jdk8" revision="74e4f1844dfa9b8df9e0fe2ff34a2ecc24d52b07" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/jdk/jdk9" path="prebuilts/jdk/jdk9" revision="3447ef32fa4961229942fa345c8707c7f9e00246" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/ktlint" path="prebuilts/ktlint" revision="fddd5e7beee2d5aba454e8a0fe38700a6aae7d8a" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/manifest-merger" path="prebuilts/manifest-merger" revision="c61778dd7fdef4194cf8592f9d4a7ead9bb16811" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk-cw-fs,pdk-fs" name="platform/prebuilts/maven_repo/android" path="prebuilts/maven_repo/android" revision="ecc2406087855bedf2d8e8e528ab0b2b4e6c7298" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk-cw-fs,pdk-fs" name="platform/prebuilts/maven_repo/bumptech" path="prebuilts/maven_repo/bumptech" revision="a9302911c0f0c2308d0bfa09ef93173a438233bb" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/misc" path="prebuilts/misc" revision="d635463bac1eff2564dfe59319ce25e610288c1c" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/module_sdk/art" path="prebuilts/module_sdk/art" revision="0a68152386e56eab7fce3813aca01301e197b17b" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/ndk" path="prebuilts/ndk" revision="c41613541a7c15d1a676f53503e630913f0ebc76" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="darwin,pdk,pdk-cw-fs,pdk-fs" name="platform/prebuilts/python/darwin-x86/2.7.5" path="prebuilts/python/darwin-x86/2.7.5" revision="0c5958b1636c47ed7c284f859c8e805fd06a0e63" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="linux,pdk,pdk-cw-fs,pdk-fs" name="platform/prebuilts/python/linux-x86/2.7.5" path="prebuilts/python/linux-x86/2.7.5" revision="53add29eb7b4eaa9e128e3ec84eac9e65cf4c986" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/qemu-kernel" path="prebuilts/qemu-kernel" revision="973acaa875014fd42374d7f8bfc9525621c984ae" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/r8" path="prebuilts/r8" revision="758bb406983f1acac24b8581e0ce3edb1bdb5934" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/remoteexecution-client" path="prebuilts/remoteexecution-client" revision="588195b9236632d81e914cb7b40bee1bcc376ed4" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/runtime" path="prebuilts/runtime" revision="204609cdf43ecef9bf3d76ed4820cadd4f42a7dd" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/rust" path="prebuilts/rust" revision="d803dd208b4ecd722b75ef6083d30142a6520832" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/sdk" path="prebuilts/sdk" revision="068d145c4e940e0de15b32c7ba2e99d2e03be542" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk,tools" name="platform/prebuilts/tools" path="prebuilts/tools" revision="53a1b1e054e85d6544d4291604c29d0214541fa0" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/vndk/v27" path="prebuilts/vndk/v27" revision="ff2c01a1b01ef3e2529561293cc5468b09ddea64" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/vndk/v28" path="prebuilts/vndk/v28" revision="d6ed2d7c6d55e3ad3cba372233160b812c250e2e" upstream="refs/tags/android-r-preview-2"/>
+  <project clone-depth="1" groups="pdk" name="platform/prebuilts/vndk/v29" path="prebuilts/vndk/v29" revision="b43d21914ddad9107202fd22b6719505aba9bab1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs" name="platform/sdk" path="sdk" revision="b0dcd4a2c77ad06abaf0870d0d3029432b1756ae" upstream="refs/tags/android-r-preview-2">
     <linkfile dest="frameworks/support/README.md" src="current/androidx-README.md"/>
   </project>
-  <project groups="pdk" name="platform/system/apex" path="system/apex" revision="5374de3d8565493fc3a31054080a71d1d8c16c2d" upstream="master"/>
-  <project groups="pdk" name="platform/system/bpf" path="system/bpf" revision="b479fd6a9f2b96099e86fd1a47002de904340c4f" upstream="master"/>
-  <project groups="pdk" name="platform/system/bpfprogs" path="system/bpfprogs" revision="8acde7e93168f176f5e5f409be22c534a0b3d890" upstream="master"/>
-  <project groups="pdk" name="platform/system/bt" path="system/bt" revision="94193de29892b20c15e03e2e8b75cedfc6ca1803" upstream="master"/>
-  <project groups="pdk" name="platform/system/ca-certificates" path="system/ca-certificates" revision="75d1036dedaaacd1e06223377fd7b6b4aa568414" upstream="master"/>
-  <project groups="pdk" name="platform/system/chre" path="system/chre" revision="685d9f308f0f4d42514df25b3abcf85006f4b456" upstream="master"/>
-  <project groups="pdk" name="platform/system/connectivity/wificond" path="system/connectivity/wificond" revision="b690a5bb31c01102f886f4327abeeb311842cc76" upstream="master"/>
-  <project groups="pdk" name="platform/system/connectivity/wifilogd" path="system/connectivity/wifilogd" revision="5c472914a7cffbb8b7689873306bb63a243ca91d" upstream="master"/>
-  <project groups="pdk" name="platform/system/core" path="system/core" revision="0a86d01080f6916864f76bec523b4d8cbacb0356" upstream="master"/>
-  <project groups="pdk" name="platform/system/extras" path="system/extras" revision="4f94e91035fd4b0275f7559be3970ea971c0f826" upstream="master"/>
-  <project groups="pdk" name="platform/system/gatekeeper" path="system/gatekeeper" revision="e583844fc9c6d6dbb293f8694fd66cd5a4794c02" upstream="master"/>
-  <project groups="pdk" name="platform/system/gsid" path="system/gsid" revision="32af40977e9153036141a785e09a1e926584ff74" upstream="master"/>
-  <project groups="pdk" name="platform/system/hardware/interfaces" path="system/hardware/interfaces" revision="f3dd37f5318e279949364bcc953fdd98dc2933ef" upstream="master"/>
-  <project groups="pdk" name="platform/system/hwservicemanager" path="system/hwservicemanager" revision="193bfb400a25498613449725c61f985aa5ce16b3" upstream="master"/>
-  <project groups="pdk" name="platform/system/incremental_delivery" path="system/incremental_delivery" revision="471a1b767e72d9069b542bbfc9e4978ab0267ab3" upstream="master"/>
-  <project groups="pdk" name="platform/system/iorap" path="system/iorap" revision="981cac64d22c71f9dab2ffd1a3aee06720896960" upstream="master"/>
-  <project groups="pdk" name="platform/system/keymaster" path="system/keymaster" revision="12bd1461eab4de77ff1e58bff2dfdd151e118698" upstream="master"/>
-  <project groups="pdk" name="platform/system/libartpalette" path="system/libartpalette" revision="3bdec1c3f2d0246f47fda1adca24d77f4239c7c3" upstream="master"/>
-  <project groups="pdk" name="platform/system/libfmq" path="system/libfmq" revision="a7121cdb4578e5d94a3aad43cd2c8af7ea9722f6" upstream="master"/>
-  <project groups="pdk" name="platform/system/libhidl" path="system/libhidl" revision="c7998b65098ae26a3b0386c12fdae20864d3c256" upstream="master"/>
-  <project groups="pdk" name="platform/system/libhwbinder" path="system/libhwbinder" revision="59de0c2590b414387f9648aa94a18395c71d365c" upstream="master"/>
-  <project groups="pdk" name="platform/system/libsysprop" path="system/libsysprop" revision="a84edd9e991da9f3a6bc2e8ebbac1b366ec0c1c0" upstream="master"/>
-  <project groups="pdk" name="platform/system/libufdt" path="system/libufdt" revision="715ca232a5b4b870968eceedc332eb84cf312963" upstream="master"/>
-  <project groups="pdk" name="platform/system/libvintf" path="system/libvintf" revision="e73ae654c3b7aad38e8afdabe321b3fc95876d0c" upstream="master"/>
-  <project groups="pdk" name="platform/system/linkerconfig" path="system/linkerconfig" revision="9a3e85c31f7f8f01466fb1c0881e56e18fff980d" upstream="master"/>
-  <project groups="pdk" name="platform/system/media" path="system/media" revision="4b8c34b6a474da587c12c2062909a2796eb667ea" upstream="master"/>
-  <project groups="pdk" name="platform/system/memory/libion" path="system/memory/libion" revision="4dbcbf36570f3e4807687da15ab870d3a79c01c0" upstream="master"/>
-  <project groups="pdk" name="platform/system/memory/libmeminfo" path="system/memory/libmeminfo" revision="e53ba942c03e4ad8d491134df30f025f74bb2ef5" upstream="master"/>
-  <project groups="pdk" name="platform/system/memory/libmemtrack" path="system/memory/libmemtrack" revision="7db7aa7e27abfd79ef6332dd3240e7c437fd21cb" upstream="master"/>
-  <project groups="pdk" name="platform/system/memory/libmemunreachable" path="system/memory/libmemunreachable" revision="b9a01ce9dcd2d6582783b547697ce402bfd3b397" upstream="master"/>
-  <project groups="pdk" name="platform/system/memory/lmkd" path="system/memory/lmkd" revision="ed8fe8465ac371166e286434049a676969ca4590" upstream="master"/>
-  <project groups="pdk" name="platform/system/netd" path="system/netd" revision="b670f124dc0bc9dac2802bb408825411d23000f9" upstream="master"/>
-  <project groups="pdk" name="platform/system/nfc" path="system/nfc" revision="6eb02b94a0b367a230ed8e41b0ac86652cbe76c8" upstream="master"/>
-  <project groups="pdk" name="platform/system/nvram" path="system/nvram" revision="184c1c9a5c39f51f82bdb453afc9cf144f8e4183" upstream="master"/>
-  <project groups="pdk" name="platform/system/security" path="system/security" revision="704895de5601f00898060894c8a88001d4f5e04b" upstream="master"/>
-  <project groups="pdk" name="platform/system/sepolicy" path="system/sepolicy" revision="2af7e0a1fb1b10cf16e7751581438d68c542d307" upstream="master"/>
-  <project groups="pdk" name="platform/system/server_configurable_flags" path="system/server_configurable_flags" revision="2933cce6942776d2ffe0f3d7d64249ca7b8a1084" upstream="master"/>
-  <project groups="pdk" name="platform/system/teeui" path="system/teeui" revision="5caf88f1349538234d7227c004b5a7f202b11d08" upstream="master"/>
-  <project groups="pdk" name="platform/system/testing/gtest_extras" path="system/testing/gtest_extras" revision="14059b1445fd1c4157792ffbfd41bbfb8888e729" upstream="master"/>
-  <project groups="pdk" name="platform/system/timezone" path="system/timezone" revision="8fb811a2a27884cedda2ff0d9415eb31e5e656a1" upstream="master"/>
-  <project groups="pdk" name="platform/system/tools/aidl" path="system/tools/aidl" revision="e74c86d7971bbff834a4ca2f65bca98936e79419" upstream="master"/>
-  <project groups="pdk" name="platform/system/tools/hidl" path="system/tools/hidl" revision="927c1d297f3f27d9b6f005aee13e01e74b447866" upstream="master"/>
-  <project groups="pdk" name="platform/system/tools/mkbootimg" path="system/tools/mkbootimg" revision="f91a1565353daaef4aaaed7e081b156c27130aea" upstream="master"/>
-  <project groups="pdk" name="platform/system/tools/sysprop" path="system/tools/sysprop" revision="715a69ed2111ec02202645f5a8b5643db7949669" upstream="master"/>
-  <project groups="pdk" name="platform/system/tools/xsdc" path="system/tools/xsdc" revision="0ac92aa590654850397b31ea9cdd78b1ca28aaca" upstream="master"/>
-  <project groups="pdk" name="platform/system/ucontainer" path="system/ucontainer" revision="b63e91330946f9c73e1c72032cfc31d1a8c9bc8f" upstream="master"/>
-  <project groups="pdk" name="platform/system/update_engine" path="system/update_engine" revision="82cd9d3aad1ea0fac770c20a1479c73496df4cab" upstream="master"/>
-  <project groups="pdk" name="platform/system/vold" path="system/vold" revision="6492a6abf64b54b73833907306203871c66b6932" upstream="master"/>
-  <project name="platform/test/app_compat/csuite" path="test/app_compat/csuite" revision="a82698d20c210475ffbb9add00cc8502dc012abc" upstream="master"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/framework" path="test/framework" revision="0de9afdf698b7aabfc263b560a1743f2bb2f1e3a" upstream="master"/>
-  <project groups="pdk" name="platform/test/mlts/benchmark" path="test/mlts/benchmark" revision="73363e85d55bcad349bd69581c6d635e1e320908" upstream="master"/>
-  <project groups="pdk" name="platform/test/mlts/models" path="test/mlts/models" revision="a92852efb52754926c69e9cdbe651de935f55349" upstream="master"/>
-  <project name="platform/test/mts" path="test/mts" revision="5c26902c4ea0b1fcf427a5342c0389e6de0bccba" upstream="master"/>
-  <project groups="cts,pdk-cw-fs,pdk-fs" name="platform/test/suite_harness" path="test/suite_harness" revision="50db6d2bb46140a2a3739be3c09b479da6a51801" upstream="master"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vti/alert" path="test/vti/alert" revision="2270d160e38f0623d708cce36754fe14168dce64" upstream="master"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vti/dashboard" path="test/vti/dashboard" revision="a9bd47e4caa21d535fb89c0e6efe23fa08d25847" upstream="master"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vti/fuzz_test_serving" path="test/vti/fuzz_test_serving" revision="6319e3d94c65669050c49c6ca570096d41823b82" upstream="master"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vti/test_serving" path="test/vti/test_serving" revision="d3bbda3565cfd8348d8a6366f1013a163ed2aaf3" upstream="master"/>
-  <project groups="vts,pdk" name="platform/test/vts" path="test/vts" revision="d00c2ebd4a00ed3912913cc435a900114f26c290" upstream="master"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vts-testcase/fuzz" path="test/vts-testcase/fuzz" revision="0a7f78851f0c1f6054c9a03b45e91861d38e939a" upstream="master"/>
-  <project groups="vts,pdk" name="platform/test/vts-testcase/hal" path="test/vts-testcase/hal" revision="c7d3d07b574df05d15b30ef7652f53d984bc06ec" upstream="master"/>
-  <project groups="vts,pdk" name="platform/test/vts-testcase/hal-trace" path="test/vts-testcase/hal-trace" revision="2695892568f8fade958ec0ec172df8f295ae4112" upstream="master"/>
-  <project groups="vts,pdk" name="platform/test/vts-testcase/kernel" path="test/vts-testcase/kernel" revision="1163a67b72366b147e7d204127646e62f2f376f6" upstream="master"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vts-testcase/nbu" path="test/vts-testcase/nbu" revision="0712e2a442364af77a0b1dda0adf922d1d1447bc" upstream="master"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vts-testcase/performance" path="test/vts-testcase/performance" revision="f0e5dcee43de6f9c44a3872721087d96eaa48273" upstream="master"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vts-testcase/security" path="test/vts-testcase/security" revision="3c5244bb1b7d675683a73a28d28a2922b6f59b21" upstream="master"/>
-  <project groups="vts,pdk" name="platform/test/vts-testcase/vndk" path="test/vts-testcase/vndk" revision="4ac58572556870023bbd9908cffd33d992595b45" upstream="master"/>
-  <project groups="tools,vts,projectarch,pdk,tradefed" name="platform/tools/acloud" path="tools/acloud" revision="14354484cb96f029272523fcb9024cde57297322" upstream="master"/>
-  <project groups="pdk,tools" name="platform/tools/apifinder" path="tools/apifinder" revision="a5efd51e5bbd2e9d30241646ae5d3f979b9065fa" upstream="master"/>
-  <project groups="pdk,tradefed" name="platform/tools/apksig" path="tools/apksig" revision="579dc6de52f17accec3c8d86c2eff1a380249b16" upstream="master"/>
-  <project groups="pdk,tradefed" name="platform/tools/apkzlib" path="tools/apkzlib" revision="bf61dd3c1b8f6ee064aff61e5056e557f1c2c4b3" upstream="master"/>
-  <project groups="pdk" name="platform/tools/asuite" path="tools/asuite" revision="53fc0da9d8df71f43aec4ae136590a685d312205" upstream="master"/>
-  <project groups="pdk" name="platform/tools/currysrc" path="tools/currysrc" revision="0b1b0c9cebde8fbd95e61c86df9ca72c232eb822" upstream="master"/>
-  <project groups="tools,pdk-fs" name="platform/tools/dexter" path="tools/dexter" revision="17c72cc4ecf16e66d4e3f889cc052f0980e3c7ae" upstream="master"/>
-  <project groups="tools" name="platform/tools/doc_generation" path="tools/doc_generation" revision="2878f38f36246144e347a2aab31c28c3f6927e18" upstream="master"/>
-  <project groups="tools" name="platform/tools/external/fat32lib" path="tools/external/fat32lib" revision="2aa98e48614927413550d00c755351b3f68542b4" upstream="master"/>
-  <project groups="tools" name="platform/tools/external_updater" path="tools/external_updater" revision="7063a6942dc31eb46bc5dab981c5dcdaf4009454" upstream="master"/>
-  <project groups="nopresubmit,pdk,tradefed" name="platform/tools/loganalysis" path="tools/loganalysis" revision="1005173314bb8012a10e605219c8568d959f6f3e" upstream="master"/>
-  <project groups="pdk,tools" name="platform/tools/metalava" path="tools/metalava" revision="6912393086b383f3ece8dbbe2a1a7d837d0052fc" upstream="master"/>
-  <project groups="adt-infra,cts,developers,motodev,pdk,tools,tradefed" name="platform/tools/repohooks" path="tools/repohooks" revision="36d2ce62750acc984116f6af9b67b19b23a1afc5" upstream="master"/>
-  <project groups="pdk,tools" name="platform/tools/security" path="tools/security" revision="6f71beb54426f6263afcdc3539362c5e6b9dee3d" upstream="master"/>
-  <project groups="pdk" name="platform/tools/test/connectivity" path="tools/test/connectivity" revision="4f43cb51e143608e3f25a6d5ff4e056ee977560f" upstream="master"/>
-  <project groups="pdk" name="platform/tools/test/graphicsbenchmark" path="tools/test/graphicsbenchmark" revision="146c1e98ff889f7479f372394e3450384a84dd48" upstream="master"/>
-  <project groups="pdk,tradefed" name="platform/tools/tradefederation" path="tools/tradefederation/core" revision="9f0604942523b448a73340d14198d8716ab10e03" upstream="master"/>
-  <project groups="pdk,tradefed" name="platform/tools/tradefederation/contrib" path="tools/tradefederation/contrib" revision="f3cec7589d66e21295d13813f6808ef8d3eaf42a" upstream="master"/>
-  <project groups="tools,pdk" name="platform/tools/treble" path="tools/treble" revision="b4dd792ad29fbfbdbda89e60d23baa7672729f05" upstream="master"/>
-  <project groups="tools,cts,pdk,pdk-cw-fs,pdk-fs" name="platform/tools/trebuchet" path="tools/trebuchet" revision="2c4f274b549922b4a618c767125cccd7dd91be3c" upstream="master"/>
-  <project name="toolchain/benchmark" revision="1fba1825631e6e52dff5b3ceb87a5b439e2acf52" upstream="master"/>
-  <project groups="pdk" name="toolchain/pgo-profiles" revision="9ac9f8b9b4b401ec76c41773742d19713f3e29e4" upstream="master"/>
-  <project groups="pdk-cw-fs,pdk-fs,pdk" name="tools/platform-compat" revision="bf27291688c362e2599409863ae131c7ae99f502" upstream="master"/>
+  <project groups="pdk" name="platform/system/apex" path="system/apex" revision="3d773bca8aa756f8028b811474d2832c545da83d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/bpf" path="system/bpf" revision="6161ff246f648c1375e3a7fd2a271ee18dbc8b43" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/bpfprogs" path="system/bpfprogs" revision="97260028c2b7aa60752ddb301f5d909e4f39431d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/bt" path="system/bt" revision="d781b315cd40da012bacc94ca3c18de932236058" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/ca-certificates" path="system/ca-certificates" revision="f5946ce8e7753603ea9cb97e6851de58d453f169" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/chre" path="system/chre" revision="fdbc68dbd37c96f486f7781aabd2aa401d4ffe44" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/connectivity/wificond" path="system/connectivity/wificond" revision="46509c42de6d1f15ba5b59419d4734d3ea7970fb" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/connectivity/wifilogd" path="system/connectivity/wifilogd" revision="4b31b4738442ba355548d36605a169d9d1fc36ee" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/core" path="system/core" revision="b33afa9d8da88cbda0df1a82358915aa7393899b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/extras" path="system/extras" revision="0b9f8de9be1e37c735d7cf58ad93b851e06a3a83" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/gatekeeper" path="system/gatekeeper" revision="e583844fc9c6d6dbb293f8694fd66cd5a4794c02" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/gsid" path="system/gsid" revision="fc817e25fe44f3c62aa273268d9e2c2e9057699c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/hardware/interfaces" path="system/hardware/interfaces" revision="cd7224246968587cbdb1a16e36be64cd7439b329" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/hwservicemanager" path="system/hwservicemanager" revision="088c39801860788256ff2f4da508cb09c45138a4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/incremental_delivery" path="system/incremental_delivery" revision="471a1b767e72d9069b542bbfc9e4978ab0267ab3" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/iorap" path="system/iorap" revision="806a07b868ac808bbd7ef09c37d6bd180e15de36" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/keymaster" path="system/keymaster" revision="ae3b046f5ad442c1738dd0e258b95b90e4c456f5" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/libartpalette" path="system/libartpalette" revision="894b033578235e26acbb45e5fb65e93b3bdae60a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/libfmq" path="system/libfmq" revision="57103f7e0c1e913bc205b0bc2ce1a39db7b59a1d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/libhidl" path="system/libhidl" revision="330ef560a5f99b54bfd84318c0ac8d79d1b48fff" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/libhwbinder" path="system/libhwbinder" revision="889cf78f80f1035c58513fa2459c6920657e095a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/libsysprop" path="system/libsysprop" revision="2d063546b2802b56ba1938dfc2dfdd12404cf7da" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/libufdt" path="system/libufdt" revision="715ca232a5b4b870968eceedc332eb84cf312963" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/libvintf" path="system/libvintf" revision="94931a3cb52f2f9e823069d3e40b14aa81a4c8bd" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/linkerconfig" path="system/linkerconfig" revision="7587c35384ff8af14528285205910645ff3519c5" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/media" path="system/media" revision="360f362006dab2e06dc5d073630d3a39d4d786af" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/memory/libion" path="system/memory/libion" revision="63b80a458bb656bb7020934178b986001ae2aed9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/memory/libmeminfo" path="system/memory/libmeminfo" revision="15a431bd324beef987fe3569c7da4fad763c11dd" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/memory/libmemtrack" path="system/memory/libmemtrack" revision="22a4769b32dce6f1bc8401a3e9bb806dd7d6fbf9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/memory/libmemunreachable" path="system/memory/libmemunreachable" revision="9f479f24d9ffac9a9c3f8412b30aba438ea47674" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/memory/lmkd" path="system/memory/lmkd" revision="fce58e91653f33ac284b8288b3d946df3845a8c7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/netd" path="system/netd" revision="ed1acb63e7796f87c5c0e30c3e4a47bb3287818d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/nfc" path="system/nfc" revision="8d1816cb12ef7768f7a10a7a95238bd2d7f7d127" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/nvram" path="system/nvram" revision="184c1c9a5c39f51f82bdb453afc9cf144f8e4183" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/security" path="system/security" revision="21b6c38fa099855a88483bcc4960b39eb0446707" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/sepolicy" path="system/sepolicy" revision="c58ad4b82c1701c416e069ecb5eb889c471cd78b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/server_configurable_flags" path="system/server_configurable_flags" revision="94c7eb57618f3a32336bf0d5d46ecd74125f9f97" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/teeui" path="system/teeui" revision="4e1c58ce593bf0937f4aac51f265e29f6595177f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/testing/gtest_extras" path="system/testing/gtest_extras" revision="f324d3180147bbae1eb742eabd4e75d109b2882d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/timezone" path="system/timezone" revision="3bd3a573d8aeb55c99ca1b6d8374953bfd656ad1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/tools/aidl" path="system/tools/aidl" revision="b01451df7656b2437c940ba300178d81c6c951ff" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/tools/hidl" path="system/tools/hidl" revision="2a800b1c8946a1f84a6e42e0003626b0baba99de" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/tools/mkbootimg" path="system/tools/mkbootimg" revision="33a31ff81a48e20cb029a62b10e3fc6b614d93b7" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/tools/sysprop" path="system/tools/sysprop" revision="5afe96bb34146fb59d6142b132df33eb06c88f29" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/tools/xsdc" path="system/tools/xsdc" revision="27c0f47dc844be82e9bf1fe85670ab82917e6407" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/update_engine" path="system/update_engine" revision="6a6d0f13d4b4ecb8357e8bdb22be6fec626510df" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/system/vold" path="system/vold" revision="eaa3443ad830b856a4fcb8c8314e176c8ad147eb" upstream="refs/tags/android-r-preview-2"/>
+  <project name="platform/test/app_compat/csuite" path="test/app_compat/csuite" revision="a82698d20c210475ffbb9add00cc8502dc012abc" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,projectarch,pdk" name="platform/test/framework" path="test/framework" revision="65cc35a42c3dad36a0fc858035a5aefe29b4d55b" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/test/mlts/benchmark" path="test/mlts/benchmark" revision="67a799ab5bce0160ba6677ec190077d5ba5ad08d" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/test/mlts/models" path="test/mlts/models" revision="a92852efb52754926c69e9cdbe651de935f55349" upstream="refs/tags/android-r-preview-2"/>
+  <project name="platform/test/mts" path="test/mts" revision="23938da40abcebc7d44164f19aad5cf682c5cdad" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="cts,pdk-cw-fs,pdk-fs" name="platform/test/suite_harness" path="test/suite_harness" revision="3b2cb38d4561a7bed1f19ffcd30816f05e2a0b48" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,projectarch,pdk" name="platform/test/vti/dashboard" path="test/vti/dashboard" revision="a9bd47e4caa21d535fb89c0e6efe23fa08d25847" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,projectarch,pdk" name="platform/test/vti/fuzz_test_serving" path="test/vti/fuzz_test_serving" revision="6319e3d94c65669050c49c6ca570096d41823b82" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,projectarch,pdk" name="platform/test/vti/test_serving" path="test/vti/test_serving" revision="a2cebf686dd9437431d8b611f21db744c9650d0c" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/test/vts" path="test/vts" revision="00260fb7bc6303f521498f13a01b010759c8bd74" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,projectarch,pdk" name="platform/test/vts-testcase/fuzz" path="test/vts-testcase/fuzz" revision="284b33bc3c34abaf2acbe1593538cc747a5f6570" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/test/vts-testcase/hal" path="test/vts-testcase/hal" revision="3299de8fff9370ea2b45f1d7bdcfc322456bd486" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/test/vts-testcase/hal-trace" path="test/vts-testcase/hal-trace" revision="2695892568f8fade958ec0ec172df8f295ae4112" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/test/vts-testcase/kernel" path="test/vts-testcase/kernel" revision="26a8e5900e536b89bd44e6448c58fba3eb382ac4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,projectarch,pdk" name="platform/test/vts-testcase/nbu" path="test/vts-testcase/nbu" revision="0712e2a442364af77a0b1dda0adf922d1d1447bc" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,projectarch,pdk" name="platform/test/vts-testcase/performance" path="test/vts-testcase/performance" revision="f0e5dcee43de6f9c44a3872721087d96eaa48273" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,projectarch,pdk" name="platform/test/vts-testcase/security" path="test/vts-testcase/security" revision="668f52c000954da5833ef05310b127b0ec1c659f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="vts,pdk" name="platform/test/vts-testcase/vndk" path="test/vts-testcase/vndk" revision="c97165b3eed351cd322c10a292cd9b202e80dcea" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="tools,vts,projectarch,pdk,tradefed" name="platform/tools/acloud" path="tools/acloud" revision="8cec5007c2230710c071e2aabc8a0b4a6d479061" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,tools" name="platform/tools/apifinder" path="tools/apifinder" revision="05eee3720e682f4ce5ce1153f0236cee12d3883a" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,tradefed" name="platform/tools/apksig" path="tools/apksig" revision="2dd388f2f5595d93199ed322ff55c48233d89e99" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,tradefed" name="platform/tools/apkzlib" path="tools/apkzlib" revision="eba4cc5b98798e46c3f80b9dd0bdbd92757e4dde" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/tools/asuite" path="tools/asuite" revision="80e97555a4214d48ceecbb47050a151113a1f3e1" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/tools/currysrc" path="tools/currysrc" revision="ee58ce6a1931a4410059f2651d7e444bb8df35dc" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="tools,pdk-fs" name="platform/tools/dexter" path="tools/dexter" revision="fb3ac2a5b6efef22c621b973378be559f2d32196" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="tools" name="platform/tools/doc_generation" path="tools/doc_generation" revision="e7c9b74790a10ef58f165b32d0755831a8d93e32" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="tools" name="platform/tools/external/fat32lib" path="tools/external/fat32lib" revision="2aa98e48614927413550d00c755351b3f68542b4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="tools" name="platform/tools/external_updater" path="tools/external_updater" revision="d98145b82d11e300d88d27687193db38e1bbb2a8" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="nopresubmit,pdk,tradefed" name="platform/tools/loganalysis" path="tools/loganalysis" revision="838538ace54b0a1dbc2ae34d0498c8b458f1f17f" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,tools" name="platform/tools/metalava" path="tools/metalava" revision="4d219f6665223fd7cf1f3cddcbe1957bdb90a5f6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="adt-infra,cts,developers,motodev,pdk,tools,tradefed" name="platform/tools/repohooks" path="tools/repohooks" revision="73316598e68edb52962b70014e9057423d0f05e9" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,tools" name="platform/tools/security" path="tools/security" revision="f3ac98aa24ad5d682291c2144ac8b465ef2c6aa4" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/tools/test/connectivity" path="tools/test/connectivity" revision="1d63deeb1634b1bfddf9087d4f6910573dd08060" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="platform/tools/test/graphicsbenchmark" path="tools/test/graphicsbenchmark" revision="98bafdf921e46a577c0c366c85ebcf8ffa6ff9d6" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,tradefed" name="platform/tools/tradefederation" path="tools/tradefederation/core" revision="ae07bea29c08eb4c6bb880bee15469f41b693015" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk,tradefed" name="platform/tools/tradefederation/contrib" path="tools/tradefederation/contrib" revision="193e913d04ccac5cd8701e8d72c2ff58559aca61" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="tools,pdk" name="platform/tools/treble" path="tools/treble" revision="16f4a997c7d240d29535e8ce0f9037ab180da982" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="tools,cts,pdk,pdk-cw-fs,pdk-fs" name="platform/tools/trebuchet" path="tools/trebuchet" revision="d2240446bb55e53591d85fe1b9a795aca10a92be" upstream="refs/tags/android-r-preview-2"/>
+  <project name="toolchain/benchmark" revision="1fba1825631e6e52dff5b3ceb87a5b439e2acf52" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk" name="toolchain/pgo-profiles" revision="7a666994302474ff5891e256a1d2fa79be95aad3" upstream="refs/tags/android-r-preview-2"/>
+  <project groups="pdk-cw-fs,pdk-fs,pdk" name="tools/platform-compat" revision="35d5010d9febb5e5ef91a43413397ce4a5d10677" upstream="refs/tags/android-r-preview-2"/>
 
   <repo-hooks enabled-list="pre-upload" in-project="platform/tools/repohooks"/>
 </manifest>

--- a/master.xml
+++ b/master.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch="https://android.googlesource.com/"
            review="https://android-review.googlesource.com/" />
-  <default revision="master"
+  <default revision="refs/tags/android-r-preview-2"
            remote="aosp"
            sync-j="4" />
 
@@ -87,13 +87,13 @@
   <project path="device/sample" name="device/sample" groups="pdk" />
   <project path="device/ti/beagle_x15" name="device/ti/beagle-x15" groups="device,beagle_x15,pdk" />
   <project path="device/ti/beagle_x15-kernel" name="device/ti/beagle-x15-kernel" groups="device,beagle_x15,pdk" clone-depth="1" />
-  <project path="external/ARMComputeLibrary" name="platform/external/ARMComputeLibrary" groups="pdk" />
   <project path="external/aac" name="platform/external/aac" groups="pdk" />
   <project path="external/adeb" name="platform/external/adeb" groups="pdk" />
   <project path="external/adhd" name="platform/external/adhd" groups="pdk" />
   <project path="external/adt-infra" name="platform/external/adt-infra" groups="adt-infra,notdefault,pdk-fs" />
   <project path="external/android-clat" name="platform/external/android-clat" groups="pdk" />
   <project path="external/androidplot" name="platform/external/androidplot" groups="pdk" />
+  <project path="external/angle" name="platform/external/angle" groups="pdk" />
   <project path="external/ant-glob" name="platform/external/ant-glob" groups="pdk" />
   <project path="external/antlr" name="platform/external/antlr" groups="pdk" />
   <project path="external/apache-commons-bcel" name="platform/external/apache-commons-bcel" groups="pdk" />
@@ -102,7 +102,6 @@
   <project path="external/apache-harmony" name="platform/external/apache-harmony" groups="pdk" />
   <project path="external/apache-http" name="platform/external/apache-http" groups="pdk" />
   <project path="external/apache-xml" name="platform/external/apache-xml" groups="pdk" />
-  <project path="external/archive-patcher" name="platform/external/archive-patcher" groups="pdk" />
   <project path="external/arm-neon-tests" name="platform/external/arm-neon-tests" groups="vendor" />
   <project path="external/arm-optimized-routines" name="platform/external/arm-optimized-routines" groups="pdk" />
   <project path="external/arm-trusted-firmware" name="platform/external/arm-trusted-firmware" groups="pdk" />
@@ -126,11 +125,11 @@
   <project path="external/chromium-webview" name="platform/external/chromium-webview" groups="pdk" clone-depth="1" />
   <project path="external/clang" name="platform/external/clang" groups="pdk" />
   <project path="external/cldr" name="platform/external/cldr" groups="pdk" />
-  <project path="external/cmockery" name="platform/external/cmockery" groups="pdk" />
   <project path="external/cn-cbor" name="platform/external/cn-cbor" groups="pdk" />
   <project path="external/compiler-rt" name="platform/external/compiler-rt" groups="pdk" />
   <project path="external/conscrypt" name="platform/external/conscrypt" groups="pdk" />
   <project path="external/cpu_features" name="platform/external/cpu_features" groups="pdk" />
+  <project path="external/cpuinfo" name="platform/external/cpuinfo" groups="pdk" />
   <project path="external/crcalc" name="platform/external/crcalc" groups="pdk" />
   <project path="external/cros/system_api" name="platform/external/cros/system_api" groups="pdk" />
   <project path="external/crosvm" name="platform/external/crosvm" groups="pdk" />
@@ -148,7 +147,6 @@
   <project path="external/doclava" name="platform/external/doclava" groups="pdk" />
   <project path="external/dokka" name="platform/external/dokka" groups="pdk" />
   <project path="external/drm_hwcomposer" name="platform/external/drm_hwcomposer" groups="drm_hwcomposer,pdk-fs" />
-  <project path="external/droiddriver" name="platform/external/droiddriver" groups="pdk" />
   <project path="external/drrickorang" name="platform/external/drrickorang" groups="pdk" />
   <project path="external/dtc" name="platform/external/dtc" groups="pdk"/>
   <project path="external/dynamic_depth" name="platform/external/dynamic_depth" groups="pdk" />
@@ -157,7 +155,6 @@
   <project path="external/eigen" name="platform/external/eigen" groups="pdk" />
   <project path="external/elfutils" name="platform/external/elfutils" groups="pdk" />
   <project path="external/emma" name="platform/external/emma" groups="pdk" />
-  <project path="external/epid-sdk" name="platform/external/epid-sdk" groups="pdk" />
   <project path="external/error_prone" name="platform/external/error_prone" groups="pdk" />
   <project path="external/ethtool" name="platform/external/ethtool" groups="pdk" />
   <project path="external/expat" name="platform/external/expat" groups="pdk" />
@@ -172,6 +169,8 @@
   <project path="external/freetype" name="platform/external/freetype" groups="pdk" />
   <project path="external/fsck_msdos" name="platform/external/fsck_msdos" groups="pdk" />
   <project path="external/fsverity-utils" name="platform/external/fsverity-utils" groups="pdk" />
+  <project path="external/FP16" name="platform/external/FP16" groups="pdk" />
+  <project path="external/FXdiv" name="platform/external/FXdiv" groups="pdk" />
   <project path="external/gemmlowp" name="platform/external/gemmlowp" groups="pdk" />
   <project path="external/gflags" name="platform/external/gflags" groups="pdk" />
   <project path="external/giflib" name="platform/external/giflib" groups="pdk,qcom_msm8x26" />
@@ -222,6 +221,7 @@
   <project path="external/jdiff" name="platform/external/jdiff" groups="pdk" />
   <project path="external/jemalloc" name="platform/external/jemalloc" groups="pdk" />
   <project path="external/jemalloc_new" name="platform/external/jemalloc_new" groups="pdk" />
+  <project path="external/jimfs" name="platform/external/jimfs" groups="pdk" />
   <project path="external/jline" name="platform/external/jline" groups="pdk,tradefed,pdk-fs" />
   <project path="external/jsilver" name="platform/external/jsilver" groups="pdk" />
   <project path="external/jsmn" name="platform/external/jsmn" groups="pdk" />
@@ -261,7 +261,6 @@
   <project path="external/libkmsxx" name="platform/external/libkmsxx" groups="pdk" />
   <project path="external/libldac" name="platform/external/libldac" groups="pdk" />
   <project path="external/libmpeg2" name="platform/external/libmpeg2" groups="pdk" />
-  <project path="external/libmtp" name="platform/external/libmtp" groups="pdk" />
   <project path="external/libnetfilter_conntrack" name="platform/external/libnetfilter_conntrack" groups="pdk" />
   <project path="external/libnfnetlink" name="platform/external/libnfnetlink" groups="pdk" />
   <project path="external/libnl" name="platform/external/libnl" groups="pdk" />
@@ -276,7 +275,6 @@
   <project path="external/libunwind" name="platform/external/libunwind" groups="pdk" />
   <project path="external/libunwind_llvm" name="platform/external/libunwind_llvm" groups="pdk" />
   <project path="external/libusb" name="platform/external/libusb" groups="pdk" />
-  <project path="external/libusb-compat" name="platform/external/libusb-compat" groups="pdk" />
   <project path="external/libutf" name="platform/external/libutf" groups="pdk" />
   <project path="external/libvpx" name="platform/external/libvpx" groups="pdk" />
   <project path="external/libvterm" name="platform/external/libvterm" groups="pdk" />
@@ -303,6 +301,7 @@
   <project path="external/mockwebserver" name="platform/external/mockwebserver" groups="pdk" />
   <project path="external/modp_b64" name="platform/external/modp_b64" groups="pdk" />
   <project path="external/mp4parser" name="platform/external/mp4parser" groups="pdk" />
+  <project path="external/ms-tpm-20-ref" name="platform/external/ms-tpm-20-ref" groups="pdk" />
   <project path="external/mtpd" name="platform/external/mtpd" groups="pdk" />
   <project path="external/nanohttpd" name="platform/external/nanohttpd" groups="pdk" />
   <project path="external/nanopb-c" name="platform/external/nanopb-c" groups="pdk" />
@@ -333,61 +332,31 @@
   <project path="external/ppp" name="platform/external/ppp" groups="pdk" />
   <project path="external/proguard" name="platform/external/proguard" groups="pdk" />
   <project path="external/protobuf" name="platform/external/protobuf" groups="pdk" />
-  <project path="external/protobuf-javalite" name="platform/external/protobuf-javalite" groups="pdk" />
+  <project path="external/psimd" name="platform/external/psimd" groups="pdk" />
+  <project path="external/pthreadpool" name="platform/external/pthreadpool" groups="pdk" />
   <project path="external/puffin" name="platform/external/puffin" groups="pdk" />
   <project path="external/python/apitools" name="platform/external/python/apitools" groups="pdk" />
-  <project path="external/python/appdirs" name="platform/external/python/appdirs" groups="vts,pdk" />
   <project path="external/python/asn1crypto" name="platform/external/python/asn1crypto" groups="pdk" />
-  <project path="external/python/atomicwrites" name="platform/external/python/atomicwrites" groups="pdk" />
-  <project path="external/python/attrs" name="platform/external/python/attrs" groups="pdk" />
-  <project path="external/python/cachetools" name="platform/external/python/cachetools" groups="vts,pdk" />
   <project path="external/python/cffi" name="platform/external/python/cffi" groups="pdk" />
   <project path="external/python/cpython2" name="platform/external/python/cpython2" groups="pdk" />
   <project path="external/python/cpython3" name="platform/external/python/cpython3" groups="pdk" />
   <project path="external/python/cryptography" name="platform/external/python/cryptography" groups="pdk" />
   <project path="external/python/dateutil" name="platform/external/python/dateutil" groups="pdk" />
-  <project path="external/python/dill" name="platform/external/python/dill" groups="vts,pdk" />
-  <project path="external/python/enum" name="platform/external/python/enum" groups="vts,pdk" />
   <project path="external/python/enum34" name="platform/external/python/enum34" groups="vts,pdk" />
   <project path="external/python/funcsigs" name="platform/external/python/funcsigs" groups="pdk" />
-  <project path="external/python/future" name="platform/external/python/future" groups="vts,pdk" />
   <project path="external/python/futures" name="platform/external/python/futures" groups="vts,pdk" />
-  <project path="external/python/gapic-google-cloud-pubsub-v1" name="platform/external/python/gapic-google-cloud-pubsub-v1" groups="vts,pdk" />
   <project path="external/python/google-api-python-client" name="platform/external/python/google-api-python-client" groups="vts,pdk" />
-  <project path="external/python/google-auth" name="platform/external/python/google-auth" groups="vts,pdk" />
-  <project path="external/python/google-auth-httplib2" name="platform/external/python/google-auth-httplib2" groups="vts,pdk" />
-  <project path="external/python/google-cloud-core" name="platform/external/python/google-cloud-core" groups="vts,pdk" />
-  <project path="external/python/google-cloud-pubsub" name="platform/external/python/google-cloud-pubsub" groups="vts,pdk" />
-  <project path="external/python/google-gax" name="platform/external/python/google-gax" groups="vts,pdk" />
-  <project path="external/python/googleapis" name="platform/external/python/googleapis" groups="vts,pdk" />
-  <project path="external/python/grpc-google-iam-v1" name="platform/external/python/grpc-google-iam-v1" groups="vts,pdk" />
-  <project path="external/python/grpcio" name="platform/external/python/grpcio" groups="vts,pdk" />
   <project path="external/python/httplib2" name="platform/external/python/httplib2" groups="vts,pdk" />
   <project path="external/python/ipaddress" name="platform/external/python/ipaddress" groups="pdk" />
-  <project path="external/python/matplotlib" name="platform/external/python/matplotlib" groups="vts,pdk" />
   <project path="external/python/mock" name="platform/external/python/mock" groups="pdk" />
-  <project path="external/python/more-itertools" name="platform/external/python/more-itertools" groups="pdk" />
-  <project path="external/python/numpy" name="platform/external/python/numpy" groups="vts,pdk" />
   <project path="external/python/oauth2client" name="platform/external/python/oauth2client" groups="vts,pdk" />
-  <project path="external/python/olefile" name="platform/external/python/olefile" groups="vts,pdk" />
-  <project path="external/python/packaging" name="platform/external/python/packaging" groups="vts,pdk" />
-  <project path="external/python/parse" name="platform/external/python/parse" groups="vts,pdk" />
-  <project path="external/python/Pillow" name="platform/external/python/Pillow" groups="vts,pdk" />
-  <project path="external/python/ply" name="platform/external/python/ply" groups="vts,pdk" />
-  <project path="external/python/pluggy" name="platform/external/python/pluggy" groups="pdk" />
-  <project path="external/python/proto-google-cloud-pubsub-v1" name="platform/external/python/proto-google-cloud-pubsub-v1" groups="vts,pdk" />
-  <project path="external/python/protobuf" name="platform/external/python/protobuf" groups="vts,pdk" />
-  <project path="external/python/py" name="platform/external/python/py" groups="pdk" />
   <project path="external/python/pyasn1" name="platform/external/python/pyasn1" groups="vts,pdk" />
   <project path="external/python/pyasn1-modules" name="platform/external/python/pyasn1-modules" groups="vts,pdk" />
   <project path="external/python/pybind11" name="platform/external/python/pybind11" groups="pdk" />
   <project path="external/python/pycparser" name="platform/external/python/pycparser" groups="pdk" />
+  <project path="external/python/pyfakefs" name="platform/external/python/pyfakefs" groups="pdk" />
   <project path="external/python/pyopenssl" name="platform/external/python/pyopenssl" groups="pdk" />
-  <project path="external/python/pyparsing" name="platform/external/python/pyparsing" groups="vts,pdk" />
-  <project path="external/python/pytest" name="platform/external/python/pytest" groups="pdk" />
-  <project path="external/python/requests" name="platform/external/python/requests" groups="vts,pdk" />
   <project path="external/python/rsa" name="platform/external/python/rsa" groups="vts,pdk" />
-  <project path="external/python/scipy" name="platform/external/python/scipy" groups="vts,pdk" />
   <project path="external/python/setuptools" name="platform/external/python/setuptools" groups="vts,pdk" />
   <project path="external/python/six" name="platform/external/python/six" groups="vts,pdk" />
   <project path="external/python/uritemplates" name="platform/external/python/uritemplates" groups="vts,pdk" />
@@ -398,6 +367,7 @@
   <project path="external/roboto-fonts" name="platform/external/roboto-fonts" groups="pdk" />
   <project path="external/rootdev" name="platform/external/rootdev" groups="pdk" />
   <project path="external/Reactive-Extensions/RxCpp" name="platform/external/Reactive-Extensions/RxCpp" groups="pdk" />
+  <project path="external/rust/crates/bitflags" name="platform/external/rust/crates/bitflags" groups="pdk" />
   <project path="external/rust/crates/byteorder" name="platform/external/rust/crates/byteorder" groups="pdk" />
   <project path="external/rust/crates/libc" name="platform/external/rust/crates/libc" groups="pdk" />
   <project path="external/rust/crates/proc-macro2" name="platform/external/rust/crates/proc-macro2" groups="pdk" />
@@ -440,6 +410,7 @@
   <project path="external/tinyxml2" name="platform/external/tinyxml2" groups="pdk" />
   <project path="external/toolchain-utils" name="platform/external/toolchain-utils" />
   <project path="external/toybox" name="platform/external/toybox" groups="pdk" />
+  <project path="external/tpm2-tss" name="platform/external/tpm2-tss" groups="pdk" />
   <project path="external/tremolo" name="platform/external/tremolo" groups="pdk" />
   <project path="external/turbine" name="platform/external/turbine" groups="pdk" />
   <project path="external/u-boot" name="platform/external/u-boot" groups="pdk" />
@@ -465,6 +436,7 @@
   <project path="external/xmp_toolkit" name="platform/external/xmp_toolkit" groups="pdk" />
   <project path="external/xz-embedded" name="platform/external/xz-embedded" groups="pdk" />
   <project path="external/xz-java" name="platform/external/xz-java" groups="pdk" />
+  <project path="external/XNNPACK" name="platform/external/XNNPACK" groups="pdk" />
   <project path="external/yapf" name="platform/external/yapf" groups="vts,projectarch,pdk" />
   <project path="external/zlib" name="platform/external/zlib" groups="pdk" />
   <project path="external/zopfli" name="platform/external/zopfli" groups="pdk" />
@@ -584,7 +556,6 @@
   <project path="packages/apps/Car/Settings" name="platform/packages/apps/Car/Settings" groups="pdk-fs" />
   <project path="packages/apps/Car/Stream" name="platform/packages/apps/Car/Stream" groups="pdk-fs" />
   <project path="packages/apps/Car/SystemUpdater" name="platform/packages/apps/Car/SystemUpdater" groups="pdk-fs" />
-  <project path="packages/apps/Car/externallibs" name="platform/packages/apps/Car/externallibs" groups="pdk-fs" />
   <project path="packages/apps/Car/libs" name="platform/packages/apps/Car/libs" groups="pdk-fs" />
   <project path="packages/apps/Car/tests" name="platform/packages/apps/Car/tests" groups="pdk-fs" />
   <project path="packages/apps/CarrierConfig" name="platform/packages/apps/CarrierConfig" groups="pdk-cw-fs,pdk-fs" />
@@ -647,7 +618,6 @@
   <project path="packages/modules/NetworkStack" name="platform/packages/modules/NetworkStack" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/modules/TestModule" name="platform/packages/modules/TestModule" />
   <project path="packages/modules/vndk" name="platform/packages/modules/vndk" groups="pdk-cw-fs,pdk-fs" />
-  <project path="packages/providers/ApplicationsProvider" name="platform/packages/providers/ApplicationsProvider" groups="pdk-fs" />
   <project path="packages/providers/BlockedNumberProvider" name="platform/packages/providers/BlockedNumberProvider" groups="pdk-fs" />
   <project path="packages/providers/BookmarkProvider" name="platform/packages/providers/BookmarkProvider" groups="pdk-fs" />
   <project path="packages/providers/CalendarProvider" name="platform/packages/providers/CalendarProvider" groups="pdk-cw-fs,pdk-fs" />
@@ -706,7 +676,6 @@
   <project path="prebuilts/manifest-merger" name="platform/prebuilts/manifest-merger" groups="pdk" clone-depth="1" />
   <project path="prebuilts/maven_repo/android" name="platform/prebuilts/maven_repo/android" groups="pdk-cw-fs,pdk-fs" clone-depth="1" />
   <project path="prebuilts/maven_repo/bumptech" name="platform/prebuilts/maven_repo/bumptech" groups="pdk-cw-fs,pdk-fs" clone-depth="1" />
-  <project path="prebuilts/maven_repo/google-play-service-client-libraries-3p" name="platform/prebuilts/maven_repo/google-play-service-client-libraries-3p" clone-depth="1" />
   <project path="prebuilts/misc" name="platform/prebuilts/misc" groups="pdk" clone-depth="1" />
   <project path="prebuilts/module_sdk/art" name="platform/prebuilts/module_sdk/art" groups="pdk" clone-depth="1" />
   <project path="prebuilts/ndk" name="platform/prebuilts/ndk" groups="pdk" clone-depth="1" />
@@ -772,7 +741,6 @@
   <project path="system/tools/sysprop" name="platform/system/tools/sysprop" groups="pdk" />
   <project path="system/tools/xsdc" name="platform/system/tools/xsdc" groups="pdk" />
   <project path="system/update_engine" name="platform/system/update_engine" groups="pdk" />
-  <project path="system/ucontainer" name="platform/system/ucontainer" groups="pdk" />
   <project path="system/vold" name="platform/system/vold" groups="pdk" />
   <project path="test/framework" name="platform/test/framework" groups="vts,projectarch,pdk" />
   <project path="test/mlts/benchmark" name="platform/test/mlts/benchmark" groups="pdk" />
@@ -780,7 +748,6 @@
   <project path="test/app_compat/csuite" name="platform/test/app_compat/csuite" />
   <project path="test/mts" name="platform/test/mts" />
   <project path="test/suite_harness" name="platform/test/suite_harness" groups="cts,pdk-cw-fs,pdk-fs" />
-  <project path="test/vti/alert" name="platform/test/vti/alert" groups="vts,projectarch,pdk" />
   <project path="test/vti/dashboard" name="platform/test/vti/dashboard" groups="vts,projectarch,pdk" />
   <project path="test/vti/fuzz_test_serving" name="platform/test/vti/fuzz_test_serving" groups="vts,projectarch,pdk" />
   <project path="test/vti/test_serving" name="platform/test/vti/test_serving" groups="vts,projectarch,pdk" />


### PR DESCRIPTION
Align the manifest with the Android R preview

master.xml is sychronized with default.xml from
https://android.googlesource.com/platform/manifest on the
android-r-preview-2 tag.

default.xml is then regenerated after a repo sync.

linux-kselftest, seccomp-test and selinux projects pick up a commit
from aosp/master (in default.xml) to fix build issues when running
`mm` in bob tests. These SHAs are within one or two commits from the
tag.

Change-Id: Ic9d864280ed90f54ef5543d44cdcc822031bd1e5
Signed-off-by: David Kilroy <david.kilroy@arm.com>