### PR TITLE
minimal_config: Write a depfile

### DIFF
--- a/scripts/minimal_config.py
+++ b/scripts/minimal_config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,6 +71,8 @@ def main():
                         help="Path to the config JSON file")
     parser.add_argument("--ignore-missing", default=False, action="store_true",
                         help="Ignore missing database files included with 'source'")
+    parser.add_argument("--depfile", type=argparse.FileType("wt"),
+                        help="Write dependencies to a depfile")
     args = parser.parse_args()
 
     if not os.path.isfile(args.database):
@@ -83,6 +85,9 @@ def main():
     json_config = config_to_json(args.database, args.config, args.ignore_missing)
     with config_system.utils.open_and_write_if_changed(args.output) as fp:
         json.dump(json_config, fp, sort_keys=True, indent=4, separators=(',', ': '))
+
+    if args.depfile:
+        args.depfile.write("{output}: {config} {database}\n".format(**vars(args)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add support to `minimal_config.py` for writing a depfile. This is
required on Android.bp, where users of the script will want to use
`config.json` as a source file to a bob_generate_source, but cannot,
because it is in the `out` directory, which soong prohibits.

Change-Id: I3090c160084a10c787d7bfc4bdee2d8af42e19aa
Signed-off-by: Chris Diamand <chris.diamand@arm.com>