### PR TITLE
Align generated source outputs on Android.bp

### DIFF
--- a/tests/transform_source/build.bp
+++ b/tests/transform_source/build.bp
@@ -97,7 +97,7 @@ bob_transform_source {
         "f6.in",
     ],
     out: {
-        match: ".*/(.+).in",
+        match: ".*/(.+)\\.in",
         replace: [
             "$1.cpp",
             "$1.h",


### PR DESCRIPTION
Soong's gen dirs are generally of the form `/path/to/module/gen`. However, the Android.mk and Linux backends use the form `build/gen/module_name`. Normally this doesn't matter, as everything is contained within the gen dir, except when chaining multiple generated modules. In this case, bob_transform_source used on Android.mk or Linux may expect the module name to be included when doing the regex replacement, and be exporting include directories accordingly.  This means that the transform_source tests are failing on Android.bp, because the output path of `generate_source_to_transform` does not contain the module name.  Fix this by adding a subdirectory named after the module inside Soong's gen dir when calculating the outputs of generated modules.


