### PR TITLE
Support `out` in generated libraries

### DIFF
--- a/core/gen_binary.go
+++ b/core/gen_binary.go
@@ -43,7 +43,7 @@ func (m *generateBinary) libExtension() string {
 //// Support singleOutputModule
 
 func (m *generateBinary) outputFileName() string {
-	return m.Name() + m.libExtension()
+	return m.altName() + m.libExtension()
 }
 
 //// Support blueprint.Module

--- a/core/gen_library.go
+++ b/core/gen_library.go
@@ -28,6 +28,9 @@ import (
 type GenerateLibraryProps struct {
 	// List of headers that are created (if any)
 	Headers []string
+
+	// Alternate output name, used for the file name and Android rules
+	Out *string
 }
 
 type generateLibrary struct {
@@ -103,7 +106,20 @@ func (m *generateLibrary) topLevelProperties() []interface{} {
 //// Support singleOutputModule interface
 
 func (m *generateLibrary) outputName() string {
+	if m.Properties.Out != nil {
+		return *m.Properties.Out
+	}
 	return m.Name()
+}
+
+// Other naming functions, which need to reflect the output name, e.g. for the
+// module name map to work correctly on Android.mk.
+func (l *generateLibrary) altName() string {
+	return l.outputName()
+}
+
+func (l *generateLibrary) altShortName() string {
+	return l.outputName()
 }
 
 //// Support installable

--- a/core/gen_shared.go
+++ b/core/gen_shared.go
@@ -53,7 +53,7 @@ func (m *generateSharedLibrary) GenerateBuildActions(ctx blueprint.ModuleContext
 //// Support singleOutputModule
 
 func (m *generateSharedLibrary) outputFileName() string {
-	return m.Name() + m.libExtension()
+	return m.altName() + m.libExtension()
 }
 
 //// Factory functions

--- a/core/gen_static.go
+++ b/core/gen_static.go
@@ -52,7 +52,7 @@ func (m *generateStaticLibrary) GenerateBuildActions(ctx blueprint.ModuleContext
 //// Support singleOutputModule
 
 func (m *generateStaticLibrary) outputFileName() string {
-	return m.Name() + m.libExtension()
+	return m.altName() + m.libExtension()
 }
 
 //// Factory functions

--- a/tests/generate_libs/build.bp
+++ b/tests/generate_libs/build.bp
@@ -130,11 +130,60 @@ bob_generate_binary {
     },
 }
 
+bob_generate_shared_library {
+    name: "libblah_shared_rename",
+    out: "libblah_shared2",
+    srcs: ["libblah/libblah.c"],
+    headers: [
+        "include/libblah.h",
+        "include/libblah_feature.h",
+    ],
+    export_gen_include_dirs: ["include"],
+    cmd: "{{.gen_cc}} -fPIC -o ${out} -shared ${in}; mkdir -p ${gen_dir}/include; cp ${module_dir}/libblah/libblah.h ${module_dir}/libblah/libblah_feature.h ${gen_dir}/include/.",
+    target: "host",
+    builder_android_bp: {
+        /* On Android BP generated libraries are not supported. */
+        enabled: false,
+    },
+
+}
+
+bob_binary {
+    name: "binary_linked_to_gen_shared_rename",
+    srcs: ["main.c"],
+    shared_libs: ["libblah_shared_rename"],
+    host_supported: true,
+    target_supported: false,
+    build_by_default: true,
+    builder_android_bp: {
+        /* On Android BP generated libraries are not supported. */
+        enabled: false,
+    },
+}
+
+/* Check that the binary has a NEEDED entry for the renamed shared library */
+bob_generate_source {
+    name: "check_renamed_gen_library",
+    out: ["success.txt"],
+    module_srcs: ["binary_linked_to_gen_shared_rename"],
+    tool: "check_library_link.py",
+    cmd: "${tool} --links-to libblah_shared2 ${args} ${in} && touch ${out}",
+    osx: {
+        args: ["--read-deps-method otool"],
+    },
+    build_by_default: true,
+    builder_android_bp: {
+        /* On Android BP generated libraries are not supported. */
+        enabled: false,
+    },
+}
+
 bob_alias {
     name: "bob_test_generate_libs",
     srcs: [
         "binary_linked_to_gen_static",
         "binary_linked_to_gen_shared",
         "generated_binary",
+        "check_renamed_gen_library",
     ],
 }

--- a/tests/generate_libs/check_library_link.py
+++ b/tests/generate_libs/check_library_link.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# Copyright 2020 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+def match_lines(cmd, regex):
+    """Run `cmd` and return the match groups from each line matching `regex`"""
+    try:
+        dump = subprocess.check_output(cmd).decode()
+    except subprocess.CalledProcessError as e:
+        print(e)
+        sys.exit(e.returncode)
+
+    matched = set()
+    for line in dump.splitlines():
+        m = regex.match(line)
+        if not m:
+            continue
+        matched.add(m.group(1))
+    return matched
+
+
+OBJDUMP_RE = re.compile(r'\s*NEEDED\s+([a-zA-Z0-9_-]+).so[0-9.]*')
+OTOOL_RE = re.compile(r'\s+(.*?)(?:\.dylib)?\s+\(.*\)')
+
+READ_DEPS_METHODS = {
+    "objdump": lambda lib: match_lines(["objdump", "-p", lib], OBJDUMP_RE),
+    "otool": lambda lib: [os.path.basename(i) for i in match_lines(["otool", "-L", lib], OTOOL_RE)],
+}
+
+
+def check_links(lib, links_to, read_deps):
+    all_links = read_deps(lib)
+    for link in links_to:
+        if link not in all_links:
+            print("ERROR: {} does not link to {}".format(lib, link))
+            print("ERROR: The following dependencies were detected: " +
+                  ", ".join(sorted(all_links)))
+            sys.exit(1)
+
+
+def parse_args():
+    ap = argparse.ArgumentParser()
+
+    ap.add_argument("--read-deps-method", choices=READ_DEPS_METHODS.keys(), default="objdump",
+                    help="Program used to read library dependencies")
+    ap.add_argument("--links-to", "-l", metavar="LIBNAME", default=[], action="append",
+                    help="Check that LIBRARY links to LIBNAME")
+    ap.add_argument("library")
+
+    return ap.parse_args()
+
+
+def main():
+    args = parse_args()
+    check_links(args.library, args.links_to, READ_DEPS_METHODS[args.read_deps_method])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Allow generated libraries to use a different output filename than the
module name. This allows e.g. a library which is generated via a
sub-build on Linux to be linked via a `bob_external_library` with the
same `.so` name on Android.

Change-Id: Iadef232e975ed0ed23e0b6dabc97d545931f502b
Signed-off-by: Chris Diamand <chris.diamand@arm.com>