### PR TITLE
Fix match_srcs for Android.bp backend

### DIFF
--- a/core/androidbp_backend.go
+++ b/core/androidbp_backend.go
@@ -62,17 +62,18 @@ func (g *androidBpGenerator) buildDir() string {
 }
 
 func (g *androidBpGenerator) sourceDir() string {
-	// The androidbp backend writes paths into an Android.bp file in
-	// the project directory. All paths should be relative to that
-	// file, so there should be no need for the source directory.
-	return ""
+	// On the androidbp backend, sourceDir() is only used for match_src
+	// handling and for locating bob scripts. In these cases we want
+	// paths relative to ANDROID_BUILD_TOP directory,
+	// which is where all commands will be executed from
+	return getSourceDir()
 }
 
 func (g *androidBpGenerator) bobScriptsDir() string {
 	// In the androidbp backend, we just want the relative path to the
 	// script directory.
 	srcToScripts, _ := filepath.Rel(getSourceDir(), getBobScriptsDir())
-	return filepath.Join(g.sourceDir(), srcToScripts)
+	return srcToScripts
 }
 
 func (g *androidBpGenerator) sharedLibsDir(tgtType) string {

--- a/tests/match_source/build.bp
+++ b/tests/match_source/build.bp
@@ -48,10 +48,6 @@ bob_binary {
         srcs: ["order_file.txt"],
         ldflags: ["-Wl,-order_file,{{match_srcs \"*.txt\"}}"],
     },
-    builder_android_bp: {
-        /* On Android BP match_srcs macro is not working correctly yet */
-        enabled: false,
-    },
 }
 
 bob_alias {


### PR DESCRIPTION
match_srcs expects to find the matching sources relative to the
current module, but only one Android.bp gets written per project
and soong will always run from with TOP_DIR as the current directory.
As such, we need the full path for the source files to be returned
by the backend.

Signed-off-by: Liviu Dudau <liviu.dudau@arm.com>
Change-Id: I732f9a18ff103227c4e90c13a0f590b56665247d