### PR TITLE
Allow setting LD in kernel module builds

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -1088,7 +1088,7 @@ func (g *androidMkGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.
 		"--module-dir \"$(output_module_dir)\" $(extra_includes) " +
 		"--sources $(sources) " +
 		"--kernel \"$(kernel_dir)\" --cross-compile \"$(kernel_cross_compile)\" " +
-		"$(cc_flag) $(hostcc_flag) $(clang_triple_flag) " +
+		"$(cc_flag) $(hostcc_flag) $(clang_triple_flag) $(ld_flag) " +
 		"$(kbuild_options) --extra-cflags=\"$(extra_cflags)\" $(make_args)"
 
 	sb.WriteString("\techo " + cmd + "\n")

--- a/core/androidbp_kernel_module.go
+++ b/core/androidbp_kernel_module.go
@@ -84,10 +84,11 @@ func (g *androidBpGenerator) kernelModuleActions(l *kernelModule, mctx blueprint
 			"--make-command", prebuiltMake,
 		},
 		stringParam("--kbuild-options", utils.Join(l.Properties.Kbuild_options)),
-		stringParam("--cc", l.Properties.Kernel_cc),
-		stringParam("--clang-triple", l.Properties.Kernel_clang_triple),
 		stringParam("--cross-compile", l.Properties.Kernel_cross_compile),
+		stringParam("--cc", l.Properties.Kernel_cc),
 		stringParam("--hostcc", l.Properties.Kernel_hostcc),
+		stringParam("--clang-triple", l.Properties.Kernel_clang_triple),
+		stringParam("--ld", l.Properties.Kernel_ld),
 		stringParams("-I",
 			l.Properties.Include_dirs,
 			getPathsInSourceDir(l.Properties.Local_include_dirs)))

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -124,6 +124,7 @@ type kbuildArgs struct {
 	CCFlag             string
 	HostCCFlag         string
 	ClangTripleFlag    string
+	LDFlag             string
 }
 
 func (a kbuildArgs) toDict() map[string]string {
@@ -139,6 +140,7 @@ func (a kbuildArgs) toDict() map[string]string {
 		"cc_flag":              a.CCFlag,
 		"hostcc_flag":          a.HostCCFlag,
 		"clang_triple_flag":    a.ClangTripleFlag,
+		"ld_flag":              a.LDFlag,
 	}
 }
 
@@ -185,6 +187,11 @@ func (m *kernelModule) generateKbuildArgs(ctx blueprint.BaseModuleContext) kbuil
 		clangTriple = "--clang-triple " + clangTriple
 	}
 
+	ld := m.Properties.Build.Kernel_ld
+	if ld != "" {
+		ld = "--ld " + ld
+	}
+
 	return kbuildArgs{
 		KmodBuild:          kmodBuild,
 		ExtraIncludes:      strings.Join(extraIncludePaths, " "),
@@ -198,6 +205,7 @@ func (m *kernelModule) generateKbuildArgs(ctx blueprint.BaseModuleContext) kbuil
 		OutputModuleDir: filepath.Join(m.outputDir(), projectModuleDir(ctx)),
 		CCFlag:          kernelToolchain,
 		HostCCFlag:      hostToolchain,
+		LDFlag:          ld,
 		ClangTripleFlag: clangTriple,
 	}
 }

--- a/core/library.go
+++ b/core/library.go
@@ -165,6 +165,8 @@ type BuildProps struct {
 	Kernel_cc string
 	// Kernel host compiler
 	Kernel_hostcc string
+	// Kernel linker
+	Kernel_ld string
 	// Target triple when using clang as the compiler
 	Kernel_clang_triple string
 

--- a/core/linux.go
+++ b/core/linux.go
@@ -1022,14 +1022,14 @@ var kbuildRule = pctx.StaticRule("kbuild",
 			"--module-dir $output_module_dir $extra_includes " +
 			"--sources $in " +
 			"--kernel $kernel_dir --cross-compile '$kernel_cross_compile' " +
-			"$cc_flag $hostcc_flag $clang_triple_flag " +
+			"$cc_flag $hostcc_flag $clang_triple_flag $ld_flag " +
 			"$kbuild_options --extra-cflags='$extra_cflags' $make_args",
 		Depfile:     "$out.d",
 		Deps:        blueprint.DepsGCC,
 		Pool:        blueprint.Console,
 		Description: "$out",
 	}, "kmod_build", "depfile", "extra_includes", "extra_cflags", "kernel_dir", "kernel_cross_compile",
-	"kbuild_options", "make_args", "output_module_dir", "cc_flag", "hostcc_flag", "clang_triple_flag")
+	"kbuild_options", "make_args", "output_module_dir", "cc_flag", "hostcc_flag", "clang_triple_flag", "ld_flag")
 
 func (g *linuxGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.ModuleContext) {
 	// Calculate and record outputs

--- a/scripts/kmod_build.py
+++ b/scripts/kmod_build.py
@@ -68,7 +68,8 @@ def build_module(output_dir, module_ko, kdir, module_dir, make_command, make_arg
     # Sanitize the environment - we should only use build options passed in via
     # the command line.
     env = dict(os.environ)
-    for var in ["ARCH", "CROSS_COMPILE", "CC", "HOSTCC", "CLANG_TRIPLE", "KBUILD_EXTRA_SYMBOLS"]:
+    for var in ["ARCH", "CROSS_COMPILE", "CC", "HOSTCC",
+                "CLANG_TRIPLE", "KBUILD_EXTRA_SYMBOLS", "LD"]:
         env.pop(var, None)
 
     try:
@@ -177,6 +178,8 @@ def parse_args():
                        help="Kernel CROSS_COMPILE")
     group.add_argument("--clang-triple", default=None,
                        help="Kernel CLANG_TRIPLE")
+    group.add_argument("--ld", default=None,
+                       help="Kernel LD")
     group.add_argument("--kbuild-options", nargs="+", default=[],
                        help="Kernel config options to enable, that get added to EXTRA_CFLAGS too")
     group.add_argument("--extra-cflags", default="",
@@ -261,6 +264,11 @@ def main():
         make_args.append("HOSTCC=" + host_cc)
     if args.clang_triple:
         make_args.append("CLANG_TRIPLE=" + args.clang_triple)
+    if args.ld:
+        make_args.append("LD=" + args.ld)
+    elif kernel_config_parser.option_enabled(abs_kdir, "CONFIG_LD_IS_LLD"):
+        # Auto-set LD to `ld.lld` if LTO has been enabled
+        make_args.append("LD=ld.lld")
     if args.extra_symbols:
         extra_symbols = [os.path.abspath(d) for d in args.extra_symbols]
         make_args.append("KBUILD_EXTRA_SYMBOLS=" + " ".join(extra_symbols))


### PR DESCRIPTION
Add a new property, `kernel_ld`, which maps to the `LD` Make variable
when build kernel modules. When this is not specified, but the kernel
has CONFIG_LD_IS_LLD enabled, default this to `ld.lld`. This allows
modules compiled against kernels with LTO enabled to build.

Change-Id: I233884e8fcdfcd8eacdc485a6fce687295190c43
Signed-off-by: Chris Diamand <chris.diamand@arm.com>