### PR TITLE
config_system: report config inconsistencies after plugin

### DIFF
--- a/config_system/config_system/log_handlers.py
+++ b/config_system/config_system/log_handlers.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,14 +48,7 @@ class ErrorCounterHandler(logging.Handler):
 
     def __init__(self, *args, **kwargs):
         super(ErrorCounterHandler, self).__init__(*args, **kwargs)
-        self.counts = {
-            "NOTSETS": 0,
-            "DEBUG": 0,
-            "INFO": 0,
-            "WARNING": 0,
-            "ERROR": 0,
-            "CRITICAL": 0,
-        }
+        self.reset()
 
     def emit(self, record):
         lvl = record.levelname
@@ -75,6 +68,16 @@ class ErrorCounterHandler(logging.Handler):
 
     def criticals(self):
         return self.counts["CRITICAL"]
+
+    def reset(self):
+        self.counts = {
+            "NOTSETS": 0,
+            "DEBUG": 0,
+            "INFO": 0,
+            "WARNING": 0,
+            "ERROR": 0,
+            "CRITICAL": 0,
+        }
 
 
 class ColorFormatter(logging.Formatter):


### PR DESCRIPTION
Plugins may set config values which command line options may depend
on. So we should only complain that the output config is consistent
after the plugins have executed.

eg.

config YELLOW
    bool "Yellow"
    depends on COLOR_TV

config COLOR_TV
    bool "Color TV"
    default n

$ ./update_config.py YELLOW=y
ERROR: YELLOW=y was ignored; its dependencies were not met: COLOR_TV[=n]

... will fail if COLOR_TV is set by a plugin

We want the configs to be as consistent as possible for the plugins.
So continue to run enforce_dependent_values before, however disable
any errors in this run. Rerun after the plugins execute to recheck
consistency, and enable error reporting in this final run.

Note this change converts an exception to an error in
enforce_dependent_values so that we can report multiple issues in each
run.

Add a test to check this behavior. In doing so, ensure that the tests
are resetting the error counts on each call to update_config.py

Change-Id: Ic1ecac00c393bb61a28dc1245a6012b7994d7877
Signed-off-by: David Kilroy <david.kilroy@arm.com>