### PR TITLE
Remove TOPNAME option from Bob

### DIFF
--- a/bob.bootstrap.version
+++ b/bob.bootstrap.version
@@ -1,2 +1,2 @@
 # Version number used to identify whether the user needs to re-boostrap their build directory.
-BOB_VERSION="5"
+BOB_VERSION="6"

--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@
 # BOB_CONFIG_OPTS - Configuration options to be used when calling the
 #                   configuration system.
 # BOB_CONFIG_PLUGINS - Configuration system plugins to use
-# TOPNAME - Name used for Bob Blueprint files.
 
 # The location that this script is called from determines the working
 # directory of the build.
@@ -49,11 +48,6 @@ fi
 if [[ -z "$CONFIGNAME" ]]; then
   echo "CONFIGNAME is not set - using bob.config"
   CONFIGNAME="bob.config"
-fi
-
-if [[ -z "$TOPNAME" ]]; then
-  echo "TOPNAME must be set"
-  exit 1
 fi
 
 if [[ -z "$BOB_CONFIG_OPTS" ]]; then
@@ -89,6 +83,7 @@ BOB_DIR="$(relative_path $(pwd) "${SCRIPT_DIR}")"
 CONFIG_FILE="${BUILDDIR}/${CONFIGNAME}"
 CONFIG_JSON="${BUILDDIR}/config.json"
 
+export TOPNAME="build.bp"
 export BOOTSTRAP="${BOB_DIR}/bootstrap.bash"
 export BLUEPRINTDIR="${BOB_DIR}/blueprint"
 

--- a/docs/project_setup.md
+++ b/docs/project_setup.md
@@ -72,9 +72,6 @@ expected. This is expected to be relative to the working directory
 
 `BLUEPRINT_LIST_FILE` is the path to the Blueprint list file.
 
-`TOPNAME` is the path to the root build definition, relative to
-`SRCDIR`.
-
 `CONFIGNAME` is the path to the configuration file, relative to
 `BUILDDIR`.
 
@@ -99,7 +96,7 @@ You should update the following:
 * Set `SRCDIR` based on `SCRIPT_DIR`. If the bootstrap script is in
   the root directory, this can be set to `SCRIPT_DIR`.
 
-* Tweak `TOPNAME`, `BLUEPRINT_LIST_FILE`, `CONFIGNAME` as needed.
+* Tweak `BLUEPRINT_LIST_FILE` and `CONFIGNAME` as needed.
 
 * Tweak `BOB_CONFIG_OPTS` and `BOB_CONFIG_PLUGINS` if needed.
 
@@ -113,7 +110,7 @@ On Android the output directory is determined by the project name.
 * Update `PROJ_NAME` to be a short string that is unique in the
   Android makefile namespace.
 
-* Update `SRCDIR`, `TOPNAME`, `BLUEPRINT_LIST_FILE`, `CONFIGNAME`,
+* Update `SRCDIR`, `BLUEPRINT_LIST_FILE`, `CONFIGNAME`,
   `BOB_CONFIG_OPTS` and `BOB_CONFIG_PLUGINS` as done for Linux.
 
 ## Blueprint file list (bplist)

--- a/example/bootstrap_androidbp.bash
+++ b/example/bootstrap_androidbp.bash
@@ -85,7 +85,6 @@ cd "${ANDROID_BUILD_TOP}"
 ### Variables required for Bob and Android.mk bootstrap ###
 BPBUILD_DIR="${OUT}/gen/STATIC_LIBRARIES/bobbp_${PROJ_NAME}_intermediates"
 export BUILDDIR="${BPBUILD_DIR}"
-export TOPNAME="build.bp"
 export CONFIGNAME="bob.config"
 export SRCDIR="${PROJ_DIR}"
 export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"

--- a/example/bootstrap_androidmk.bash
+++ b/example/bootstrap_androidmk.bash
@@ -88,7 +88,6 @@ cd "${ANDROID_BUILD_TOP}"
 # in Android.mk.blueprint.
 ANDROIDMK_DIR="${OUT}/gen/STATIC_LIBRARIES/${PROJ_NAME}_intermediates"
 export BUILDDIR="${ANDROIDMK_DIR}"
-export TOPNAME="build.bp"
 export CONFIGNAME="bob.config"
 export SRCDIR="${PROJ_DIR}"
 export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"

--- a/example/bootstrap_linux.bash
+++ b/example/bootstrap_linux.bash
@@ -46,7 +46,6 @@ cd "${SRCDIR}"
 export SRCDIR
 export BUILDDIR
 export CONFIGNAME="bob.config"
-export TOPNAME="build.bp"
 export BOB_CONFIG_OPTS=
 export BOB_CONFIG_PLUGINS=
 export BLUEPRINT_LIST_FILE="bplist"

--- a/tests/bootstrap_androidbp
+++ b/tests/bootstrap_androidbp
@@ -95,7 +95,6 @@ cd "${ANDROID_BUILD_TOP}"
 
 BPBUILD_DIR="${OUT}/gen/STATIC_LIBRARIES/bobbp_${PROJ_NAME}_intermediates"
 export BUILDDIR="${BPBUILD_DIR}"
-export TOPNAME="build.bp"
 export CONFIGNAME="bob.config"
 export SRCDIR="${PROJ_DIR}"
 export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"

--- a/tests/bootstrap_androidmk
+++ b/tests/bootstrap_androidmk
@@ -97,7 +97,6 @@ cd "${ANDROID_BUILD_TOP}"
 # in Android.mk.blueprint.
 ANDROIDMK_DIR="${OUT}/gen/STATIC_LIBRARIES/${PROJ_NAME}_intermediates"
 export BUILDDIR="${ANDROIDMK_DIR}"
-export TOPNAME="build.bp"
 export CONFIGNAME="bob.config"
 export SRCDIR="${PROJ_DIR}"
 export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"

--- a/tests/bootstrap_linux
+++ b/tests/bootstrap_linux
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -79,7 +79,6 @@ create_link .. "${SCRIPT_DIR}/bob"
 
 # Bootstrap Bob
 export CONFIGNAME="bob.config"
-export TOPNAME="build.bp"
 export SRCDIR="${SCRIPT_DIR}"
 export BUILDDIR
 export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"


### PR DESCRIPTION
This commit removes the `TOPNAME` option from Bob.
Blueprint's `TOPNAME` is now always being set to "build.bp".

Change-Id: Ia6a24f32d5b623591dcc7edf927b4f34035892ba
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>