### PR TITLE
Set `Deps` type in Blueprint rules

### DIFF
--- a/plugins/genrulebob/genrule.go
+++ b/plugins/genrulebob/genrule.go
@@ -315,6 +315,7 @@ func (m *genrulebobCommon) writeNinjaRules(ctx android.ModuleContext, args map[s
 
 	if m.Properties.Depfile {
 		args["depfile"] = ""
+		ruleparams.Deps = blueprint.DepsGCC
 	}
 	args["headers_generated"] = ""
 	args["srcs_generated"] = ""


### PR DESCRIPTION
Set the `Deps` field in Ninja rules in the "genrulebob" and "gensrcsbob"
module types. Without this, the depfile is ignored.

Change-Id: Ie0ed24604928bb101607ae328d8aa4651188e5f7
Signed-off-by: Chris Diamand <chris.diamand@arm.com>