### PR TITLE
Add --depfile option to *config.py scripts

### DIFF
--- a/config.bash
+++ b/config.bash
@@ -48,4 +48,6 @@ cd -P "${WORKDIR}"
 "${BOB_DIR}/config_system/update_config.py" --new -d "${SRCDIR}/Mconfig" \
     ${BOB_CONFIG_OPTS} ${BOB_CONFIG_PLUGIN_OPTS} \
     -j "${CONFIG_JSON}" \
-    -c "${CONFIG_FILE}" "${ARG_TARGET[@]}"
+    -c "${CONFIG_FILE}" \
+    --depfile "${CONFIG_FILE}.d" \
+    "${ARG_TARGET[@]}"

--- a/config_system/config_system/data.py
+++ b/config_system/config_system/data.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@ logger.addHandler(logging.NullHandler())
 
 
 __mconfig_dir = ""
+__mconfig_srcs = []
 
 
 def get_mconfig_dir():
@@ -30,16 +31,25 @@ def get_mconfig_dir():
     return __mconfig_dir
 
 
+def get_mconfig_srcs():
+    """
+    Retrieve the list of sourced configuration files.
+    """
+    return __mconfig_srcs
+
+
 def init(options_filename, ignore_missing=False):
     from config_system import lex, lex_wrapper, syntax
 
     global __mconfig_dir
+    global __mconfig_srcs
     global configuration
 
     try:
         lexer = lex_wrapper.LexWrapper(ignore_missing)
         lexer.source(options_filename)
         configuration = syntax.parser.parse(None, debug=False, lexer=lexer)
+        __mconfig_srcs = lexer.sources
     except lex.TokenizeError as e:
         logger.debug("Failed to tokenise input")
         exit(1)

--- a/config_system/config_system/general.py
+++ b/config_system/config_system/general.py
@@ -235,6 +235,12 @@ def write_config(config_filename):
     logger.info("Written configuration to '%s'" % config_filename)
 
 
+def write_depfile(depfile, target_name):
+    with open(depfile, "wt") as fp:
+        fp.write(target_name + ": \\\n    ")
+        fp.write(" \\\n    ".join(data.get_mconfig_srcs()) + "\n")
+
+
 def get_options_selecting(selected):
     """Return the options which select `selected`"""
     opt = data.get_config(selected)

--- a/config_system/config_system/lex_wrapper.py
+++ b/config_system/config_system/lex_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@ from config_system import lex
 class LexWrapper:
     def __init__(self, ignore_missing, verbose=False):
         self.lexers = []
+        self.sources = []
         self.root_dir = None
         self.ignore_missing = ignore_missing
         self.verbose = verbose
@@ -48,6 +49,7 @@ class LexWrapper:
             fname = os.path.join(self.root_dir, fname)
 
         self.open(fname)
+        self.sources.append(fname)
 
     def current_lexer(self):
         return self.lexers[-1]

--- a/config_system/menuconfig.py
+++ b/config_system/menuconfig.py
@@ -626,6 +626,8 @@ def parse_args():
     parser.add_argument("--debug", action="store_true", dest="debug", help="Enable debug logging")
     parser.add_argument("-p", "--plugin", action="append",
                         help="Post configuration plugin to execute", default=[])
+    parser.add_argument('--depfile', default=None,
+                        help='Write dependencies to named file')
     parser.add_argument("--ignore-missing", action="store_true", default=False,
                         help="Ignore missing database files included with 'source'")
     return parser.parse_args()
@@ -691,6 +693,8 @@ def main():
         general.write_config(args.config)
         if args.json is not None:
             config_json.write_config(args.json)
+        if args.depfile is not None:
+            general.write_depfile(args.depfile, args.config)
 
     # Flush all log messages on exit
     msgBuffer.close()

--- a/config_system/tests/test_update_config.py
+++ b/config_system/tests/test_update_config.py
@@ -131,6 +131,7 @@ def test_ignored_config_option(caplog, mocker, tmpdir, mconfig, args, error):
         json=None,
         new=True,
         plugin=[],
+        depfile=None,
         ignore_missing=False,
         args=args,
     ))
@@ -273,6 +274,7 @@ def test_select_depend(caplog, mocker, tmpdir,
         json=None,
         new=(config==None),
         plugin=[],
+        depfile=None,
         ignore_missing=False,
         args=args,
     ))
@@ -345,6 +347,7 @@ def test_option_depends_on_plugin(caplog, mocker, tmpdir, plugin, mconfig, args)
         json=None,
         new=True,
         plugin=[os.path.splitext(str(plugin_fname))[0]],
+        depfile=None,
         ignore_missing=False,
         args=args,
     ))

--- a/config_system/update_config.py
+++ b/config_system/update_config.py
@@ -25,7 +25,7 @@ import sys
 from config_system import log_handlers, config_json
 from config_system.general import enforce_dependent_values, init_config, \
     read_config, read_profile_file, set_config_if_prompt, write_config, \
-    can_enable
+    can_enable, write_depfile
 from config_system.data import get_config
 from config_system.expr import format_dependency_list
 
@@ -133,6 +133,8 @@ def parse_args():
     parser.add_argument('-p', '--plugin', action='append',
                         help='Post configuration plugin to execute',
                         default=[])
+    parser.add_argument('--depfile', default=None,
+                        help='Write dependencies to named file')
     parser.add_argument('--ignore-missing', action='store_true', default=False,
                         help="Ignore missing database files included with 'source'")
     parser.add_argument('args', nargs="*")
@@ -191,6 +193,8 @@ def main():
     write_config(args.config)
     if args.json is not None:
         config_json.write_config(args.json)
+    if args.depfile is not None:
+        write_depfile(args.depfile, args.config)
 
     error_count = counter.errors() + counter.criticals()
 

--- a/menuconfig.bash
+++ b/menuconfig.bash
@@ -28,4 +28,5 @@ cd -P "${WORKDIR}"
 "${BOB_DIR}/config_system/menuconfig.py" -d "${SRCDIR}/Mconfig" \
     ${BOB_CONFIG_OPTS} ${BOB_CONFIG_PLUGIN_OPTS} \
     -j "${CONFIG_JSON}" \
+    --depfile "${CONFIG_FILE}.d" \
     "${CONFIG_FILE}"


### PR DESCRIPTION
This commits adds `--depfile` option to `update_config.py` and
`menuconfig.py` to write Mconfig dependencies.

Change-Id: Idb8135591c8a055e4a10bfec1039d9f3203e3f05
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>