### PR TITLE
Improve checks for outdated Android.bp

### DIFF
--- a/config_system/config_system/general.py
+++ b/config_system/config_system/general.py
@@ -236,7 +236,7 @@ def write_config(config_filename):
 
 
 def write_depfile(depfile, target_name):
-    with open(depfile, "wt") as fp:
+    with utils.open_and_write_if_changed(depfile) as fp:
         fp.write(target_name + ": \\\n    ")
         fp.write(" \\\n    ".join(data.get_mconfig_srcs()) + "\n")
 

--- a/scripts/verify_hash.py
+++ b/scripts/verify_hash.py
@@ -25,14 +25,14 @@ def parse_args():
     ap = argparse.ArgumentParser()
 
     ap.add_argument("--hash", type=str, required=True,
-                    help="Combined hash of build.bp files")
+                    help="Combined hash of the build.bp and Mconfig files")
     # We have to create an output file to stop the check being run on every
     # build. FileType("wt") will automatically create one, so there's no need
     # for any extra code.
     ap.add_argument("--out", type=argparse.FileType("wt"),
                     help="Dummy output file name. This is written, but not used")
     ap.add_argument("inputs", nargs="+", type=str, default=[],
-                    help="build.bp files to check")
+                    help="build.bp and Mconfig files to check")
 
     return ap.parse_args()
 
@@ -42,18 +42,18 @@ def main():
 
     combinedHash = hashlib.sha1()
 
-    for buildbp in sorted(args.inputs):
+    for src in args.inputs:
         fileHash = hashlib.sha1()
-        with open(buildbp, "rb") as fp:
+        with open(src, "rb") as fp:
             fileHash.update(fp.read())
         combinedHash.update(fileHash.digest())
 
     if combinedHash.hexdigest() != args.hash:
         lines = [
-            "+---------------------------------------------------------------------------+",
-            "| WARNING: build.bp files have been changed since Android.bp was generated! |",
-            "| WARNING:                  Please regenerate Android.bp                    |",
-            "+---------------------------------------------------------------------------+",
+            "+--------------------------------------------------------------------+",
+            "| WARNING: Android.bp is not up to date with build.bp/Mconfig files! |",
+            "| WARNING:               Please regenerate Android.bp                |",
+            "+--------------------------------------------------------------------+",
         ]
         for line in lines:
             sys.stderr.write(line + "\n")


### PR DESCRIPTION
This commit extends the checks to support detecting changes in
`Mconfig` files (commit 58d536fa handles `build.bp` changes).

Change-Id: I3f9d2ec5054eea65bbb12a307415f59cdf184733
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>