### PR TITLE
Kmod changes

### DIFF
--- a/core/androidbp_generated.go
+++ b/core/androidbp_generated.go
@@ -101,6 +101,16 @@ func populateCommonProps(gc *generateCommon, mctx blueprint.ModuleContext, m bpw
 	m.AddStringList("asflags", gc.Properties.FlagArgsBuild.Asflags)
 	m.AddStringList("ldflags", gc.Properties.FlagArgsBuild.Ldflags)
 	m.AddStringList("ldlibs", gc.Properties.FlagArgsBuild.Ldlibs)
+
+	// make use of soong properties for selecting variant
+	// (by default device is supported and host is not)
+	if gc.getTarget() == tgtTypeHost {
+		m.AddBool("device_supported", false)
+		m.AddBool("host_supported", true)
+	} else if gc.getTarget() == tgtTypeTarget {
+		m.AddBool("device_supported", true)
+		m.AddBool("host_supported", false)
+	}
 }
 
 func (g *androidBpGenerator) generateSourceActions(gs *generateSource, mctx blueprint.ModuleContext) {

--- a/core/androidbp_kernel_module.go
+++ b/core/androidbp_kernel_module.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 
 	"github.com/google/blueprint"
-	"github.com/google/blueprint/proptools"
 
 	"github.com/ARM-software/bob-build/internal/utils"
 )
@@ -102,17 +101,8 @@ func (g *androidBpGenerator) kernelModuleActions(l *kernelModule, mctx blueprint
 		l.Properties.Make_args,
 	)
 
-	installProps := l.getInstallableProps()
-	installPath, ok := installProps.getInstallGroupPath()
-	if !ok {
-		installPath = ""
-	} else {
-		if installProps.Relative_install_path != nil {
-			installPath = filepath.Join(installPath, proptools.String(installProps.Relative_install_path))
-		}
-	}
-
-	if installPath != "" {
+	installPath, ok := l.getInstallableProps().getFullInstallPath()
+	if ok {
 		bpmod.AddString("install_path", installPath)
 	}
 

--- a/core/androidbp_resource.go
+++ b/core/androidbp_resource.go
@@ -19,11 +19,9 @@ package core
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/google/blueprint"
-	"github.com/google/blueprint/proptools"
 )
 
 func (g *androidBpGenerator) resourceActions(r *resource, mctx blueprint.ModuleContext) {
@@ -31,15 +29,7 @@ func (g *androidBpGenerator) resourceActions(r *resource, mctx blueprint.ModuleC
 		return
 	}
 
-	installProps := r.getInstallableProps()
-	installPath, ok := installProps.getInstallGroupPath()
-	if !ok {
-		installPath = ""
-	} else {
-		if installProps.Relative_install_path != nil {
-			installPath = filepath.Join(installPath, proptools.String(installProps.Relative_install_path))
-		}
-	}
+	installPath, _ := r.getInstallableProps().getFullInstallPath()
 
 	subdir := ""
 	var modType string

--- a/core/install.go
+++ b/core/install.go
@@ -19,6 +19,7 @@ package core
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/google/blueprint"
 	"github.com/google/blueprint/proptools"
@@ -105,6 +106,18 @@ func (props *InstallableProps) getInstallGroupPath() (path string, ok bool) {
 		return "", false
 	}
 	return proptools.String(props.Install_path), true
+}
+
+func (props *InstallableProps) getFullInstallPath() (installPath string, ok bool) {
+	installPath, ok = props.getInstallGroupPath()
+	if !ok {
+		installPath = ""
+	} else {
+		if props.Relative_install_path != nil {
+			installPath = filepath.Join(installPath, proptools.String(props.Relative_install_path))
+		}
+	}
+	return
 }
 
 func getShortNamesForDirectDepsIf(ctx blueprint.ModuleContext,

--- a/plugins/genrulebob/genrule.go
+++ b/plugins/genrulebob/genrule.go
@@ -142,7 +142,8 @@ func genrulebobFactory() android.Module {
 	// note: we register our custom properties first, to take precedence before common ones
 	m.AddProperties(&m.Properties)
 	m.AddProperties(&m.genrulebobCommon.Properties)
-	android.InitAndroidModule(m)
+	// init module with target-specific variants info
+	android.InitAndroidArchModule(m, android.HostAndDeviceSupported, android.MultilibCommon)
 	return m
 }
 
@@ -152,7 +153,8 @@ func gensrcsbobFactory() android.Module {
 	// note: we register our custom properties first, to take precedence before common ones
 	m.AddProperties(&m.Properties)
 	m.AddProperties(&m.genrulebobCommon.Properties)
-	android.InitAndroidModule(m)
+	// init module with target-specific variants info
+	android.InitAndroidArchModule(m, android.HostAndDeviceSupported, android.MultilibCommon)
 	return m
 }
 

--- a/tests/flag_defaults/build.bp
+++ b/tests/flag_defaults/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Arm Limited.
+ * Copyright 2018,2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,6 +48,7 @@ bob_generate_source {
     args: ["--check-host"],
     out: ["flags.txt"],
     target: "host",
+    build_by_default: true,
 }
 
 bob_generate_source {
@@ -58,6 +59,7 @@ bob_generate_source {
     args: ["--check-target"],
     out: ["flags.txt"],
     target: "target",
+    build_by_default: true,
 }
 
 bob_alias {


### PR DESCRIPTION
Those 5 commits are changes related to genrule_bob:
- convert Android.bp kernel module generation from soong genrule to customized genrule_bob
- make use of soong properties for selecting host or device variants in genrulebob, using bob 'target' property of generate source and transform source.
- enabling flag_defaults test, that uses above 'target' property (test was not enabled on AndroidBP apparently by mistake)
- add back once forgotten feature of installing kernel modules onto one of the target partitions
- add missing support for extra_cflags and make_args for AndroidBP
- remove depfile from args, as it is duplicated by the resulting ninja params
- extract getFullInstallPath() function