### PR TITLE
Add support for testing the availability of compiler flags

### DIFF
--- a/core/standalone.go
+++ b/core/standalone.go
@@ -171,6 +171,7 @@ func Main() {
 			ctx.RegisterTopDownMutator("escape_mutator", escapeMutator).Parallel()
 		}
 		ctx.RegisterTopDownMutator("match_sources_mutator", matchSourcesMutator).Parallel()
+		ctx.RegisterBottomUpMutator("check_supported_flags_mutator", checkCompilerFlagsMutator).Parallel()
 	}
 
 	if builder_ninja {

--- a/core/template.go
+++ b/core/template.go
@@ -91,6 +91,10 @@ func matchSrcs(input string) string {
 	return "{{match_srcs " + input + "}}"
 }
 
+func filter_compiler_flags(flag string) string {
+	return "{{add_if_supported " + flag + "}}"
+}
+
 // ApplyTemplate writes configuration values (from properties) into the string
 // properties in props. This is done recursively.
 func ApplyTemplate(props interface{}, properties *configProperties) {
@@ -102,6 +106,7 @@ func ApplyTemplate(props interface{}, properties *configProperties) {
 	funcmap["reg_match"] = regMatch
 	funcmap["reg_replace"] = regReplace
 	funcmap["match_srcs"] = matchSrcs
+	funcmap["add_if_supported"] = filter_compiler_flags
 	propsVal := reflect.Indirect(reflect.ValueOf(props))
 
 	applyTemplateRecursive(propsVal, stringvalues, funcmap)

--- a/docs/features.md
+++ b/docs/features.md
@@ -79,6 +79,9 @@ A few custom functions are implemented by Bob:
                              `srcs` property (only valid in `ldflags`,
                              `cmd` and `args`)
 
+`{{add_if_supported compiler_flag}}` - return the parameter if the compiler used for
+                                     the module recognises it as a valid argument
+
 Go templates natively support more. [Check Go template package.](https://golang.org/pkg/text/template/)
 
 #### Example

--- a/docs/user_guide/libraries_2.md
+++ b/docs/user_guide/libraries_2.md
@@ -276,6 +276,20 @@ bob_static_library {
 }
 ```
 
+## Supporting different generations of compiler flags
+
+Sometimes a library needs to be compatible with a whole range of
+compiler versions that might have different behaviours between each
+generation. One common usage is to avoid new warnings being introduced
+by more modern compilers.
+
+In that case you can use the template `{{add_if_supported
+"<compiler_flag>"}}` in the `cflags`, `cxxflags` or `conlyflags` to
+instruct Bob to add the given compiler flag to the compiler arguments,
+but only if the compiler recognises that flag. If the compiler doesn't
+recognise the `<compiler_flag>` it will be silently discarded from
+`cflags`, `cxxflags` and `conlyflags`.
+
 ## Retaining API functions in shared libraries
 
 The linker will typically remove unused code from the output file. For

--- a/tests/bplist
+++ b/tests/bplist
@@ -12,6 +12,7 @@
 ./export_include_dirs/libb/build.bp
 ./external_libs/build.bp
 ./flag_defaults/build.bp
+./flag_supported/build.bp
 ./forwarding_libs/forwarding/build.bp
 ./forwarding_libs/forwarding_impl/build.bp
 ./forwarding_libs/forwarding_user/build.bp

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -67,6 +67,8 @@ bob_alias {
         "bob_test_export_include_dirs",
         "bob_test_external_libs",
         "bob_test_flag_defaults",
+        "bob_test_flag_supported",
+        "bob_test_flag_unsupported",
         "bob_test_forwarding_libs",
         "bob_test_generate_libs",
         "bob_test_generate_source",

--- a/tests/flag_supported/build.bp
+++ b/tests/flag_supported/build.bp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+bob_binary {
+    name: "bob_test_flag_supported",
+    srcs: ["test.c", "test_cpp.cpp"],
+    conlyflags: [
+        "{{add_if_supported \"-Wno-discarded-qualifiers\"}}",
+        "{{add_if_supported \"-Wno-ignored-qualifiers\"}}",
+        "{{add_if_supported \"-Wno-main-return-type\"}}",
+	/* old gcc uses -Wmain to warn about the declaration of 'main' */
+        "{{add_if_supported \"-Wno-main\"}}",
+    ],
+    cflags: ["-Wall", "-Werror"],
+    cxxflags: [
+        "{{add_if_supported \"-Wno-ignored-qualifiers\"}}",
+    ],
+}
+
+bob_binary {
+    name: "bob_test_flag_unsupported",
+    srcs: ["test2.c"],
+    conlyflags: ["{{add_if_supported \"-Wnon_existent_conly_flag\"}}"],
+    cflags: ["{{add_if_supported \"-Wnon_existent_c_flag\"}}"],
+    cxxflags: ["{{add_if_supported \"-Wnon_existent_cxx_flag\"}}"],
+}

--- a/tests/flag_supported/test.c
+++ b/tests/flag_supported/test.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+void useless(void)
+{
+    printf("I am not used\n");
+}
+
+const char main(int argc, char** argv)
+{
+    (void)argc;
+    (void)argv;
+    const int i = 0;
+    return i;
+}

--- a/tests/flag_supported/test2.c
+++ b/tests/flag_supported/test2.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+void useless(void)
+{
+    printf("I am not used\n");
+}
+
+const char main(int argc, char** argv)
+{
+    (void)argc;
+    (void)argv;
+    const int i = 0;
+    return i;
+}

--- a/tests/flag_supported/test_cpp.cpp
+++ b/tests/flag_supported/test_cpp.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+#ifdef EXTRA_CXXFLAGS
+#define QUALIFIER    const
+#else
+#define QUALIFIER
+#endif
+
+QUALIFIER int hello() {
+    cout << string("Hello World!") << endl;
+    return 0;
+}


### PR DESCRIPTION
Newer versions of a compiler adds support for new flags that would not be
understood by older compilers. To allow for the addition of those new flags
into the build.bp file, add '{{addIfSupported' late template
that will take as an argument the compiler flag to be tested for support
by the current toolchain compiler. Note that 'cflags' and 'export_cflags'
are tested with both the C and C++ compilers.

Signed-off-by: Liviu Dudau <liviu.dudau@arm.com>
Change-Id: Ifce31bb3d7df44d37ba0b16a72e8475980e5691e