### PR TITLE
Add LC_ALL=C to bplist_regen.sh to ensure consistent ordering.

### DIFF
--- a/tests/bplist_regen.sh
+++ b/tests/bplist_regen.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright 2018 Arm Limited.
+# Copyright 2018, 2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +36,7 @@ find . -mindepth 1 \
 echo ./bob/Blueprints >> "${TEMP_LIST_FILE}"
 echo ./bob/blueprint/Blueprints >> "${TEMP_LIST_FILE}"
 
-sort "${TEMP_LIST_FILE}" -o "${TEMP_LIST_FILE}"
+LC_ALL=C sort "${TEMP_LIST_FILE}" -o "${TEMP_LIST_FILE}"
 
 if cmp -s "${LIST_FILE}" "${TEMP_LIST_FILE}"; then
   rm "${TEMP_LIST_FILE}"


### PR DESCRIPTION
Without a fixed locale the output of sort will depend on the locale
settings on the machine where 'bplist_regen.sh' gets run, which
might re-order some of the entries in the old list.

Signed-off-by: Liviu Dudau <liviu.dudau@arm.com>
Change-Id: I1dd4c80f87a4a72d9e3a8b8702e314b929a2aafa