### PR TITLE
Test Go 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,13 @@ matrix:
       - DO_COMMIT_CHECKS=0
       - DO_PYTHON_TESTS=0
       - DO_GO_TESTS=1
+  - os: linux
+    go: "1.14"
+    env:
+      - PYTHON_SUFFIX=2.7
+      - DO_COMMIT_CHECKS=0
+      - DO_PYTHON_TESTS=0
+      - DO_GO_TESTS=1
   - os: osx
     go: "1.13"
     env:


### PR DESCRIPTION
Golang 1.14 was released in February - update `.travis.yml` to test it.

Change-Id: I56b7c7a378e82f2b0a2b2ea579be4dea14b229f9
Signed-off-by: Chris Diamand <chris.diamand@arm.com>