### PR TITLE
Add proper support for property exclude_implicit_srcs

### DIFF
--- a/core/androidbp_generated.go
+++ b/core/androidbp_generated.go
@@ -125,7 +125,7 @@ func (g *androidBpGenerator) generateSourceActions(gs *generateSource, mctx blue
 
 	m.AddStringList("srcs", gs.generateCommon.Properties.getSources(mctx))
 	m.AddStringList("out", gs.Properties.Out)
-	m.AddStringList("implicit_srcs", gs.Properties.Implicit_srcs)
+	m.AddStringList("implicit_srcs", gs.Properties.getImplicitSources(mctx))
 	m.AddStringList("implicit_outs", gs.Properties.Implicit_outs)
 
 	populateCommonProps(&gs.generateCommon, mctx, m)

--- a/core/generated.go
+++ b/core/generated.go
@@ -497,6 +497,7 @@ func getRspfileName(s string) string {
 
 func (m *generateSource) processPaths(ctx blueprint.BaseModuleContext, g generatorBackend) {
 	m.Properties.Implicit_srcs = utils.PrefixDirs(m.Properties.Implicit_srcs, projectModuleDir(ctx))
+	m.Properties.Exclude_implicit_srcs = utils.PrefixDirs(m.Properties.Exclude_implicit_srcs, projectModuleDir(ctx))
 	m.generateCommon.processPaths(ctx, g)
 }
 

--- a/docs/module_types/bob_generate_source.md
+++ b/docs/module_types/bob_generate_source.md
@@ -72,6 +72,11 @@ List of implicit sources. Implicit sources are input files that do not get
 mentioned on the command line, and are not specified in the explicit sources.
 
 ----
+### **bob_generate_source.exclude_implicit_srcs** (optional)
+From `implicit_srcs` files filter out those that should not be included.
+Useful if `implicit_srcs` uses glob pattern that pulls in too many files.
+
+----
 ### **bob_generate_source.implicit_outs** (optional)
 List of implicit outputs. Implicit outputs are output files that do not get
 mentioned on the command line.

--- a/tests/generate_source/an.implicit.src
+++ b/tests/generate_source/an.implicit.src
@@ -1,0 +1,4 @@
+int main(void)
+{
+	return 0;
+}

--- a/tests/generate_source/bn.src
+++ b/tests/generate_source/bn.src
@@ -1,0 +1,1 @@
+#error This file should not be included in compilation

--- a/tests/generate_source/build.bp
+++ b/tests/generate_source/build.bp
@@ -238,7 +238,18 @@ bob_generate_source {
     name: "gen_source_globbed_implicit_sources",
     implicit_srcs: ["*.implicit.src"],
     out: ["validate_globbed_implicit_dependency.c"],
-    cmd: "echo 'int main(void) { return 0; }' > ${out}",
+    tool: "join_srcs.py",
+    cmd: "python ${tool} --src-dir ${module_dir} --use-a --out ${out}",
+    build_by_default: true,
+}
+
+bob_generate_source {
+    name: "gen_source_globbed_exclude_implicit_sources",
+    implicit_srcs: ["*.src"],
+    exclude_implicit_srcs: ["an.implicit.src", "bn.src"],
+    out: ["validate_globbed_exclude_implicit_dependency.c"],
+    tool: "join_srcs.py",
+    cmd: "python ${tool} --src-dir ${module_dir} --use-c --out ${out}",
     build_by_default: true,
 }
 
@@ -246,6 +257,7 @@ bob_binary {
     name: "use_miscellaneous_generated_source_tests",
     generated_sources: [
         "gen_source_globbed_implicit_sources",
+        "gen_source_globbed_exclude_implicit_sources",
     ],
 }
 

--- a/tests/generate_source/cn.src
+++ b/tests/generate_source/cn.src
@@ -1,0 +1,4 @@
+int submain(void)
+{
+	return 0;
+}

--- a/tests/generate_source/join_srcs.py
+++ b/tests/generate_source/join_srcs.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# Copyright 2020 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+
+parser = argparse.ArgumentParser(description='Join input sources into single output file.')
+parser.add_argument('--src-dir', action='store', required=True, help='Dir containing source files')
+parser.add_argument('--use-a', action='store_true', help='Use file A as input')
+parser.add_argument('--use-c', action='store_true', help='Use file C as input')
+parser.add_argument('--out', dest='output', action='store', required=True, help='Output file')
+args = parser.parse_args()
+
+inputs = []
+if args.use_a:
+    inputs.append(os.path.join(args.src_dir, 'an.implicit.src'))
+if args.use_c:
+    inputs.append(os.path.join(args.src_dir, 'cn.src'))
+
+try:
+    with open(args.output, 'w') as outfile:
+        for infile in inputs:
+            if not os.path.exists(infile):
+                print("Input file doesn't exist: " + infile)
+                sys.exit(1)
+            outfile.write(open(infile, 'r').read() + '\n')
+except IOError as e:
+    print("Output file couldn't be created: " + str(e))
+    sys.exit(1)


### PR DESCRIPTION
Add documentation and test. Test now uses external join_srcs.py script
to actually read input files and produce relevant output. Adapted
previous test to use it too.

Change-Id: Iaaa18b48e900e116ea25c1aa50e9925ba4fa9fee
Signed-off-by: Michal Przeplata <michal.przeplata@arm.com>