### PR TITLE
Align flag quoting with soong

### DIFF
--- a/.travis/run_go_tests.sh
+++ b/.travis/run_go_tests.sh
@@ -4,7 +4,7 @@ trap "echo '<------------- $(basename ${0}) failed'" ERR
 
 cd ${BOB_WORKSPACE}/src/github.com/ARM-software/bob-build/
 NAMESPACE="github.com/ARM-software/bob-build"
-go test "$NAMESPACE/core" "$NAMESPACE/internal/graph" "$NAMESPACE/internal/utils"
+go test "$NAMESPACE/core" "$NAMESPACE/internal/escape" "$NAMESPACE/internal/graph" "$NAMESPACE/internal/utils"
 #go test ./... # This should run all tests in current directory and all of its subdirectories
 
 # go test -race -short ./...

--- a/Blueprints
+++ b/Blueprints
@@ -32,6 +32,7 @@ bootstrap_go_package {
         "blueprint-pathtools",
         "bob-bpwriter",
         "bob-ccflags",
+        "bob-escape",
         "bob-fileutils",
         "bob-graph",
         "bob-utils",
@@ -49,6 +50,7 @@ bootstrap_go_package {
         "core/config_props.go",
         "core/defaults.go",
         "core/external_library.go",
+        "core/escape.go",
         "core/feature.go",
         "core/filepath.go",
         "core/gen_binary.go",
@@ -98,6 +100,17 @@ bootstrap_go_package {
         "internal/ccflags/ccflags.go",
     ],
     pkgPath: "github.com/ARM-software/bob-build/internal/ccflags",
+}
+
+bootstrap_go_package {
+    name: "bob-escape",
+    deps: [
+        "blueprint",
+    ],
+    srcs: [
+        "internal/escape/escape.go",
+    ],
+    pkgPath: "github.com/ARM-software/bob-build/internal/escape",
 }
 
 bootstrap_go_package {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,14 +66,12 @@ Bob has three kinds of tests:
   export GOPATH=~/go
   ./scripts/setup_workspace_for_bob.bash
   go test github.com/ARM-software/bob-build/core \
+          github.com/ARM-software/bob-build/internal/escape \
           github.com/ARM-software/bob-build/internal/graph \
           github.com/ARM-software/bob-build/internal/utils
   # OR:
-  cd $GOPATH/src/github.com/ARM-software/bob-build/core
-  go test
-  # OR:
   cd $GOPATH/src/github.com/ARM-software/bob-build
-  go test ./core ./internal/graph ./internal/utils
+  go test ./core ./internal/escape ./internal/graph ./internal/utils
   ```
 
 - The configuration system tests:

--- a/core/androidbp_backend.go
+++ b/core/androidbp_backend.go
@@ -89,6 +89,12 @@ func (g *androidBpGenerator) sharedLibsDir(tgtType) string {
 	return ""
 }
 
+func (g *androidBpGenerator) escapeFlag(s string) string {
+	// Soong will handle the escaping of flags, so the androidbp backend
+	// just passes them through.
+	return s
+}
+
 type androidBpSingleton struct {
 }
 

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -90,6 +90,9 @@ type generatorBackend interface {
 	bobScriptsDir() string
 	sharedLibsDir(tgt tgtType) string
 
+	// Backend flag escaping
+	escapeFlag(string) string
+
 	// Backend initialisation
 	init(*blueprint.Context, *bobConfig)
 

--- a/core/escape.go
+++ b/core/escape.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"github.com/google/blueprint"
+
+	"github.com/ARM-software/bob-build/internal/escape"
+)
+
+func escapeMutator(mctx blueprint.TopDownMutatorContext) {
+	// This mutator is not registered on the androidbp backend, as it
+	// doesn't need escaping
+
+	g := getBackend(mctx)
+	module := mctx.Module()
+
+	if _, ok := module.(*defaults); ok {
+		// No need to apply to defaults
+		return
+	}
+
+	if e, ok := module.(enableable); ok {
+		if !isEnabled(e) {
+			// Not enabled, skip execution
+			return
+		}
+	}
+
+	// Escape libraries as well as generator modules
+	var build *Build
+	if b, ok := module.(moduleWithBuildProps); ok {
+		build = b.build()
+	} else if gsc, ok := getGenerateCommon(module); ok {
+		build = &gsc.Properties.FlagArgsBuild
+	} else {
+		return
+	}
+
+	// Escape each of asflags, cflags, conlyflags, cxxflags, and ldflags
+	// If the flags contain template sequences, we avoid escaping those
+	build.Asflags = escape.EscapeTemplatedStringList(build.Asflags, g.escapeFlag)
+	build.Cflags = escape.EscapeTemplatedStringList(build.Cflags, g.escapeFlag)
+	build.Conlyflags = escape.EscapeTemplatedStringList(build.Conlyflags, g.escapeFlag)
+	build.Cxxflags = escape.EscapeTemplatedStringList(build.Cxxflags, g.escapeFlag)
+	build.Ldflags = escape.EscapeTemplatedStringList(build.Ldflags, g.escapeFlag)
+}

--- a/core/generated.go
+++ b/core/generated.go
@@ -418,7 +418,7 @@ func (m *generateCommon) getArgs(ctx blueprint.ModuleContext) (string, map[strin
 	cc, cctargetflags := tc.getCCompiler()
 	cxx, cxxtargetflags := tc.getCXXCompiler()
 	linker := tc.getLinker().getTool()
-	ldflags := tc.getLinker().getFlags()
+	ldtargetflags := tc.getLinker().getFlags()
 	ldlibs := tc.getLinker().getLibs()
 
 	props := &m.Properties.FlagArgsBuild
@@ -434,7 +434,7 @@ func (m *generateCommon) getArgs(ctx blueprint.ModuleContext) (string, map[strin
 		"conlyflags":        strings.Join(append(cctargetflags, props.Conlyflags...), " "),
 		"cxx":               cxx,
 		"cxxflags":          strings.Join(append(cxxtargetflags, props.Cxxflags...), " "),
-		"ldflags":           utils.Join(ldflags, props.Ldflags),
+		"ldflags":           utils.Join(ldtargetflags, props.Ldflags),
 		"ldlibs":            utils.Join(ldlibs, props.Ldlibs),
 		"linker":            linker,
 		"gen_dir":           m.outputDir(),

--- a/core/linux.go
+++ b/core/linux.go
@@ -81,6 +81,10 @@ func addPhony(p phonyInterface, ctx blueprint.ModuleContext,
 		})
 }
 
+func (g *linuxGenerator) escapeFlag(s string) string {
+	return proptools.NinjaAndShellEscape(s)
+}
+
 func (g *linuxGenerator) sourceDir() string {
 	return "${SrcDir}"
 }
@@ -339,9 +343,8 @@ func (l *library) CompileObjs(ctx blueprint.ModuleContext) ([]string, []string) 
 	gendirs, orderOnly := l.GetGeneratedHeaders(ctx)
 	includeDirs = append(includeDirs, gendirs...)
 	includeFlags := utils.PrefixAll(includeDirs, "-I")
-	cflagsList := utils.NewStringSlice(l.Properties.Cflags, includeFlags)
-	cflagsList = append(cflagsList, l.Properties.Export_cflags...)
-	cflagsList = append(cflagsList, exportedCflags...)
+	cflagsList := utils.NewStringSlice(l.Properties.Cflags, l.Properties.Export_cflags,
+		exportedCflags, includeFlags)
 
 	tc := g.getToolchain(l.Properties.TargetType)
 	as, astargetflags := tc.getAssembler()

--- a/docs/module_types/common_generate_module_properties.md
+++ b/docs/module_types/common_generate_module_properties.md
@@ -13,26 +13,34 @@ be referred to as `bob_generated`.
 
 ----
 ### **bob_generated.cmd** (required)
-The command that is to be run for this source generation.
-Substitutions can be made in the command, by using
-`$name_of_var`. A list of substitutions that can be used:
+The command that is to be run for this module. Bob supports various
+substitutions in the command, by using `${name_of_var}`. The
+available substitutions are:
 
-- `$gen_dir` - the path to the directory which belongs to this source generator
-- `$in` - the path to the sources - space-delimited
-- `$out` - the path to the targets - space-delimited
-- `$depfile` - the path to generated dependency file
-- `$rspfile` - the path to the RSP file, if rsp_content is set
-- `$args` - the value of "args" - space-delimited
-- `$tool` - the path to the tool
-- `$host_bin` - the path to the binary that is produced by the host_bin module
-- `$(name)_dir` - the build directory for each dep in generated_dep
-- `$src_dir` - the path to the project source directory - this will be different
+- `${in}` - space-delimited list of source (input) paths
+- `${out}` - space-delimited list of target (output) paths
+- `${depfile}` - the path for the generated dependency file
+- `${rspfile}` - the path to the RSP file, if `rsp_content` is set
+- `${args}` - the value of `args` - space-delimited
+- `${tool}` - the path to the script specified by `tool`
+- `${host_bin}` - the path to the binary specified by `host_bin`
+- `${module_dir}` - the path this module's source directory
+- `${gen_dir}` - the path to the output directory for this module
+- `${(name)_dir}` - the output directory for the `module_deps` dependency with `name`
+- `${(name)_out}` - the outputs of the `module_deps` dependency with `name`
+- `${src_dir}` - the path to the project source directory - this will be different
   than the build source directory for Android.
-- `$module_dir` - the path to the module directory
+
+The value in `cmd` is executed by the shell. Compound shell
+expressions and expansions can be used, though we recommend keeping
+commands simple. If double quotes (") need to be on the shell command
+line, they should be escaped with backslash (\) to get through the
+blueprint parser. Where a `$` needs to be evaluated by the shell (for
+example to expand an environment variable) use `$$`.
 
 ----
 ### **bob_generated.tool** (required)
-A path to the tool that is to be used in `cmd`. If `$tool` is in
+A path to the tool that is to be used in `cmd`. If `${tool}` is in
 the command variable, then this will be replaced with the path to
 this tool.
 
@@ -45,7 +53,7 @@ be built before the `bob_generated`.
 ----
 ### **bob_generated.module_deps** (optional)
 A list of other modules that this generator depends on. The dependencies can be
-used in the command through `$(name_of_dependency)_dir` (that is, the variable's
+used in the command through `${(name_of_dependency)_dir}` (that is, the variable's
 name is the name of the dependency, with the `_dir` suffix).
 
 ----

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -98,6 +98,19 @@ Flags can be added with the `cflags` parameter.
 Note that defines are not specially treated, and must
 thus be added as flags using `"-DCOLOR_DEF=blue"`
 
+Double quotes (") need to be escaped with backslash (\) to prevent the
+blueprint parser consuming them. As with any string property, Go
+templates can be used. Otherwise each flag should be written
+as the C compiler expects to see it in its argument list i.e. without
+shell escaping. Expansion of environment variables, ninja variables,
+or make variables is not possible.
+
+For example to define a string literal:
+
+```
+    cflags: ["-DCOLOR_DEF=\"blue\""]
+```
+
 ----
 ### **bob_module.export_cflags** (optional)
 Flags exported to modules which depend on the current one. These will
@@ -108,22 +121,38 @@ dependencies `libA -> libB -> libC`, flags inside `libC`'s
 If `libB` wishes to propagate `libC`'s flags to `libA`, it should add
 `libC` to its `reexport_libs` list.
 
+Also see `cflags`.
+
 ----
 ### **bob_module.conlyflags** (optional)
-Flags used for C compilation.
+Flags used for C compilation. See `cflags`.
 
 ----
 ### **bob_module.cxxflags** (optional)
-Flags used for C++ compilation.
+Flags used for C++ compilation. See `cflags`.
 
 ----
 ### **bob_module.asflags** (optional)
 Flags used for assembly compilation.
 
+Double quotes (") need to be escaped with backslash (\) to prevent the
+blueprint parser consuming them. As with any string property, Go
+templates can be used. Otherwise each flag should be written as the
+assembler expects to see it in its argument list i.e. without shell
+escaping. Expansion of environment variables, ninja variables, or make
+variables is not possible.
+
 ----
 ### **bob_module.ldflags** (optional)
 Flags used for linking. Unlike `ldlibs`, `ldflags` is added to the _start_ of
 the linker command-line.
+
+Double quotes (") need to be escaped with backslash (\) to prevent the
+blueprint parser consuming them. As with any string property, Go
+templates can be used. Otherwise each flag should be written
+as the linker expects to see it in its argument list i.e. without
+shell escaping. Expansion of environment variables, ninja variables,
+or make variables is not possible.
 
 ---
 ### **bob_module.header_libs** (optional)

--- a/internal/escape/escape.go
+++ b/internal/escape/escape.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package escape
+
+import (
+	"strings"
+
+	"github.com/google/blueprint/proptools"
+)
+
+var makefileEscaper = strings.NewReplacer("$", "$$")
+
+// Escape characters in a string that Make may interpret in recipes
+// (as part of the rule context).
+//
+// Ocurrences of $ need to be escaped as $$. The new escaped string is
+// returned.
+func MakefileEscape(s string) string {
+	return makefileEscaper.Replace(s)
+}
+
+// Escape characters in a list of strings that Make may interpret in
+// recipes (as part of the rule context).
+//
+// A new slice containing the escaped strings is returned.
+func MakefileEscapeList(list []string) []string {
+	// Create a new slice initialised with the initial list
+	list = append([]string(nil), list...)
+	for i, s := range list {
+		list[i] = MakefileEscape(s)
+	}
+	return list
+}
+
+// Escape characters that are special to either Make or the shell.
+//
+// The new escaped string is returned.
+func MakefileAndShellEscape(s string) string {
+	return proptools.ShellEscape(MakefileEscape(s))
+}
+
+// Escape characters that are special to either Make or the shell.
+//
+// A new slice containing the escaped strings is returned.
+func MakefileAndShellEscapeList(list []string) []string {
+	return proptools.ShellEscapeList(MakefileEscapeList(list))
+}
+
+// Escape a string which may contain Go templates.
+//
+// The content of the template is not escaped.
+//
+// This function is only useful where the template output is not
+// expected to be escaped. If the template output needs escaping too,
+// then expand the template before escaping instead.
+//
+// The new escaped string is returned.
+func EscapeTemplatedString(s string, escapeFn func(string) string) string {
+	var str strings.Builder
+
+	for len(s) > 0 {
+		start := strings.Index(s, "{{")
+		end := strings.Index(s, "}}")
+		if start >= 0 && end > start {
+			end += 2
+			str.WriteString(escapeFn(s[0:start]))
+			str.WriteString(s[start:end])
+			s = s[end:]
+		} else if end >= 0 && start > end {
+			// Ignore closing }} without a matching {{
+			// These will be escaped if needed.
+			str.WriteString(escapeFn(s[0:start]))
+			s = s[start:]
+		} else {
+			// No further template, or unclosed final
+			str.WriteString(escapeFn(s))
+			s = ""
+		}
+	}
+
+	return str.String()
+}
+
+// Escape a string which may contain Go templates.
+//
+// A new slice containing the escaped strings is returned.
+func EscapeTemplatedStringList(list []string, escapeFn func(string) string) []string {
+	// Create a new slice initialised with the initial list
+	list = append([]string(nil), list...)
+	for i, s := range list {
+		list[i] = EscapeTemplatedString(s, escapeFn)
+	}
+	return list
+}

--- a/internal/escape/escape_test.go
+++ b/internal/escape/escape_test.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package escape
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testCase struct {
+	name string
+	in   string
+	out  string
+}
+
+var makefileEscapeTests = []testCase{
+	{
+		name: "no escaping",
+		in:   `sed -e "s/a/b/g" input.txt > output.txt`,
+		out:  `sed -e "s/a/b/g" input.txt > output.txt`,
+	},
+	{
+		name: "leading $", // typically shell environment expansions
+		in:   "$PATH",
+		out:  "$$PATH",
+	},
+	{
+		name: "trailing $", // atypical case. ensure we get last char.
+		in:   "trailing$",
+		out:  "trailing$$",
+	},
+	{
+		name: "multiple $",
+		in:   "PATH=$PATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH",
+		out:  "PATH=$$PATH LD_LIBRARY_PATH=$$LD_LIBRARY_PATH",
+	},
+}
+
+func TestMakefileEscaping(t *testing.T) {
+	for _, testcase := range makefileEscapeTests {
+		out := MakefileEscape(testcase.in)
+		assert.Equalf(t, out, testcase.out, "Test case %s",
+			testcase.name)
+	}
+}
+
+var templatedStringTests = []testCase{
+	{
+		name: "no template, no escape",
+		in:   "The quick brown fox",
+		out:  "The quick brown fox",
+	},
+	{
+		name: "only template",
+		in:   "{{function .param \"$tring\" 5}}",
+		out:  "{{function .param \"$tring\" 5}}",
+	},
+	{
+		name: "escape before template",
+		in:   "The $QUICK ${{color 4 \"$\"}} fox",
+		out:  "The $$QUICK $${{color 4 \"$\"}} fox",
+	},
+	{
+		name: "escape after template",
+		in:   "The {{adjective 3 \"$\"}}$BROWN $FOX",
+		out:  "The {{adjective 3 \"$\"}}$$BROWN $$FOX",
+	},
+	{
+		name: "partial template at start",
+		in:   "The $quick}} {{brown \"$\"}} fox",
+		out:  "The $$quick}} {{brown \"$\"}} fox",
+	},
+	{
+		name: "partial template at end",
+		in:   "The {{quick \"$\"}} {{$brown fox",
+		out:  "The {{quick \"$\"}} {{$$brown fox",
+	},
+	{
+		name: "Interleaved templates",
+		in:   "The $QUICK {{adjective 4 \"$\"}} $BROWN {{mammal 3 \"$\"}}",
+		out:  "The $$QUICK {{adjective 4 \"$\"}} $$BROWN {{mammal 3 \"$\"}}",
+	},
+	{
+		name: "Adjacent templates",
+		in:   "The $QUICK {{adjective 4 \"$\"}}{{color 4 \"$\"}} $MAMMAL",
+		out:  "The $$QUICK {{adjective 4 \"$\"}}{{color 4 \"$\"}} $$MAMMAL",
+	},
+	{
+		name: "Unmatched }}",
+		in:   "The $QUICK {{adjective 4 \"$\"}} color 4 \"$\"}} {{mammal 3 \"$\"}}",
+		out:  "The $$QUICK {{adjective 4 \"$\"}} color 4 \"$$\"}} {{mammal 3 \"$\"}}",
+	},
+}
+
+func TestEscapeTemplatedString(t *testing.T) {
+	for _, testcase := range templatedStringTests {
+		out := EscapeTemplatedString(testcase.in, MakefileEscape)
+		assert.Equalf(t, out, testcase.out, "Test case %s",
+			testcase.name)
+	}
+}

--- a/tests/bplist
+++ b/tests/bplist
@@ -5,6 +5,7 @@
 ./build.bp
 ./command_vars/build.bp
 ./cxx11_simple/build.bp
+./escaping/build.bp
 ./export_cflags/liba/build.bp
 ./export_cflags/libb/build.bp
 ./export_include_dirs/liba/build.bp

--- a/tests/escaping/build.bp
+++ b/tests/escaping/build.bp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+bob_binary {
+    name: "bob_test_escaping",
+    srcs: [
+        "escaping_c.c",
+        "escaping_cxx.cpp",
+    ],
+    cflags: [
+        // Check string literal definitions
+        "-DSTRING=\"string\"",
+
+        // Check shell characters get escaped
+        "-DCOMMAND=\"PATH=$PATH `uname` | true < /dev/random > /dev/null &\"",
+    ],
+    conlyflags: [
+        "--std=c11",
+        "-DSTRING1=\"string1\"",
+    ],
+    cxxflags: [
+        "--std=c++11",
+        "-DSTRING2=\"string2\"",
+    ],
+
+    add_to_alias: ["bob_tests"],
+}

--- a/tests/escaping/escaping_c.c
+++ b/tests/escaping/escaping_c.c
@@ -1,0 +1,35 @@
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+/* Verify the macros are string literals */
+static const char str[] = "" STRING;
+static const char cmd[] = "" COMMAND;
+static const char str1[] = "" STRING1;
+
+int checkc(void) {
+	int result = 0;
+
+	printf("C STRING is `%s`\n", str);
+	printf("C COMMAND is `%s`\n", cmd);
+	printf("C STRING1 is `%s`\n", str1);
+
+	/* Run time check macro values. Ideally we would do this at compile time,
+	 * but this is difficult to get right across different compilers and
+	 * versions. We rely on the C++ test to verify that the escaping is
+	 * correct at compile time. */
+	if (strcmp(str, "string") != 0) {
+		printf("C STRING is incorrect\n");
+		result = 1;
+	}
+	if (strcmp(cmd, "PATH=$PATH `uname` | true < /dev/random > /dev/null &") != 0) {
+		printf("C COMMAND is incorrect\n");
+		result = 1;
+	}
+	if (strcmp(str1, "string1") != 0) {
+		printf("C STRING1 is incorrect\n");
+		result = 1;
+	}
+
+	return result;
+}

--- a/tests/escaping/escaping_cxx.cpp
+++ b/tests/escaping/escaping_cxx.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+
+extern "C" int checkc(void);
+
+/* This function checks that the input strings are equivalent,
+ * and can be called from static_assert */
+constexpr bool equals(const char *s0, const char *s1) {
+
+	/* In C++11 (and older compilers) we're only allowed a single
+	 * return statement, so do this check using recursion. */
+	return ((*s0 == *s1) &&
+	        ((*s0 == '\0') ||
+	         equals(s0+1, s1+1)));
+}
+
+/* Verify the macros are string literals */
+static const char str[] = "" STRING;
+static const char cmd[] = "" COMMAND;
+static const char str2[] = "" STRING2;
+
+/* Check macro values at compile time */
+static_assert(equals(STRING, "string"), "bad macro definition STRING");
+static_assert(equals(COMMAND, "PATH=$PATH `uname` | true < /dev/random > /dev/null &"),
+              "bad macro definition COMMAND");
+static_assert(equals(STRING2, "string2"), "bad macro definition STRING2");
+
+
+int main(void) {
+	// Make use of the static variables
+	std::cout << "C++ STRING is `" << str << "`\n";
+	std::cout << "C++ Command is `" << cmd << "`\n";
+	std::cout << "C++ STRING2 is `" << str2 << "`\n";
+
+	/* Link the C checks */
+	return checkc();
+}


### PR DESCRIPTION
Flags should be written as the tool expects to see them when reading
its arguments. i.e. without any shell quoting

Note that double quotes must be escaped for the blueprint parser.
Expansion of environment variables, ninja variables and make variables
is not supported in these properties.

This pull request updates the handling of asflags, conlyflags, cflags and
cxxflags in the Linux and Android make backends.
