### PR TITLE
Test external shared libs with zlib

### DIFF
--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -159,8 +159,20 @@ source "bob/mconfig/toolchain.Mconfig"
 
 endmenu
 
+## pkg-config configuration sub-menu
+
+menu "pkg-config configuration"
+	depends on ALLOW_HOST_EXPLORE
+	help
+	  pkg-config is a Linux tool that allows discovery of available
+	  libraries. On a standard Linux install pkg-config will be
+	  setup correctly for the build host. To use pkg-config for a
+	  target system in a cross compile, the package information
+	  for the target needs to be available.
+
 config PKG_CONFIG
 	bool "Enable use of pkg-config"
+	default y if BUILDER_NINJA
 	help
 	  When enabled, pkg-config is used to retrieve information
 	  about the package(s) declared in PKG_CONFIG_PACKAGES.
@@ -177,6 +189,69 @@ config PKG_CONFIG
 
 	  Where no package information exists the default configuration
 	  value will be used.
+
+config PKG_CONFIG_FLAGS
+	depends on PKG_CONFIG
+	string "pkg-config flags"
+	help
+	  This field contains command line arguments to pass to pkg-config.
+
+	  This field is specially processed so that the text %MCONFIGDIR% is
+	  replaced with the absolute directory that the Mconfig file is in.
+
+	  This should usually be left empty.
+
+config PKG_CONFIG_PACKAGES
+	depends on PKG_CONFIG
+	string "Packages"
+	default "zlib"
+	help
+	  This field contains a comma separated list of packages.
+
+	  The default value contains packages normally used in the
+	  selected configuration.
+
+config PKG_CONFIG_SYSROOT_DIR
+	depends on PKG_CONFIG
+	string "PKG_CONFIG_SYSROOT_DIR"
+	default ""
+	help
+	  This field allows a path to be assigned to the PKG_CONFIG_SYSROOT_DIR
+	  environment variable. See pkg-config man pages for further details of
+	  what PKG_CONFIG_SYSROOT_DIR does.
+
+config PKG_CONFIG_PATH
+	depends on PKG_CONFIG
+	string "PKG_CONFIG_PATH"
+	help
+	  This field allows a path to be assigned to the PKG_CONFIG_PATH
+	  environment variable. See pkg-config man pages for further details of
+	  what PKG_CONFIG_PATH does.
+
+	  This field is specially processed so that the text %MCONFIGDIR%
+	  is replaced with the absolute directory that the Mconfig file is
+	  in. This is to allow a project to point pkg-config at its own
+	  pkgconfig files.
+
+# Eg. for a package called 'win-utils' declared in PKG_CONFIG_PACKAGES, the following three
+# configuration entries must be present. The defaults will be overridden by pkg-config if
+# package information is available.
+#
+# config WIN_UTILS_CFLAGS
+#	string ""
+#	default "-I/usr/include"
+#
+# config WIN_UTILS_LDFLAGS
+#	string ""
+#	default "-L/usr/lib"
+#
+# config WIN_UTILS_LIBS
+#	string ""
+#	default "-lwin-utils"
+
+source "external_libs/Mconfig"
+
+endmenu
 
 ## Include this to allow us to test Bob host exploration if needed
 config ALLOW_HOST_EXPLORE

--- a/tests/external_libs/Mconfig
+++ b/tests/external_libs/Mconfig
@@ -1,0 +1,23 @@
+# Copyright 2020 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+config ZLIB_CFLAGS
+	string "zlib CFLAGS"
+
+config ZLIB_LDFLAGS
+	string "zlib LDFLAGS"
+
+config ZLIB_LDLIBS
+	string "zlib LDLIBS"

--- a/tests/external_libs/build.bp
+++ b/tests/external_libs/build.bp
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2019-2020 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 bob_external_static_library {
     name: "libbob_test_external_static",
 }
@@ -8,6 +25,19 @@ bob_external_shared_library {
 
 bob_external_header_library {
     name: "libbob_test_external_header",
+}
+
+// The above external libraries are difficult to test on Linux without invoking
+// a second build system, but we can do a simple test using zlib. Note that
+// this must be called `libz` to match what Android calls it, but the
+// pkg-config file is `zlib`.
+bob_external_shared_library {
+    name: "libz",
+    builder_ninja: {
+        export_cflags: ["{{.zlib_cflags}}"],
+        export_ldflags: ["{{.zlib_ldflags}}"],
+        ldlibs: ["{{.zlib_ldlibs}}"],
+    },
 }
 
 bob_static_library {
@@ -79,11 +109,18 @@ bob_binary {
     },
 }
 
+bob_binary {
+    name: "use_external_zlib",
+    srcs: ["zlib.c"],
+    shared_libs: ["libz"],
+}
+
 bob_alias {
     name: "bob_test_external_libs",
     srcs: [
         "use_external_libs",
         "use_external_header",
         "use_external_lib_proxy_user",
+        "use_external_zlib",
     ],
 }

--- a/tests/external_libs/zlib.c
+++ b/tests/external_libs/zlib.c
@@ -1,0 +1,7 @@
+#include <zlib.h>
+
+int main(void) {
+	z_stream strm = { 0 };
+
+	return deflateInit(&strm, Z_DEFAULT_COMPRESSION);
+}


### PR DESCRIPTION
The existing external_lib tests are difficult to run outside of an
Android build, because it would be necessary to invoke another build
system somehow to build the test libraries.

To test this feature on Linux, add a simple test using the
commonly-available zlib library instead. This also requires adding the
missing options for pkg-config support to Mconfig.

`external_libs/build.bp` is also missing a copyright header - add one.

Change-Id: Id0cb02c6e3a6e9e546a66c2b9ec1758aa9198053
Signed-off-by: Chris Diamand <chris.diamand@arm.com>