### PR TITLE
Export generated include dirs on Soong

### DIFF
--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -177,7 +177,9 @@ func addCcLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContex
 	}
 	m.AddStringList("srcs", utils.Filter(utils.IsCompilableSource, l.Properties.Srcs))
 	m.AddStringList("generated_sources", l.getGeneratedSourceModules(mctx))
-	m.AddStringList("generated_headers", l.getGeneratedHeaderModules(mctx))
+	genHeaderModules := l.getGeneratedHeaderModules(mctx)
+	m.AddStringList("generated_headers", genHeaderModules)
+	m.AddStringList("export_generated_headers", genHeaderModules)
 	m.AddStringList("exclude_srcs", l.Properties.Exclude_srcs)
 	err := addCFlags(m, cflags, l.Properties.Conlyflags, l.Properties.Cxxflags)
 	if err != nil {


### PR DESCRIPTION
The Linux and Android Make backends automatically propagate generated
include directories up the library dependency tree, due to an absence of
an explicit `export_generated_headers` property in library module types.

This occurs in `GetGeneratedHeaders()` (library.go:419), but that
function isn't used by Android.bp, so it currently does not have the
same behaviour; it doesn't set the corresponding
`export_generated_headers` property in the `cc_library_shared` module.

Ideally we would add the extra property - for now, however, just ensure
that all backends are consistent, by writing the
`export_generate_headers` property in `androidbp_cclibs.go`.

Change-Id: I835fafb40b79d2e5abc186c82a12c611af3d086f
Signed-off-by: Chris Diamand <chris.diamand@arm.com>