### PR TITLE
Fix soong device and host properties usage in genrulebob

### DIFF
--- a/core/androidbp_generated.go
+++ b/core/androidbp_generated.go
@@ -101,16 +101,6 @@ func populateCommonProps(gc *generateCommon, mctx blueprint.ModuleContext, m bpw
 	m.AddStringList("asflags", gc.Properties.FlagArgsBuild.Asflags)
 	m.AddStringList("ldflags", gc.Properties.FlagArgsBuild.Ldflags)
 	m.AddStringList("ldlibs", gc.Properties.FlagArgsBuild.Ldlibs)
-
-	// make use of soong properties for selecting variant
-	// (by default device is supported and host is not)
-	if gc.getTarget() == tgtTypeHost {
-		m.AddBool("device_supported", false)
-		m.AddBool("host_supported", true)
-	} else if gc.getTarget() == tgtTypeTarget {
-		m.AddBool("device_supported", true)
-		m.AddBool("host_supported", false)
-	}
 }
 
 func (g *androidBpGenerator) generateSourceActions(gs *generateSource, mctx blueprint.ModuleContext) {

--- a/plugins/genrulebob/genrule.go
+++ b/plugins/genrulebob/genrule.go
@@ -149,7 +149,8 @@ func genrulebobFactory() android.Module {
 	m.AddProperties(&m.Properties)
 	m.AddProperties(&m.genrulebobCommon.Properties)
 	// init module with target-specific variants info, needed also to get install path right
-	android.InitAndroidArchModule(m, android.HostAndDeviceSupported, android.MultilibCommon)
+	// (hardcode to device variant, host variant currently not supported)
+	android.InitAndroidArchModule(m, android.DeviceSupported, android.MultilibCommon)
 	return m
 }
 
@@ -160,7 +161,8 @@ func gensrcsbobFactory() android.Module {
 	m.AddProperties(&m.Properties)
 	m.AddProperties(&m.genrulebobCommon.Properties)
 	// init module with target-specific variants info, needed also to get install path right
-	android.InitAndroidArchModule(m, android.HostAndDeviceSupported, android.MultilibCommon)
+	// (hardcode to device variant, host variant currently not supported)
+	android.InitAndroidArchModule(m, android.DeviceSupported, android.MultilibCommon)
 	return m
 }
 


### PR DESCRIPTION
Supporting device_supported and host_supported soong properties is
causing soong errors about 'missing variants', when module tries to use
host variant. Therefore we hardcode to use device variant only. We still
cannot revert to using InitAndroidModule(), because we need proper
install path for kernel modules, that is coming from
InitAndroidArchModule().

Change-Id: I6a4d6fbeb54977417c131eef37dd1b77b43a8af3
Signed-off-by: Michal Przeplata <michal.przeplata@arm.com>