### PR TITLE
Fix `--ignore-missing` in Mconfig depfiles

### DIFF
--- a/config_system/config_system/lex_wrapper.py
+++ b/config_system/config_system/lex_wrapper.py
@@ -41,6 +41,7 @@ class LexWrapper:
 
         self.push_lexer(lexer)
         self.input(file_contents)
+        self.sources.append(fname)
 
     def source(self, fname):
         """Handle the source command, ensuring we open the file relative to
@@ -49,7 +50,6 @@ class LexWrapper:
             fname = os.path.join(self.root_dir, fname)
 
         self.open(fname)
-        self.sources.append(fname)
 
     def current_lexer(self):
         return self.lexers[-1]


### PR DESCRIPTION
This commit fixes a bug where a nonexistent `Mconfig` would still be
added to the depfile despite `--ignore-missing` option being set.

Change-Id: I6be7aeab96c9570d7c453a327901e684072c3cff
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>