### PR TITLE
Actually use Go template for late templates

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -259,8 +259,13 @@ const (
 	tgtTypeUnknown tgtType = ""
 )
 
-func stripEmptyComponentsRecursive(propsVal reflect.Value) {
+func stripEmptyComponents(list []string) []string {
 	var emptyStrFilter = func(s string) bool { return s != "" }
+
+	return utils.Filter(emptyStrFilter, list)
+}
+
+func stripEmptyComponentsRecursive(propsVal reflect.Value) {
 
 	for i := 0; i < propsVal.NumField(); i++ {
 		field := propsVal.Field(i)
@@ -269,7 +274,7 @@ func stripEmptyComponentsRecursive(propsVal reflect.Value) {
 		case reflect.Slice:
 			if field.Type().Elem().Kind() == reflect.String {
 				list := field.Interface().([]string)
-				list = utils.Filter(emptyStrFilter, list)
+				list = stripEmptyComponents(list)
 				field.Set(reflect.ValueOf(list))
 			}
 

--- a/core/late_template.go
+++ b/core/late_template.go
@@ -19,8 +19,9 @@ package core
 
 import (
 	"fmt"
-	"regexp"
+	"reflect"
 	"strings"
+	"text/template"
 
 	"github.com/google/blueprint"
 	"github.com/google/blueprint/pathtools"
@@ -28,40 +29,94 @@ import (
 	"github.com/ARM-software/bob-build/internal/utils"
 )
 
-var matchSourcesRegex = regexp.MustCompile(`\{\{match_srcs\s+(.+?)\}\}`)
+// Insert a function callback for a specific property.
+func addtoFuncmap(propfnmap map[string]template.FuncMap, propList []string, name string,
+	fn interface{}) {
 
-func (s *SourceProps) matchSources(ctx blueprint.BaseModuleContext, arg string,
-	matchedNonCompiledSources map[string]bool) string {
-
-	g := getBackend(ctx)
-
-	for _, match := range matchSourcesRegex.FindAllStringSubmatch(arg, -1) {
-		if len(match) <= 0 {
-			panic("Invalid argument for match_srcs. match_srcs expects a single pattern used to match a file.")
+	for _, prop := range propList {
+		if _, ok := propfnmap[prop]; !ok {
+			propfnmap[prop] = make(template.FuncMap)
 		}
-		matchedSources := []string{}
-		for _, src := range s.getSources(ctx) {
-			matched, err := pathtools.Match("**/"+match[1], src)
-			if err != nil {
-				panic("Error during matching filepath pattern")
-			}
-			if matched {
-				matchedNonCompiledSources[src] = true
-				matchedSources = append(matchedSources, getBackendPathInSourceDir(g, src))
-			}
-		}
-		if len(matchedSources) == 0 {
-			panic(fmt.Errorf("Could not match '%s' for module '%s'", match[1], ctx.ModuleName()))
-		}
-		arg = strings.Replace(arg, match[0], strings.Join(matchedSources, " "), 1)
+		propfnmap[prop][name] = fn
 	}
-	return arg
 }
 
-// This mutator handles {{match_srcs}}. It returns the result of the
-// input glob when applied to the modules source list. Because it
-// needs access to the source list, this runs much later than other
-// templates.
+// Apply late templates on strings, slices and recursively in structures.
+//
+// This function supports property specific funcmaps for templates,
+// allowing template functions to only be valid for particular
+// properties.
+func applyLateTemplateRecursive(propsVal reflect.Value, stringvalues map[string]string,
+	propfnmap map[string]template.FuncMap) {
+
+	for i := 0; i < propsVal.NumField(); i++ {
+		field := propsVal.Field(i)
+		propName := propsVal.Type().Field(i).Name
+
+		switch field.Kind() {
+		case reflect.String:
+			if funcmap, ok := propfnmap[propName]; ok {
+				applyTemplateString(field, stringvalues, funcmap)
+			}
+
+		case reflect.Slice:
+			// Array of strings
+			if funcmap, ok := propfnmap[propName]; ok {
+				emptyStrings := false
+				for j := 0; j < field.Len(); j++ {
+					elem := field.Index(j)
+					if elem.Kind() == reflect.String {
+						applyTemplateString(elem, stringvalues, funcmap)
+						if elem.String() == "" {
+							emptyStrings = true
+						}
+					}
+				}
+
+				if emptyStrings {
+					// The template expansion has left empty
+					// strings in the slice, so strip them
+					list := field.Interface().([]string)
+					list = stripEmptyComponents(list)
+					field.Set(reflect.ValueOf(list))
+				}
+			}
+
+		case reflect.Ptr:
+			if funcmap, ok := propfnmap[propName]; ok {
+				tgtField := reflect.Indirect(field)
+				if tgtField.Kind() == reflect.String {
+					applyTemplateString(tgtField, stringvalues, funcmap)
+				}
+			}
+
+		case reflect.Struct:
+			applyLateTemplateRecursive(field, stringvalues, propfnmap)
+		}
+	}
+}
+
+// Record non-compiled sources (only relevant for C/C++ compiled
+// libraries/binaries)
+func (s *SourceProps) initializeNonCompiledSourceMap(mctx blueprint.BaseModuleContext) map[string]bool {
+	// Unused non-compiled sources are not allowed, so create
+	// a map to mark whether a non-compiled source is matched.
+	nonCompiledSources := make(map[string]bool)
+	if _, ok := getLibrary(mctx.Module()); ok {
+		for _, src := range s.getSources(mctx) {
+			if utils.IsNotCompilableSource(src) {
+				nonCompiledSources[src] = false
+			}
+		}
+	}
+	return nonCompiledSources
+}
+
+// Set up {{match_srcs}} handling
+//
+// {{match_srcs}} returns the result of the input glob when applied to
+// the modules source list. Because it needs access to the source
+// list, this runs much later than other templates.
 //
 // This template is only applied in specific properties where we've
 // seen sensible use-cases:
@@ -70,59 +125,61 @@ func (s *SourceProps) matchSources(ctx blueprint.BaseModuleContext, arg string,
 // - Generated Common:
 //  - Args
 //  - Cmd
-func matchSourcesMutator(mctx blueprint.TopDownMutatorContext) {
-	module := mctx.Module()
-	matchSrcsString := "{{match_srcs "
-	if e, ok := module.(enableable); ok {
-		if !isEnabled(e) {
-			// Not enabled, skip execution
-			return
-		}
-	}
-	propArr := []*[]string{}
-	propStr := []*string{}
-	errorArrays := []*[]string{}
+func setupMatchSources(mctx blueprint.BaseModuleContext,
+	propfnmap map[string]template.FuncMap) map[string]bool {
+
 	var sourceProps *SourceProps
+	var matchSrcProps []string
+
+	module := mctx.Module()
+
 	if gsc, ok := getGenerateCommon(module); ok {
-		propArr = []*[]string{&gsc.Properties.Args}
-		propStr = []*string{gsc.Properties.Cmd}
 		sourceProps = &gsc.Properties.SourceProps
+		matchSrcProps = append(matchSrcProps, "Cmd")
+		matchSrcProps = append(matchSrcProps, "Args")
+
 	} else if buildProps, ok := module.(moduleWithBuildProps); ok {
-		b := buildProps.build()
-		propArr = []*[]string{&b.Ldflags}
-		errorArrays = []*[]string{&b.Export_ldflags}
-		propStr = []*string{}
-		sourceProps = &b.SourceProps
+		sourceProps = &buildProps.build().SourceProps
+		matchSrcProps = append(matchSrcProps, "Ldflags")
+		// {{match_srcs}} not supported on export_ldflags
 	}
 
-	// Unused non-compiled sources are not allowed, so create
-	// a map to mark whether a non-compiled source is matched.
-	matchedNonCompiledSources := make(map[string]bool)
-	if _, ok := getLibrary(module); ok {
-		for _, src := range sourceProps.getSources(mctx) {
-			if utils.IsNotCompilableSource(src) {
-				matchedNonCompiledSources[src] = false
-			}
+	nonCompiledSources := sourceProps.initializeNonCompiledSourceMap(mctx)
+	addtoFuncmap(propfnmap, matchSrcProps, "match_srcs",
+		func(arg string) string {
+			return sourceProps.matchSources(mctx, arg, nonCompiledSources)
+		})
+
+	return nonCompiledSources
+}
+
+// Callback function implementing {{match_srcs}}
+func (s *SourceProps) matchSources(ctx blueprint.BaseModuleContext, arg string,
+	matchedNonCompiledSources map[string]bool) string {
+
+	g := getBackend(ctx)
+
+	matchedSources := []string{}
+	for _, src := range s.getSources(ctx) {
+		matched, err := pathtools.Match("**/"+arg, src)
+		if err != nil {
+			panic("Error during matching filepath pattern")
 		}
+		if matched {
+			matchedNonCompiledSources[src] = true
+			matchedSources = append(matchedSources, getBackendPathInSourceDir(g, src))
+		}
+	}
+	if len(matchedSources) == 0 {
+		panic(fmt.Errorf("Could not match '%s' for module '%s'", arg, ctx.ModuleName()))
 	}
 
-	for _, prop := range propArr {
-		for i := range *prop {
-			(*prop)[i] = sourceProps.matchSources(mctx, (*prop)[i], matchedNonCompiledSources)
-		}
-	}
-	for _, prop := range propStr {
-		*prop = sourceProps.matchSources(mctx, *prop, matchedNonCompiledSources)
-	}
-	for _, prop := range errorArrays {
-		for i := range *prop {
-			if strings.Contains((*prop)[i], matchSrcsString) {
-				panic("Match_srcs not supported for exported variables.")
-			}
-		}
-	}
+	return strings.Join(matchedSources, " ")
+}
 
-	// Ensure that all non-compiled sources have been matched.
+// Ensure that every non-compiled source has been used by at least one
+// {{match_srcs}} instance.
+func verifyMatchSources(matchedNonCompiledSources map[string]bool) {
 	for src, matched := range matchedNonCompiledSources {
 		if !matched {
 			panic(fmt.Errorf("Non-compiled source %s is not used by match_srcs.", src))
@@ -130,48 +187,85 @@ func matchSourcesMutator(mctx blueprint.TopDownMutatorContext) {
 	}
 }
 
-var flagFilterRegex = regexp.MustCompile(`\{\{add_if_supported\s+(.+?)\}\}`)
-
-// Iterate over an array of flags and filter out the ones that are not supported
-// based on the list of languages in a toolchain
-func checkFlags(flags, languages []string, tc toolchain) []string {
-	out := []string{}
-	for _, flag := range flags {
-		matches := flagFilterRegex.FindAllStringSubmatch(flag, -1)
-		if matches != nil {
-			for _, match := range matches {
-				for _, lang := range languages {
-					if tc.checkFlagIsSupported(lang, match[1]) {
-						out = append(out, match[1])
-						break
-					}
-				}
-			}
-		} else {
-			out = append(out, flag)
+// If the flag is supported by any of the input languages return it,
+// otherwise return "" to exclude it
+func checkCompilerFlag(flag string, languages []string, tc toolchain) string {
+	for _, lang := range languages {
+		if tc.checkFlagIsSupported(lang, flag) {
+			return flag
 		}
 	}
-	return out
+	return ""
 }
 
-// This mutator handles {{add_if_supported}}. It checks the compiler flag passed
+// Handle {{add_if_supported}}. It checks the compiler flag passed
 // on the input and keeps it *if* the compiler supports it.
-func checkCompilerFlagsMutator(mctx blueprint.BottomUpMutatorContext) {
-	module := mctx.Module()
-	g := getBackend(mctx)
-	if e, ok := module.(enableable); ok {
-		if !isEnabled(e) {
-			// Not enabled, skip execution
-			return
-		}
-	}
+func setupAddIfSupported(mctx blueprint.BaseModuleContext,
+	propfnmap map[string]template.FuncMap) {
 
 	if t, ok := mctx.Module().(moduleWithBuildProps); ok {
 		build := t.build()
-		tc := g.getToolchain(build.TargetType)
-		build.Cflags = checkFlags(build.Cflags, []string{"c++", "c"}, tc)
-		build.Cxxflags = checkFlags(build.Cxxflags, []string{"c++"}, tc)
-		build.Export_cflags = checkFlags(build.Export_cflags, []string{"c++", "c"}, tc)
-		build.Conlyflags = checkFlags(build.Conlyflags, []string{"c"}, tc)
+		tc := getBackend(mctx).getToolchain(build.TargetType)
+
+		addtoFuncmap(propfnmap, []string{"Cflags", "Export_cflags"}, "add_if_supported",
+			func(s string) string {
+				return checkCompilerFlag(s, []string{"c++", "c"}, tc)
+			})
+		addtoFuncmap(propfnmap, []string{"Cxxflags"}, "add_if_supported",
+			func(s string) string {
+				return checkCompilerFlag(s, []string{"c++"}, tc)
+			})
+		addtoFuncmap(propfnmap, []string{"Conlyflags"}, "add_if_supported",
+			func(s string) string {
+				return checkCompilerFlag(s, []string{"c"}, tc)
+			})
+	}
+}
+
+// Applies late templates to the given module
+func applyLateTemplates(mctx blueprint.BaseModuleContext) {
+
+	m, ok := mctx.Module().(featurable)
+	if !ok {
+		// Features and templates not supported by this module type
+		return
+	}
+
+	propfnmap := make(map[string]template.FuncMap)
+
+	// Set up {{match_srcs}} and {{add_if_supported}} handling
+	nonCompiledSources := setupMatchSources(mctx, propfnmap)
+	setupAddIfSupported(mctx, propfnmap)
+
+	// Add more late templates above this line
+
+	if len(propfnmap) == 0 {
+		// If propfnmap is empty, then no late templates are
+		// applicable to this module type
+		return
+	}
+
+	// Generic template expansion
+	for _, p := range m.topLevelProperties() {
+		propsVal := reflect.Indirect(reflect.ValueOf(p))
+
+		// Properties have already been expanded, so set stringvalues to nil
+		applyLateTemplateRecursive(propsVal, nil, propfnmap)
+	}
+
+	verifyMatchSources(nonCompiledSources)
+}
+
+// This mutator handles late templates
+//
+// These templates have access to more information that normal
+// templates in template.go
+func lateTemplateMutator(mctx blueprint.TopDownMutatorContext) {
+	module := mctx.Module()
+
+	if e, ok := module.(enableable); ok {
+		if isEnabled(e) {
+			applyLateTemplates(mctx)
+		}
 	}
 }

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -170,8 +170,7 @@ func Main() {
 			// so optimize by skipping the mutator
 			ctx.RegisterTopDownMutator("escape_mutator", escapeMutator).Parallel()
 		}
-		ctx.RegisterTopDownMutator("match_sources_mutator", matchSourcesMutator).Parallel()
-		ctx.RegisterBottomUpMutator("check_supported_flags_mutator", checkCompilerFlagsMutator).Parallel()
+		ctx.RegisterTopDownMutator("late_template_mutator", lateTemplateMutator).Parallel()
 	}
 
 	if builder_ninja {

--- a/core/template.go
+++ b/core/template.go
@@ -88,11 +88,11 @@ func regReplace(rule string, input string, replace string) string {
 }
 
 func matchSrcs(input string) string {
-	return "{{match_srcs " + input + "}}"
+	return "{{match_srcs \"" + input + "\"}}"
 }
 
 func filter_compiler_flags(flag string) string {
-	return "{{add_if_supported " + flag + "}}"
+	return "{{add_if_supported \"" + flag + "\"}}"
 }
 
 // ApplyTemplate writes configuration values (from properties) into the string

--- a/docs/build_defs.md
+++ b/docs/build_defs.md
@@ -84,6 +84,11 @@ property is determined by the module type.
 Maps may contain values of any type. Lists and maps may have trailing
 commas after the last value.
 
+Strings can contain Go templates (except in the `name`, `defaults`,
+and `flag_defaults` properties). Go templates start with `{{` and end
+with `}}`. Bob may expand Go templates more that once, which means
+that getting literal `{{` or `}}` is implementation dependent.
+
 ## Operators
 
 Strings, lists  of strings,  and maps  can be  appended using  the `+`

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -408,6 +408,4 @@ The `instrumentation` Soong property will be automatically set to `true` if
 `profile_file` is set. Similarly, the only supported value of Soong's `sampling`
 field is `false`, so it is not settable in Bob.
 
-Note that the `add_if_supported` template is not supported on `pgo.cflags`.
-
 On backends other than Android.bp, these properties will be ignored.

--- a/tests/transform_source/build.bp
+++ b/tests/transform_source/build.bp
@@ -85,9 +85,8 @@ bob_transform_source {
 bob_generate_source {
     name: "generate_template_source_used_by_transform",
     out: ["test_src.tmpl"],
-    // To get a single pair of braces `{}` in the output, we have to escape
-    // Go's templates and *then* Python's format() specifiers.
-    cmd: "echo 'void output_{func}(void) {{\"{{\"}}{{\"}}\"}}' > ${out}",
+    tool: "write_tmpl.py",
+    cmd: "python ${tool} ${out}",
 }
 
 bob_transform_source {

--- a/tests/transform_source/write_tmpl.py
+++ b/tests/transform_source/write_tmpl.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+# Copyright 2020 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import argparse
+
+
+def parse_args():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("out", action="store", help="Output file")
+
+    return ap.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    with open(args.out, 'wt') as outfile:
+        outfile.write("void output_{func}() {{}}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Current late templates are specific to properties, so implement an
independent function that allows each property to support different
functions.