### PR TITLE
Improve config host_explore when PKG_CONFIG_* are set

### DIFF
--- a/scripts/host_explore.py
+++ b/scripts/host_explore.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,6 +58,13 @@ def pkg_config():
         pkg_config_flags = pkg_config_flags.replace("%MCONFIGDIR%", get_mconfig_dir())
         cmd.extend(pkg_config_flags.split(' '))
 
+        # clean already existing env vars, as leaving them may be erroneous
+        for k in ('PKG_CONFIG_PATH', 'PKG_CONFIG_SYSROOT_DIR'):
+            if k in os.environ:
+                logger.warning("Environment variable %s is already defined. "
+                               "It will be ignored." % k)
+                del os.environ[k]
+
         pkg_config_path = get_config_string('PKG_CONFIG_PATH')
         if pkg_config_path != '':
             pkg_config_path = pkg_config_path.replace("%MCONFIGDIR%", get_mconfig_dir())
@@ -65,6 +72,7 @@ def pkg_config():
 
         pkg_config_sys_root = get_config_string('PKG_CONFIG_SYSROOT_DIR')
         if pkg_config_sys_root != '':
+            pkg_config_sys_root = pkg_config_sys_root.replace("%MCONFIGDIR%", get_mconfig_dir())
             os.putenv('PKG_CONFIG_SYSROOT_DIR', pkg_config_sys_root)
 
         pkg_config_packages = get_config_string('PKG_CONFIG_PACKAGES')


### PR DESCRIPTION
Also allow PKG_CONFIG_SYSROOT_DIR to handle %MCONFIGDIR%, as this should
be a usual way to handle path prefix change, rather than utilizing
PKG_CONFIG_FLAGS.

Change-Id: Ib015e427df63777cccffcc35a24e22eabad2bcd9
Signed-off-by: Michal Przeplata <michal.przeplata@arm.com>