### PR TITLE
Avoid testing in the Travis home directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,13 @@ git:
 
 cache:
   directories:
-    - $HOME/ninjabin
+    - $TRAVIS_WORK_DIR/ninjabin
 
 addons:
   apt:
     packages:
       - rsync
       - python
-      - python-pip
       - python3
       - python3-pip
   homebrew:
@@ -23,6 +22,7 @@ addons:
       - md5sha1sum
 
 before_install:
+  - export TRAVIS_WORK_DIR=$TRAVIS_BUILD_DIR/../..
   - export -f travis_nanoseconds
   - export -f travis_fold
   - export -f travis_time_start
@@ -30,19 +30,19 @@ before_install:
 
 install:
   - .travis/install-ninja.sh
-  - export PATH=$PATH:~/ninjabin
+  - export PATH=$PATH:$TRAVIS_WORK_DIR/ninjabin
   - python${PYTHON_SUFFIX} -m pip install --user setuptools
   - python${PYTHON_SUFFIX} -m pip install --user ply pytest pytest-catchlog mock pytest-mock
   - python${PYTHON_SUFFIX} -m pip install --user pycodestyle pylint
 
 before_script:
-  - mkdir -p ~/bob_workspace
-  - mkdir -p ~/bob_workspace/src/github.com/google/
-  - mkdir -p ~/bob_workspace/src/github.com/ARM-software/
-  - ln -s "$(pwd)/blueprint/" ~/bob_workspace/src/github.com/google/blueprint
-  - ln -s "$(pwd)"            ~/bob_workspace/src/github.com/ARM-software/bob-build
+  - mkdir -p $TRAVIS_WORK_DIR/bob_workspace
+  - mkdir -p $TRAVIS_WORK_DIR/bob_workspace/src/github.com/google/
+  - mkdir -p $TRAVIS_WORK_DIR/bob_workspace/src/github.com/ARM-software/
+  - ln -s $TRAVIS_BUILD_DIR/blueprint $TRAVIS_WORK_DIR/bob_workspace/src/github.com/google/blueprint
+  - ln -s $TRAVIS_BUILD_DIR $TRAVIS_WORK_DIR/bob_workspace/src/github.com/ARM-software/bob-build
   - export GOROOT=$(go env GOROOT)
-  - export BOB_WORKSPACE=~/bob_workspace
+  - export BOB_WORKSPACE=$TRAVIS_WORK_DIR/bob_workspace
   - export GOPATH=${BOB_WORKSPACE}
   - go get github.com/stretchr/testify
 

--- a/.travis/install-ninja.sh
+++ b/.travis/install-ninja.sh
@@ -7,7 +7,7 @@ set -ev
 
 SCRIPT_HASH=$(sha1sum ${BASH_SOURCE[0]} | awk '{print $1}')
 
-cd ~
+cd $TRAVIS_WORK_DIR
 if [[ -d ninjabin && "$SCRIPT_HASH" == "$(cat ninjabin/script_hash)" ]]; then
     exit 0
 fi

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -45,15 +45,15 @@ result_fail() {
 set_python_version() {
     local SUFFIX=$1
     if [[ -n $SUFFIX ]]; then
-        local PYTHON_WRAPPER=~/pythonbin/python
+        local PYTHON_WRAPPER=$TRAVIS_WORK_DIR/pythonbin/python
         rm -f "$PYTHON_WRAPPER"
-        mkdir -p $(dirname "$PYTHON_WRAPPER" ~/pythonbin)
+        mkdir -p $(dirname "$PYTHON_WRAPPER" $TRAVIS_WORK_DIR/pythonbin)
 
         echo "#!/usr/bin/env bash" > "$PYTHON_WRAPPER"
         echo "python$PYTHON_SUFFIX" '"$@"' >> "$PYTHON_WRAPPER"
         chmod +x $PYTHON_WRAPPER
 
-        export PATH=~/pythonbin:$PATH
+        export PATH=$TRAVIS_WORK_DIR/pythonbin:$PATH
         local PYVER=$(python -c 'import sys; print("%d.%d." % (sys.version_info.major, sys.version_info.minor))')
         echo "Check python version"
         if [[ $PYVER != "$SUFFIX."* ]]; then


### PR DESCRIPTION
This commit moves `ninjabin`, `pythonbin` and `bob_workspace`
from `$HOME` to `$TRAVIS_BUILD_DIR/.project`.

Change-Id: I47dbc06d275f7a493a1c1b6e077c8e43964ea31a
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>