### PR TITLE
Add basic PGO support

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -115,6 +115,16 @@ type AndroidProps struct {
 	Owner string
 }
 
+// AndroidPGOProps defines properties used to support profile-guided optimization.
+type AndroidPGOProps struct {
+	Pgo struct {
+		Benchmarks         []string
+		Profile_file       *string
+		Enable_profile_use *bool
+		Cflags             []string
+	}
+}
+
 func getBobScriptsDir() string {
 	return filepath.Join(getBobDir(), "scripts")
 }

--- a/core/library.go
+++ b/core/library.go
@@ -149,6 +149,7 @@ type BuildProps struct {
 	SplittableProps
 	StripProps
 	AndroidProps
+	AndroidPGOProps
 
 	// Linux kernel config options to emulate. These are passed to Kbuild in
 	// the 'make' command-line, and set in the source code via EXTRA_CFLAGS

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -381,3 +381,33 @@ bob_binary {
     },
 }
 ```
+
+----
+### **bob_module.pgo** (optional)
+Bob has rudimentary support for Profile-Guided Optimization when using the
+Android.bp backend. Properties in the `pgo` block can be set, and will be
+used as the values for the corresponding Soong properties, as described
+[here](https://source.android.com/devices/tech/perf/pgo).
+
+```bp
+bob_binary {
+    name: "pgo_optimized_binary",
+    srcs: [...],
+    pgo: {
+        benchmarks: [
+            "benchmark1",
+            "benchmark2",
+        ],
+        profile_file: "pgo_optimized_binary.profdata",
+        enable_profile_use: true,
+        cflags: ["-DENABLED_WHEN_PGO_USED"],
+    }
+```
+
+The `instrumentation` Soong property will be automatically set to `true` if
+`profile_file` is set. Similarly, the only supported value of Soong's `sampling`
+field is `false`, so it is not settable in Bob.
+
+Note that the `add_if_supported` template is not supported on `pgo.cflags`.
+
+On backends other than Android.bp, these properties will be ignored.

--- a/internal/bpwriter/bpwriter.go
+++ b/internal/bpwriter/bpwriter.go
@@ -63,6 +63,7 @@ type property struct {
 type Group interface {
 	AddString(name, value string)
 	AddBool(name string, value bool)
+	AddOptionalBool(name string, value *bool)
 	AddStringList(name string, list []string)
 	AddStringCmd(name string, argLists ...[]string)
 }
@@ -100,6 +101,14 @@ func (g *group) AddBool(name string, value bool) {
 		g.addProp(name, "true")
 	} else {
 		g.addProp(name, "false")
+	}
+}
+
+// Add a boolean property to the property group, leaving it unset if no value
+// was explicitly provided.
+func (g *group) AddOptionalBool(name string, value *bool) {
+	if value != nil {
+		g.AddBool(name, *value)
 	}
 }
 
@@ -175,6 +184,12 @@ func (m *module) AddString(name, value string) {
 // Add a boolean property as a top level module property
 func (m *module) AddBool(name string, value bool) {
 	m.group.AddBool(name, value)
+}
+
+// Add a boolean property as a top level module property, leaving it unset if
+// no value was explicitly provided.
+func (m *module) AddOptionalBool(name string, value *bool) {
+	m.group.AddOptionalBool(name, value)
 }
 
 // Add a string list property as a top level module property

--- a/tests/bplist
+++ b/tests/bplist
@@ -25,6 +25,7 @@
 ./kernel_module/module2/build.bp
 ./match_source/build.bp
 ./output/build.bp
+./pgo/build.bp
 ./properties/build.bp
 ./reexport_libs/build.bp
 ./resources/build.bp

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -77,6 +77,7 @@ bob_alias {
         "bob_test_kernel_module",
         "bob_test_match_source",
         "bob_test_output",
+        "bob_test_pgo",
         "bob_test_properties",
         "bob_test_reexport_libs",
         "bob_test_resources",

--- a/tests/pgo/build.bp
+++ b/tests/pgo/build.bp
@@ -1,0 +1,22 @@
+bob_shared_library {
+    name: "libbob_pgo_test",
+    srcs: ["main.c"],
+    enabled: false,
+    builder_android_bp: {
+        enabled: true,
+        build_by_default: true,
+    },
+    pgo: {
+        benchmarks: ["pgo_test_benchmark"],
+        profile_file: "libbob_pgo_test.profdata",
+        enable_profile_use: true,
+        cflags: ["-DPGO_USED=1"],
+    },
+}
+
+bob_alias {
+    name: "bob_test_pgo",
+    srcs: [
+        "libbob_pgo_test",
+    ],
+}

--- a/tests/pgo/main.c
+++ b/tests/pgo/main.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+// The PGO_USED macro will be set to 1 when building with e.g.
+// `mm ANDROID_PGO_INSTRUMENT=pgo_test_benchmark`. Do not assert it here though,
+// as in general the Bob tests are just run with `mm`.
+
+int main(void) {
+    printf("Hello PGO!\n");
+    return 0;
+}


### PR DESCRIPTION
Support setting the PGO properties documented at
https://source.android.com/devices/tech/perf/pgo when using the
Android.bp backend.

For now, these just map 1:1 to the Soong properties - this isn't
supported on any other backends, so this is the simplest way to make PGO
usable.

Change-Id: I6e670fc01bca4a9cacd2d514ee1e025b9b87376c
Signed-off-by: Chris Diamand <chris.diamand@arm.com>