### PR TITLE
Make soong config vars available to genrule_bob

### DIFF
--- a/plugins/genrulebob/genrule.go
+++ b/plugins/genrulebob/genrule.go
@@ -133,6 +133,14 @@ type hostToolBinTagType struct {
 	blueprint.BaseDependencyTag
 }
 
+func init() {
+	// Import config package into pctx context, which is used for writing ninja rules.
+	// This makes vars from config package accessible, eg. ${config.ClangBin} reference
+	// can be used in cmd and args of ninja rules, which will interpolate
+	// into ${g.android.soong.cc.config.ClangBin}
+	pctx.Import("android/soong/cc/config")
+}
+
 var (
 	pctx = android.NewPackageContext("plugins/genrulebob")
 


### PR DESCRIPTION
With this we can reference config vars from cmd and args of ninja rules,
limiting usage of hardcoded paths defined in soong.

Change-Id: I8a11fcda672eb12454ff3f645c57a83580c7c43b
Signed-off-by: Michal Przeplata <michal.przeplata@arm.com>