### PR TITLE
Allow implicit_src on generated libraries

### DIFF
--- a/docs/module_types/bob_generate_library.md
+++ b/docs/module_types/bob_generate_library.md
@@ -37,6 +37,8 @@ bob_generate_shared_library {
     name: "custom_name",
     srcs: ["src/a.cpp", "src/b.cpp", "src/common/*.cpp"],
     exclude_srcs: ["src/common/skip_this.cpp"],
+    implicit_srcs: ["foo/*.tmpl],
+    exclude_implicit_srcs: ["foo/a.tmpl"],
     headers: ["my.h"],
 
     enabled: false,
@@ -72,6 +74,18 @@ bob_generate_shared_library {
     rsp_content: "${in}",
 }
 ```
+
+----
+### **bob_generate_*.implicit_srcs** (optional)
+
+List of implicit sources. Implicit sources are input files that do not get
+mentioned on the command line, and are not specified in the explicit sources.
+
+----
+### **bob_generate_*.exclude_implicit_srcs** (optional)
+
+Used in combination with glob patterns in `implicit_srcs` to exclude
+files that are not sources.
 
 ----
 ### **bob_generate_*.headers** (optional)

--- a/docs/module_types/bob_generate_source.md
+++ b/docs/module_types/bob_generate_source.md
@@ -26,6 +26,7 @@ bob_generate_source {
     out: ["my_out.cpp"],
     depfile: true,
     implicit_srcs: ["foo/scatter.scat"],
+    exclude_implicit_srcs: ["foo/skip.scat"],
 
     enabled: false,
     build_by_default: true,
@@ -73,8 +74,8 @@ mentioned on the command line, and are not specified in the explicit sources.
 
 ----
 ### **bob_generate_source.exclude_implicit_srcs** (optional)
-From `implicit_srcs` files filter out those that should not be included.
-Useful if `implicit_srcs` uses glob pattern that pulls in too many files.
+Used in combination with glob patterns in `implicit_srcs` to exclude
+files that are not sources.
 
 ----
 ### **bob_generate_source.implicit_outs** (optional)

--- a/tests/build_tests.sh
+++ b/tests/build_tests.sh
@@ -230,13 +230,20 @@ SRC=tests/generate_source/depgen2.in
 UPDATE=(${build_dir}/gen/gen_source_depfile/output.txt)
 check_dep_updated "generate source depfile" "${build_dir}" "${SRC}" "${UPDATE[@]}"
 
+# generated sources with implicit source
 SRC=tests/generate_source/an.implicit.src
 UPDATE=(${build_dir}/gen/gen_source_globbed_implicit_sources/validate_globbed_implicit_dependency.c)
 check_dep_updated "generate source implicit source" "${build_dir}" "${SRC}" "${UPDATE[@]}"
 
+# generated source with excluded implicit source
 SRC=tests/generate_source/an.implicit.src
 UPDATE=(${build_dir}/gen/gen_source_globbed_exclude_implicit_sources/validate_globbed_exclude_implicit_dependency.c)
 check_dep_not_updated "excluded implicit source" "${build_dir}" "${SRC}" "${UPDATE[@]}"
+
+# generated library with implicit source
+SRC=tests/generate_libs/libblah/libblah_feature.h
+UPDATE=(${build_dir}/gen/libblah_shared/libblah_shared${SHARED_LIBRARY_EXTENSION})
+check_dep_updated "generate library implicit source" "${build_dir}" "${SRC}" "${UPDATE[@]}"
 
 # resource dependencies
 SRC=tests/resources/main.c

--- a/tests/generate_libs/build.bp
+++ b/tests/generate_libs/build.bp
@@ -45,6 +45,10 @@ bob_install_group {
 bob_generate_shared_library {
     name: "libblah_shared",
     srcs: ["libblah/libblah.c"],
+    implicit_srcs: [
+        "libblah/libblah.h",
+        "libblah/libblah_feature.h",
+    ],
     headers: ["include/libblah.h"],
     always_enabled_feature: {
         headers: ["include/libblah_feature.h"],
@@ -81,6 +85,10 @@ bob_binary {
 bob_generate_static_library {
     name: "libblah_static",
     srcs: ["libblah/libblah.c"],
+    implicit_srcs: [
+        "libblah/libblah.h",
+        "libblah/libblah_feature.h",
+    ],
     headers: ["include/libblah.h"],
     always_enabled_feature: {
         headers: ["include/libblah_feature.h"],
@@ -134,6 +142,10 @@ bob_generate_shared_library {
     name: "libblah_shared_rename",
     out: "libblah_shared2",
     srcs: ["libblah/libblah.c"],
+    implicit_srcs: [
+        "libblah/libblah.h",
+        "libblah/libblah_feature.h",
+    ],
     headers: [
         "include/libblah.h",
         "include/libblah_feature.h",

--- a/tests/generate_libs/libblah/libblah.c
+++ b/tests/generate_libs/libblah/libblah.c
@@ -1,3 +1,6 @@
+#include "libblah.h"
+#include "libblah_feature.h"
+
 int output(void) {
 	return 42;
 }


### PR DESCRIPTION
Update generated library tests to declare appropriate implicit_srcs.
These tests are all copying headers from the source directory without
declaring the headers as dependencies.

Also update the libblah.c source to use the headers that are implicit
sources.

Change-Id: I4a85fdc136fdb24e66206ef5fee0ed43cb561044
Signed-off-by: David Kilroy <david.kilroy@arm.com>