### PR TITLE
Remove dependency on python3-pip in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
     packages:
       - python
       - python3
-      - python3-pip
       - rsync
   homebrew:
     packages:
@@ -32,9 +31,9 @@ before_install:
 install:
   - .travis/install-ninja.sh
   - export PATH=$PATH:$TRAVIS_WORK_DIR/ninjabin
-  - python3 -m pip install --user setuptools
-  - python3 -m pip install --user virtualenv
-  - python3 -m virtualenv -p ${PYTHON_SUFFIX} $TRAVIS_WORK_DIR/python_env
+  - python -m pip install --user setuptools
+  - python -m pip install --user virtualenv
+  - python -m virtualenv -p python${PYTHON_SUFFIX} $TRAVIS_WORK_DIR/python_env
   - source $TRAVIS_WORK_DIR/python_env/bin/activate
   - pip install -r .travis/pip_requirements.txt
 


### PR DESCRIPTION
`pip` should now be included in Python 3 by default,
so there is no need to install it.

Change-Id: Ia62e5ead49016847d78c2f7ea8182e8f150576cb
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>