### PR TITLE
Adding support for {TARGET,HOST}_AR_BINARY

### DIFF
--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -419,7 +419,7 @@ func (tc toolchainGnuCross) getStdCxxHeaderDirs() []string {
 func newToolchainGnuCommon(config *bobConfig, tgt tgtType) (tc toolchainGnuCommon) {
 	props := config.Properties
 	tc.prefix = props.GetString(string(tgt) + "_gnu_prefix")
-	tc.arBinary = tc.prefix + props.GetString("ar_binary")
+	tc.arBinary = props.GetString(string(tgt) + "_ar_binary")
 	tc.asBinary = tc.prefix + props.GetString("as_binary")
 
 	tc.objcopyBinary = props.GetString(string(tgt) + "_objcopy_binary")
@@ -527,7 +527,7 @@ func newToolchainClangCommon(config *bobConfig, tgt tgtType) (tc toolchainClangC
 
 	// This assumes arBinary and asBinary are either in the path, or the same directory as clang.
 	// This is not necessarily the case. This will need to be updated when we support clang on linux without a GNU toolchain.
-	tc.arBinary = tc.prefix + props.GetString("ar_binary")
+	tc.arBinary = props.GetString(string(tgt) + "_ar_binary")
 	tc.asBinary = tc.prefix + props.GetString("as_binary")
 
 	tc.objcopyBinary = props.GetString(string(tgt) + "_objcopy_binary")
@@ -829,7 +829,7 @@ func (tc toolchainXcode) getStripBinary() string {
 func newToolchainXcodeCommon(config *bobConfig, tgt tgtType) (tc toolchainXcode) {
 	props := config.Properties
 	tc.prefix = props.GetString(string(tgt) + "_xcode_prefix")
-	tc.arBinary = tc.prefix + props.GetString("ar_binary")
+	tc.arBinary = props.GetString(string(tgt) + "_ar_binary")
 	tc.asBinary = tc.prefix + props.GetString("as_binary")
 	tc.objcopyBinary = props.GetString(string(tgt) + "_objcopy_binary")
 

--- a/mconfig/host_toolchain.Mconfig
+++ b/mconfig/host_toolchain.Mconfig
@@ -129,3 +129,9 @@ config HOST_OBJCOPY_BINARY
 	help
 	  The objcopy executable that we can use in post install scripts
 	  to manipulate host libraries and executables.
+
+config HOST_AR_BINARY
+	string "GNU and Clang Archiver binary"
+	default "ar"
+	help
+	  The name of the archiver used to create host static libraries.

--- a/mconfig/target_toolchain.Mconfig
+++ b/mconfig/target_toolchain.Mconfig
@@ -126,3 +126,9 @@ config TARGET_OBJCOPY_BINARY
 	help
 	  The objcopy executable that we can use in post install scripts
 	  to manipulate target libraries and executables.
+
+config TARGET_AR_BINARY
+	string "GNU and Clang Archiver binary"
+	default "ar"
+	help
+	  The name of the archiver used to create target static libraries.

--- a/mconfig/toolchain.Mconfig
+++ b/mconfig/toolchain.Mconfig
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 Arm Limited.
+# Copyright 2016-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,12 +28,6 @@ config GNU_CXX_BINARY
 	default "g++"
 	help
 	  The name of the C++ compiler when the GNU toolchain is used.
-
-config AR_BINARY
-	string "GNU and Clang Archiver binary"
-	default "ar"
-	help
-	  The name of the archiver used to create static libraries.
 
 config AS_BINARY
 	string "GNU and Clang Assembler binary"

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -291,7 +291,7 @@ config GEN_CC
 
 config GEN_AR
 	string "Archiver"
-	default HOST_GNU_PREFIX + AR_BINARY
+	default HOST_GNU_PREFIX + HOST_AR_BINARY
 
 ## KERNEL_ config needed for testing kernel modules
 config KERNEL_CC


### PR DESCRIPTION
Separate AR_BINARY into TARGET_AR_BINARY and HOST_AR_BINARY to match
the same setup of other build tools like OBJCOPY_BINARY.

Change-Id: I6fa5797457669b964fb3df3a8c3bd756a340d56b
Signed-off-by: Renato Grottesi <renato.grottesi@arm.com>