### PR TITLE
Set flag test output file

### DIFF
--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -261,7 +261,8 @@ func (cache *flagSupportedCache) checkFlag(tc toolchain, language, flag string) 
 	// we can test the actual flag. This is to work around the fact that gcc is silent
 	// about '-Wno-<flag_name>' flags it doesn't recognise until you actually compile a file
 	saneFlag := strings.Replace(flag, "-Wno-", "-W", 1)
-	testFlags := utils.Remove(utils.NewStringSlice(flags, []string{"-x", language, "-c", os.DevNull, "-Werror", saneFlag}), "")
+	testFlags := utils.NewStringSlice(flags, []string{"-x", language, "-c", os.DevNull, "-o", os.DevNull, "-Werror", saneFlag})
+	testFlags = utils.Remove(testFlags, "")
 	cmd := exec.Command(compiler, testFlags...)
 	_, err := cmd.CombinedOutput()
 	if err == nil {


### PR DESCRIPTION
Explicitly set the output file, used when checking for supported flags,
to `/dev/null`. This avoids creating a `null.o` file in the working
directory.

Change-Id: Ibe701bbc26e52a9e89d4f9fde127aefd5e762b48
Signed-off-by: Chris Diamand <chris.diamand@arm.com>