### PR TITLE
Automatically split install paths

### DIFF
--- a/core/android.go
+++ b/core/android.go
@@ -20,7 +20,11 @@ package core
 // Logic common to the Android.mk and Android.bp backends
 
 import (
+	"path/filepath"
+
 	"github.com/google/blueprint"
+
+	"github.com/ARM-software/bob-build/internal/utils"
 )
 
 var (
@@ -39,4 +43,91 @@ func enabledAndRequired(m blueprint.Module) bool {
 		}
 	}
 	return true
+}
+
+// Map of path prefixes and where to split the path into "base" and "rel" sections, roughly
+// corresponding to LOCAL_PATH and LOCAL_MODULE_RELATIVE_PATH/relative_install_path.
+var androidInstallLocationSplits = map[string]int{
+	// Paths in system and vendor have another component, e.g. `bin` or
+	// `lib` - after that, it is all relative.
+	"system":                2,
+	"vendor":                2,
+	"$(TARGET_OUT)":         3,
+	"$(TARGET_OUT_PRODUCT)": 2,
+	"$(TARGET_OUT_SYSTEM)":  2,
+	"$(TARGET_OUT_VENDOR)":  2,
+
+	// Android.mk-specific build dir, which a subdirectory per module type.
+	"$(TARGET_OUT_GEN)": 2,
+
+	// Filetype-specific Android.mk variables already include the `lib` or `bin` part.
+	"$(TARGET_OUT_DATA_EXECUTABLES)":            1,
+	"$(TARGET_OUT_DATA_METRIC_TESTS)":           1,
+	"$(TARGET_OUT_DATA_NATIVE_TESTS)":           1,
+	"$(TARGET_OUT_DATA_SHARED_LIBRARIES)":       1,
+	"$(TARGET_OUT_EXECUTABLES)":                 1,
+	"$(TARGET_OUT_OEM_EXECUTABLES)":             1,
+	"$(TARGET_OUT_OEM_SHARED_LIBRARIES)":        1,
+	"$(TARGET_OUT_OPTIONAL_EXECUTABLES)":        1,
+	"$(TARGET_OUT_PRODUCT_EXECUTABLES)":         1,
+	"$(TARGET_OUT_PRODUCT_SHARED_LIBRARIES)":    1,
+	"$(TARGET_OUT_SHARED_LIBRARIES)":            1,
+	"$(TARGET_OUT_VENDOR_EXECUTABLES)":          1,
+	"$(TARGET_OUT_VENDOR_OPTIONAL_EXECUTABLES)": 1,
+	"$(TARGET_OUT_VENDOR_SHARED_LIBRARIES)":     1,
+
+	// /etc contains subdirs like `firmware` which need to be part of the base path
+	"vendor/etc":                         3,
+	"system/etc":                         3,
+	"etc":                                2,
+	"$(TARGET_OUT_DATA_ETC)":             2,
+	"$(TARGET_OUT_ETC)":                  2,
+	"$(TARGET_OUT_OEM_ETC)":              2,
+	"$(TARGET_OUT_PRODUCT_ETC)":          2,
+	"$(TARGET_OUT_PRODUCT_SERVICES_ETC)": 2,
+	"$(TARGET_OUT_VENDOR_ETC)":           2,
+
+	// /data isn't quite so structured, so put most components in the relative_install_path.
+	// Note that $(TARGET_OUT_DATA_EXECUTABLES) etc actually maps to /system, so is handled
+	// the same as the other filetype-specific stuff - this just catches anything else.
+	"data":               1,
+	"$(TARGET_OUT_DATA)": 1,
+}
+
+func splitAndroidPath(path string) (string, string) {
+	components := utils.SplitPath(path)
+
+	// If no match, the whole path is the "base" section.
+	relStart := len(components)
+
+	// Try longer sections of path first to avoid incorrect matches on common prefixes
+	for i := 2; i > 0; i-- {
+		if i > len(components) {
+			continue
+		}
+		split, ok := androidInstallLocationSplits[filepath.Join(components[0:i]...)]
+		if ok {
+			relStart = split
+			break
+		}
+	}
+
+	if relStart > len(components) {
+		relStart = len(components)
+	}
+
+	base := filepath.Join(components[:relStart]...)
+	rel := filepath.Join(components[relStart:]...)
+
+	return base, rel
+}
+
+func getAndroidInstallPath(props *InstallableProps) (string, string, bool) {
+	installPath, ok := props.getInstallPath()
+	if !ok {
+		return "", "", false
+	}
+
+	base, rel := splitAndroidPath(installPath)
+	return base, rel, true
 }

--- a/core/android_test.go
+++ b/core/android_test.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func checkSplit(t *testing.T, path, expectedBase, expectedRel string) {
+	base, rel := splitAndroidPath(path)
+
+	assert.Equal(t, base, expectedBase)
+	assert.Equal(t, rel, expectedRel)
+}
+
+func Test_splitAndroidPath(t *testing.T) {
+	checkSplit(t, "vendor/lib/", "vendor/lib", "")
+	checkSplit(t, "vendor/bin/binsubdir", "vendor/bin", "binsubdir")
+	checkSplit(t, "vendor/bin", "vendor/bin", "")
+	checkSplit(t, "data/nativetest/mytests", "data", "nativetest/mytests")
+	checkSplit(t, "$(TARGET_OUT_DATA)/nativetest", "$(TARGET_OUT_DATA)", "nativetest")
+	checkSplit(t, "$(TARGET_OUT_VENDOR)/lib", "$(TARGET_OUT_VENDOR)/lib", "")
+	checkSplit(t, "$(TARGET_OUT_EXECUTABLES)", "$(TARGET_OUT_EXECUTABLES)", "")
+	checkSplit(t, "$(TARGET_OUT_SHARED_LIBRARIES)/libdir", "$(TARGET_OUT_SHARED_LIBRARIES)", "libdir")
+}

--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	"github.com/google/blueprint"
-	"github.com/google/blueprint/proptools"
 
 	"github.com/ARM-software/bob-build/internal/bpwriter"
 	"github.com/ARM-software/bob-build/internal/ccflags"
@@ -220,8 +219,10 @@ func addCcLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContex
 	m.AddStringList("export_static_lib_headers", reexportStatic)
 	m.AddStringList("export_header_lib_headers", reexportHeaders)
 	m.AddStringList("ldflags", l.Properties.Ldflags)
-	if l.getInstallableProps().Relative_install_path != nil {
-		m.AddString("relative_install_path", proptools.String(l.getInstallableProps().Relative_install_path))
+
+	_, installRel, ok := getAndroidInstallPath(l.getInstallableProps())
+	if ok && installRel != "" {
+		m.AddString("relative_install_path", installRel)
 	}
 
 	addProvenanceProps(m, l.Properties.Build.AndroidProps)

--- a/core/androidbp_kernel_module.go
+++ b/core/androidbp_kernel_module.go
@@ -105,7 +105,7 @@ func (g *androidBpGenerator) kernelModuleActions(l *kernelModule, mctx blueprint
 		l.Properties.Make_args,
 	)
 
-	installPath, ok := l.getInstallableProps().getFullInstallPath()
+	installPath, ok := l.getInstallableProps().getInstallPath()
 	if ok {
 		bpmod.AddString("install_path", installPath)
 	}

--- a/core/androidbp_resource.go
+++ b/core/androidbp_resource.go
@@ -29,21 +29,17 @@ func (g *androidBpGenerator) resourceActions(r *resource, mctx blueprint.ModuleC
 		return
 	}
 
-	installPath, _ := r.getInstallableProps().getFullInstallPath()
+	installBase, installRel, _ := getAndroidInstallPath(r.getInstallableProps())
 
-	subdir := ""
 	var modType string
-	if strings.HasPrefix(installPath, "data/") {
-		subdir = strings.Replace(installPath, "data/", "", 1)
+	if strings.HasPrefix(installBase+"/", "data/") {
 		modType = "prebuilt_data_bob"
-	} else if strings.HasPrefix(installPath, "etc/") {
-		subdir = strings.Replace(installPath, "etc/", "", 1)
+	} else if strings.HasPrefix(installBase+"/", "etc/") {
 		modType = "prebuilt_etc"
-	} else if strings.HasPrefix(installPath, "firmware/") {
-		subdir = strings.Replace(installPath, "firmware/", "", 1)
+	} else if strings.HasPrefix(installBase+"/", "firmware/") {
 		modType = "prebuilt_firmware"
 	} else {
-		panic(fmt.Errorf("Install path must be prefixed either with 'data' or 'etc' (%s)", installPath))
+		panic(fmt.Errorf("Could not detect partition for install path '%s'", installBase))
 	}
 
 	// as prebuilt_etc module supports only single src, we have to split into N modules
@@ -60,7 +56,7 @@ func (g *androidBpGenerator) resourceActions(r *resource, mctx blueprint.ModuleC
 
 		// add prebuilt_etc properties
 		m.AddString("src", src)
-		m.AddString("sub_dir", subdir)
+		m.AddString("sub_dir", installRel)
 		m.AddBool("filename_from_src", true)
 		m.AddBool("installable", true)
 	}

--- a/core/linux.go
+++ b/core/linux.go
@@ -587,14 +587,12 @@ func (l *library) getSharedLibFlags(ctx blueprint.ModuleContext) (ldlibs []strin
 					}
 					ldlibs = append(ldlibs, tc.getLinker().dropSharedLibraryTransitivity())
 				}
-				if installPath, ok := sl.Properties.InstallableProps.getInstallGroupPath(); ok {
-					installPath = filepath.Join(installPath, proptools.String(sl.Properties.InstallableProps.Relative_install_path))
+				if installPath, ok := sl.Properties.InstallableProps.getInstallPath(); ok {
 					libPaths = utils.AppendIfUnique(libPaths, installPath)
 				}
 			} else if sl, ok := m.(*generateSharedLibrary); ok {
 				ldlibs = append(ldlibs, pathToLibFlag(sl.outputName()))
-				if installPath, ok := sl.generateCommon.Properties.InstallableProps.getInstallGroupPath(); ok {
-					installPath = filepath.Join(installPath, proptools.String(sl.generateCommon.Properties.InstallableProps.Relative_install_path))
+				if installPath, ok := sl.generateCommon.Properties.InstallableProps.getInstallPath(); ok {
 					libPaths = utils.AppendIfUnique(libPaths, installPath)
 				}
 			} else if el, ok := m.(*externalLib); ok {
@@ -609,7 +607,7 @@ func (l *library) getSharedLibFlags(ctx blueprint.ModuleContext) (ldlibs []strin
 		ldlibs = append(ldlibs, tc.getLinker().getForwardingLibFlags())
 	}
 	if l.Properties.isRpathWanted() {
-		if installPath, ok := l.Properties.InstallableProps.getInstallGroupPath(); ok {
+		if installPath, ok := l.Properties.InstallableProps.getInstallPath(); ok {
 			var rpaths []string
 			for _, path := range libPaths {
 				out, err := filepath.Rel(installPath, path)
@@ -864,15 +862,11 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 	ins := m.(installable)
 
 	props := ins.getInstallableProps()
-	installPath, ok := props.getInstallGroupPath()
+	installPath, ok := props.getInstallPath()
 	if !ok {
 		return []string{}
 	}
 	installPath = filepath.Join("${BuildDir}", installPath)
-
-	if props.Relative_install_path != nil {
-		installPath = filepath.Join(installPath, proptools.String(props.Relative_install_path))
-	}
 
 	installedFiles := []string{}
 

--- a/core/strip.go
+++ b/core/strip.go
@@ -66,7 +66,7 @@ type stripable interface {
 
 func debugInfoMutator(mctx blueprint.TopDownMutatorContext) {
 	if m, ok := mctx.Module().(stripable); ok {
-		path := getInstallPath(mctx, debugInfoTag)
+		path := getInstallGroupPathFromTag(mctx, debugInfoTag)
 		m.setDebugPath(path)
 	}
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -334,3 +334,29 @@ func Expand(s string, mapping func(string) string) (res string) {
 	}
 	return
 }
+
+func SplitPath(path string) (components []string) {
+	pathSep := string(os.PathSeparator)
+
+	if path == "" {
+		return []string{}
+	} else if path == pathSep {
+		return []string{pathSep}
+	}
+
+	// Ignore trailing slashes
+	if path[len(path)-1:] == pathSep {
+		path = path[:len(path)-1]
+	}
+
+	dir, file := filepath.Split(path)
+
+	if dir == "" {
+		return []string{file}
+	} else if dir == pathSep {
+		// Treat subdirs of the root directory as single components, e.g. /var -> ["/var"].
+		return []string{path}
+	}
+
+	return append(SplitPath(dir), file)
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -298,3 +298,15 @@ func Test_ExpandIncomplete(t *testing.T) {
 	assert.Equal(t, "1 2 3$", res2)
 	assert.Equal(t, "1 2 3${x", res3)
 }
+
+func Test_SplitPath(t *testing.T) {
+	assert.Equal(t, []string{}, SplitPath(""))
+	assert.Equal(t, []string{"/"}, SplitPath("/"))
+	assert.Equal(t, []string{"/bin"}, SplitPath("/bin"))
+	assert.Equal(t, []string{"/bin"}, SplitPath("/bin/"))
+	assert.Equal(t, []string{"/usr", "bin"}, SplitPath("/usr/bin"))
+	assert.Equal(t, []string{"/usr", "bin"}, SplitPath("/usr/bin/"))
+	assert.Equal(t, []string{"rel"}, SplitPath("rel"))
+	assert.Equal(t, []string{"a", "rel", "path"}, SplitPath("a/rel/path"))
+	assert.Equal(t, []string{"a", "rel", "path"}, SplitPath("a/rel/path/"))
+}


### PR DESCRIPTION
On Android, different parts of installation paths are handled
separately. Android.mk has separate LOCAL_MODULE_PATH and
LOCAL_MODULE_RELATIVE_PATH components, but on Soong, the module type and
a few extra attributes (e.g. `vendor`) determine where it ends up, and
the only extra control is to set a subdirectory within that location.

This means that we need to automatically translate a user-specified path
(e.g. `vendor/bin/testdir`) into "base" and "relative" components. In
this example, `vendor/bin`) is the "base", which on Soong, will be
determined by outputting a cc_binary module with `vendor: true`. The
rest of the path is the "relative" part, which is put into the
`relative_install_dir` property.

This is subtly different to the current behaviour, which simply copies
Bob's `relative_install_path` value into Soong's. This is unfortunately
incorrect, though, because some parts of the relative path may come from
an install group; currently, this would be ignored.

Change-Id: Idcfaca9c809893df84f61d914b6d4b41b3150c17
Signed-off-by: Chris Diamand <chris.diamand@arm.com>