### PR TITLE
Support encapsulates for generated_sources property

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -199,7 +199,7 @@ func androidLibraryBuildAction(sb *strings.Builder, mod blueprint.Module, ctx bl
 	}
 
 	// Handle generated sources
-	for _, module := range m.Properties.Generated_sources {
+	for _, module := range m.getAllGeneratedSourceModules(ctx) {
 		// LOCAL_GENERATED_SOURCES is used to name target generated as
 		// part of this module which we also link into a library. The
 		// generated sources are automatically added to the
@@ -741,6 +741,7 @@ func (g *androidMkGenerator) generateCommonActions(sb *strings.Builder, m *gener
 	// Calculate and record outputs and include dirs
 	m.recordOutputsFromInout(inouts)
 	m.includeDirs = utils.PrefixDirs(m.Properties.Export_gen_include_dirs, m.outputDir())
+	m.encapsulatedMods = getGeneratedEncapsulatedModules(ctx)
 
 	sb.WriteString("##########################\ninclude $(CLEAR_VARS)\n\n")
 

--- a/core/library.go
+++ b/core/library.go
@@ -476,6 +476,20 @@ func (l *library) GetGeneratedHeaders(ctx blueprint.ModuleContext) (includeDirs 
 	return
 }
 
+func (l *library) getAllGeneratedSourceModules(ctx blueprint.ModuleContext) (modules []string) {
+	ctx.VisitDirectDepsIf(
+		func(m blueprint.Module) bool { return ctx.OtherModuleDependencyTag(m) == generatedSourceTag },
+		func(m blueprint.Module) {
+			if gs, ok := getGenerateCommon(m); ok {
+				// Add our own name
+				modules = append(modules, gs.Name())
+				// Add transitively encapsulated module names (if any)
+				modules = append(modules, gs.encapsulatedModules()...)
+			}
+		})
+	return
+}
+
 func (l *library) GetExportedVariables(ctx blueprint.ModuleContext) (expLocalIncludes, expIncludes, expCflags []string) {
 	visited := map[string]bool{}
 	ctx.VisitDirectDeps(func(dep blueprint.Module) {

--- a/core/linux.go
+++ b/core/linux.go
@@ -143,6 +143,7 @@ func (g *linuxGenerator) generateCommonActions(m *generateCommon, ctx blueprint.
 	// Calculate and record outputs and include dirs
 	m.recordOutputsFromInout(inouts)
 	m.includeDirs = utils.PrefixDirs(m.Properties.Export_gen_include_dirs, m.outputDir())
+	m.encapsulatedOuts = getGeneratedEncapsulatedFiles(ctx)
 
 	cmd, args, implicits, hostTarget := m.getArgs(ctx)
 
@@ -418,6 +419,7 @@ func (l *library) CompileObjs(ctx blueprint.ModuleContext) ([]string, []string) 
 func (l *library) GetSrcs(ctx blueprint.ModuleContext) []string {
 	srcs := l.Properties.getSources(ctx)
 	srcs = append(srcs, l.Properties.Build.SourceProps.Specials...)
+
 	ctx.VisitDirectDepsIf(
 		func(m blueprint.Module) bool { return ctx.OtherModuleDependencyTag(m) == generatedSourceTag },
 		func(m blueprint.Module) {

--- a/core/output_producer.go
+++ b/core/output_producer.go
@@ -22,6 +22,8 @@
 
 package core
 
+import "github.com/ARM-software/bob-build/internal/utils"
+
 // Modules that produce content in the build output directory that may
 // be referenced by other modules must implement the outputs() and
 // implicitOutputs() functions. This structure supplies basic versions
@@ -86,4 +88,35 @@ type headerProducer struct {
 
 func (m *headerProducer) genIncludeDirs() []string {
 	return m.includeDirs
+}
+
+// Generated modules implement this interface to provide all encapsulated
+// module names.
+type encapsulatedOutputProducer struct {
+	simpleOutputProducer
+
+	// List of all outputs of all modules encapsulated by this module,
+	// gathered recursively from dependencies (including implicit outputs).
+	encapsulatedOuts []string
+	// List of all module names encapsulated module by this module,
+	// gathered recursively from dependencies.
+	encapsulatedMods []string
+}
+
+func (m *encapsulatedOutputProducer) cmdOutputs() []string {
+	// reuse outs as the outputs explicitly defined
+	return m.simpleOutputProducer.outputs()
+}
+
+func (m *encapsulatedOutputProducer) outputs() []string {
+	// for generated modules include encapsulated outputs
+	return utils.NewStringSlice(m.cmdOutputs(), m.encapsulatedOutputs())
+}
+
+func (m *encapsulatedOutputProducer) encapsulatedOutputs() []string {
+	return m.encapsulatedOuts
+}
+
+func (m *encapsulatedOutputProducer) encapsulatedModules() []string {
+	return m.encapsulatedMods
 }

--- a/tests/source_encapsulation/build.bp
+++ b/tests/source_encapsulation/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Arm Limited.
+ * Copyright 2019-2020 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,26 +15,15 @@
  * limitations under the License.
  */
 
-//////////////////////////////////////////////////////////////
-//      Graph representation for both cases
+////////////////////////////////////////////////////////////////////////////////
+// Case A - generated headers: direct and transitive encapsulation of header dirs
 //
-//               3
-//              / .
-//             /   .
-//            /     .
-//           2       4
-//          /         \
-//         1           5
+//             3 (root module)
+//            /
+//           2
+//          /
+//         1
 //
-// Explanation:
-// 3 - root node both for simple and complex case:
-//  a) for simple case it includes via encapsulates header3
-//  b) for complex case header4 is copied into header3
-//////////////////////////////////////////////////////////////
-
-
-//////////////////////////////////////////////////////////////
-// Simple case
 bob_generate_source {
     name: "encapsulation_source1",
 
@@ -67,11 +56,17 @@ bob_generate_source {
     encapsulates: ["encapsulation_source2"],
 }
 
-// Simple case
-//////////////////////////////////////////////////////////////
-
-//////////////////////////////////////////////////////////////
-// Complex case
+/////////////////////////////////////////////////////////////////////////
+// Case B - generated headers: uses modules from case A, but additionally
+// module 3 uses output of module 4 through module_deps relation,
+// ignoring any further encapsulations that module 4 may have defined.
+//
+//             3 (root module)
+//            / .
+//           2   4
+//          /     \
+//         1       5 (should not be included by 3)
+//
 bob_generate_source {
     name: "encapsulation_source5",
 
@@ -104,8 +99,72 @@ bob_generate_source {
     encapsulates: ["encapsulation_source2"],
 }
 
-// Complex case
-//////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////
+// Case C - generated sources: direct and transitive encapsulation of outputs,
+// module 3 uses output of module 4 through module_srcs relation,
+// ignoring any further encapsulations that module 4 may have defined.
+//
+//             3 (root module)
+//            / .
+//           2   4
+//          /     \
+//         1       5 (should not be included by 3, but included by 4)
+//
+bob_generate_source {
+    name: "encapsulation_generated_sources1",
+
+    srcs: ["srcs/fun1.c"],
+    out: ["fun1.c"],
+
+    cmd: "cp ${in} ${out}",
+}
+
+bob_generate_source {
+    name: "encapsulation_generated_sources2",
+
+    srcs: ["srcs/fun2.c"],
+    out: ["fun2.c"],
+
+    cmd: "cp ${in} ${out}",
+    encapsulates: ["encapsulation_generated_sources1"],
+}
+
+bob_generate_source {
+    name: "encapsulation_generated_sources5",
+
+    srcs: ["srcs/fun5.c"],
+    out: ["fun5.c"],
+
+    cmd: "cp ${in} ${out}",
+}
+
+bob_generate_source {
+    name: "encapsulation_generated_sources4",
+
+    out: ["funcs.txt"],
+
+    tool: "extract_funcs.py",
+    cmd: "python ${tool} --in ${encapsulation_generated_sources5_out} --out ${out}",
+
+    encapsulates: ["encapsulation_generated_sources5"],
+    // module_deps is required to get encapsulation_generated_sources5_out
+    // reference in cmd, as encapsulates does not create such reference
+    module_deps: ["encapsulation_generated_sources5"],
+}
+
+bob_generate_source {
+    name: "encapsulation_generated_sources3",
+    module_srcs: ["encapsulation_generated_sources4"],
+
+    out: ["fun3.c"],
+
+    tool: "gen_fun3.py",
+    cmd: "python ${tool} --in ${in} --out ${out}",
+
+    encapsulates: ["encapsulation_generated_sources2"],
+}
+
+/////////////////////////////////////////////////////////////////////////////
 
 bob_binary {
     name: "validate_source_encapsulation_simple",
@@ -122,10 +181,17 @@ bob_binary {
     },
 }
 
+bob_binary {
+    name: "validate_source_encapsulation_generated_sources",
+    generated_sources: ["encapsulation_generated_sources3"],
+    srcs: ["main_fun.c"],
+}
+
 bob_alias {
     name: "bob_test_source_encapsulation",
     srcs: [
         "validate_source_encapsulation_simple",
         "validate_source_encapsulation_complex",
+        "validate_source_encapsulation_generated_sources",
     ],
 }

--- a/tests/source_encapsulation/extract_funcs.py
+++ b/tests/source_encapsulation/extract_funcs.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+# Copyright 2020 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+import sys
+import re
+
+parser = argparse.ArgumentParser(description='Extract function names and put into funcs.txt')
+parser.add_argument('--in', dest='input', action='store', required=True, help='Input file')
+parser.add_argument('--out', dest='output', action='store', required=True, help='Output file')
+args = parser.parse_args()
+
+# detects beginning of C-function signature
+func_re = r'\S+\s+(\S+)\s*\(\S*\)\s*\{'
+
+try:
+    with open(args.input, 'r') as infile:
+        res = re.findall(func_re, infile.read())
+        try:
+            with open(args.output, 'w') as outfile:
+                outfile.write(' '.join(res))
+        except IOError as e:
+            print("Output file couldn't be created: " + str(e))
+            sys.exit(1)
+except IOError as e:
+    print("Input file couldn't be opened: " + str(e))
+    sys.exit(1)

--- a/tests/source_encapsulation/gen_fun3.py
+++ b/tests/source_encapsulation/gen_fun3.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+# Copyright 2020 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(description='Generate fun3.c using function names from funcs.txt')
+parser.add_argument('--in', dest='input', action='store', required=True, help='Input file')
+parser.add_argument('--out', dest='output', action='store', required=True, help='Output file')
+args = parser.parse_args()
+
+s = '''
+#define FUNCS "%(funcs)s"
+int fun3(void)
+{
+    return 0;
+}
+'''.lstrip()
+
+try:
+    with open(args.input, 'r') as infile:
+        d = {'funcs': infile.read()}
+        try:
+            with open(args.output, 'w') as outfile:
+                outfile.write((s % d) + '\n')
+        except IOError as e:
+            print("Output file couldn't be created: " + str(e))
+            sys.exit(1)
+except IOError as e:
+    print("Input file couldn't be opened: " + str(e))
+    sys.exit(1)

--- a/tests/source_encapsulation/main_fun.c
+++ b/tests/source_encapsulation/main_fun.c
@@ -1,0 +1,8 @@
+extern int fun1(void);
+extern int fun2(void);
+extern int fun3(void);
+
+int main(void)
+{
+    return fun1() + fun2() + fun3();
+}

--- a/tests/source_encapsulation/srcs/fun1.c
+++ b/tests/source_encapsulation/srcs/fun1.c
@@ -1,0 +1,4 @@
+int fun1(void)
+{
+    return 0;
+}

--- a/tests/source_encapsulation/srcs/fun2.c
+++ b/tests/source_encapsulation/srcs/fun2.c
@@ -1,0 +1,4 @@
+int fun2(void)
+{
+    return 0;
+}

--- a/tests/source_encapsulation/srcs/fun3.c
+++ b/tests/source_encapsulation/srcs/fun3.c
@@ -1,0 +1,4 @@
+int fun3(void)
+{
+    return 0;
+}

--- a/tests/source_encapsulation/srcs/fun5.c
+++ b/tests/source_encapsulation/srcs/fun5.c
@@ -1,0 +1,5 @@
+// symbol conflicting with fun2.c
+int fun2(void)
+{
+    return 0;
+}

--- a/tests/source_encapsulation/srcs/header5.h
+++ b/tests/source_encapsulation/srcs/header5.h
@@ -1,1 +1,1 @@
-#define E 123
+#error This file should not be included


### PR DESCRIPTION
Encapsulates were supported but only for exported header dirs
(generated_headers property). This adds support also for outputs
(generated_sources property) for all 3 backends.

Note: outputs() function for generated modules include encapsulated
outputs. To get only direct outputs of current module use cmdOutputs().
However outputs() in genrulebob is used for modules referenced in
module_srcs, which shouldn't care for any further encapsulated outputs.
Basically, for other module relations aside of generated_header and
generated_sources, encapsulates should be invisible.

Added test to cover new case. Reshaped description of other tests.

Change-Id: I5ce48ada7fc0124b9d1129923ad8a5d5e7a49e0b
Signed-off-by: Michal Przeplata <michal.przeplata@arm.com>