### PR TITLE
Cleanup test2.c file so that it doesn't generate warnings by the comp…

### DIFF
--- a/tests/flag_supported/test2.c
+++ b/tests/flag_supported/test2.c
@@ -1,15 +1,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void useless(void)
-{
-    printf("I am not used\n");
-}
-
-const char main(int argc, char** argv)
+int main(int argc, char** argv)
 {
     (void)argc;
     (void)argv;
-    const int i = 0;
-    return i;
+    return 0;
 }


### PR DESCRIPTION
…iler.

test2.c for the flags_supported tests doesn't compile cleanly. As it is
only used for testing that invalid flags are not being passed to the
compiler, it makes no sense for it to generate warnings on its own.

Cleanup test2.c and make it a clean C file.

Signed-off-by: Liviu Dudau <liviu.dudau@arm.com>
Change-Id: I5923ed221da0df2a8368887ced7b73bd03cd8dba