### PR TITLE
Support Android output to testcases

### DIFF
--- a/core/android.go
+++ b/core/android.go
@@ -92,6 +92,10 @@ var androidInstallLocationSplits = map[string]int{
 	// the same as the other filetype-specific stuff - this just catches anything else.
 	"data":               1,
 	"$(TARGET_OUT_DATA)": 1,
+
+	// /testcases is unstructured
+	"testcases":               1,
+	"$(TARGET_OUT_TESTCASES)": 1,
 }
 
 func splitAndroidPath(path string) (string, string) {


### PR DESCRIPTION
Split the path into base and relative paths when trying to output to
the testcases directory.

Change-Id: I3f99d26cc89b18e2b248832c32e34f5f3ebb14d7
Signed-off-by: David Kilroy <david.kilroy@arm.com>