### PR TITLE
Support using host and target compilers with different base names

### DIFF
--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -425,8 +425,8 @@ func newToolchainGnuCommon(config *bobConfig, tgt tgtType) (tc toolchainGnuCommo
 
 	tc.objcopyBinary = props.GetString(string(tgt) + "_objcopy_binary")
 
-	tc.gccBinary = tc.prefix + props.GetString("gnu_cc_binary")
-	tc.gxxBinary = tc.prefix + props.GetString("gnu_cxx_binary")
+	tc.gccBinary = tc.prefix + props.GetString(string(tgt)+"_gnu_cc_binary")
+	tc.gxxBinary = tc.prefix + props.GetString(string(tgt)+"_gnu_cxx_binary")
 	tc.binDir = filepath.Dir(getToolPath(tc.gccBinary))
 
 	sysroot := props.GetString(string(tgt) + "_sysroot")
@@ -533,8 +533,8 @@ func newToolchainClangCommon(config *bobConfig, tgt tgtType) (tc toolchainClangC
 
 	tc.objcopyBinary = props.GetString(string(tgt) + "_objcopy_binary")
 
-	tc.clangBinary = tc.prefix + props.GetString("clang_cc_binary")
-	tc.clangxxBinary = tc.prefix + props.GetString("clang_cxx_binary")
+	tc.clangBinary = tc.prefix + props.GetString(string(tgt)+"_clang_cc_binary")
+	tc.clangxxBinary = tc.prefix + props.GetString(string(tgt)+"_clang_cxx_binary")
 
 	tc.target = props.GetString(string(tgt) + "_clang_triple")
 
@@ -699,8 +699,8 @@ func newToolchainArmClangCommon(config *bobConfig, tgt tgtType) (tc toolchainArm
 	tc.arBinary = tc.prefix + props.GetString("armclang_ar_binary")
 	tc.asBinary = tc.prefix + props.GetString("armclang_as_binary")
 	tc.objcopyBinary = props.GetString(string(tgt) + "_objcopy_binary")
-	tc.ccBinary = tc.prefix + props.GetString("armclang_cc_binary")
-	tc.cxxBinary = tc.prefix + props.GetString("armclang_cxx_binary")
+	tc.ccBinary = tc.prefix + props.GetString(string(tgt)+"_armclang_cc_binary")
+	tc.cxxBinary = tc.prefix + props.GetString(string(tgt)+"_armclang_cxx_binary")
 	tc.linker = newDefaultLinker(tc.cxxBinary, []string{}, []string{})
 
 	tc.cflags = strings.Split(config.Properties.GetString(string(tgt)+"_armclang_flags"), " ")
@@ -834,8 +834,8 @@ func newToolchainXcodeCommon(config *bobConfig, tgt tgtType) (tc toolchainXcode)
 	tc.asBinary = tc.prefix + props.GetString("as_binary")
 	tc.objcopyBinary = props.GetString(string(tgt) + "_objcopy_binary")
 
-	tc.ccBinary = tc.prefix + props.GetString("clang_cc_binary")
-	tc.cxxBinary = tc.prefix + props.GetString("clang_cxx_binary")
+	tc.ccBinary = tc.prefix + props.GetString(string(tgt)+"_clang_cc_binary")
+	tc.cxxBinary = tc.prefix + props.GetString(string(tgt)+"_clang_cxx_binary")
 
 	tc.target = props.GetString(string(tgt) + "_xcode_triple")
 

--- a/mconfig/host_toolchain.Mconfig
+++ b/mconfig/host_toolchain.Mconfig
@@ -25,14 +25,50 @@ config HOST_GNU_PREFIX
 	default "prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9/bin/x86_64-linux-android-" if BUILDER_ANDROID_MAKE || BUILDER_ANDROID_BP
 	default ""
 
+config HOST_GNU_CC_BINARY
+	string "Host GNU C compiler binary"
+	default "gcc"
+	help
+	  The name of the host C compiler when the GNU toolchain is used.
+
+config HOST_GNU_CXX_BINARY
+	string "Host GNU C++ compiler binary"
+	default "g++"
+	help
+	  The name of the host C++ compiler when the GNU toolchain is used.
+
 config HOST_CLANG_PREFIX
 	string "Host Clang compiler prefix"
 	default "prebuilts/clang/host/linux-x86/clang-r370808/bin/" if BUILDER_ANDROID_MAKE || BUILDER_ANDROID_BP
 	default ""
 
+config HOST_CLANG_CC_BINARY
+	string "Host Clang C compiler binary"
+	default "clang"
+	help
+	  The name of the host C compiler when Clang toolchain is used.
+
+config HOST_CLANG_CXX_BINARY
+	string "Host Clang C++ compiler binary"
+	default "clang++"
+	help
+	  The name of the host C++ compiler when Clang toolchain is used.
+
 config HOST_ARMCLANG_PREFIX
 	string "Host Arm Compiler 6 prefix"
 	default ""
+
+config HOST_ARMCLANG_CC_BINARY
+	string "Host Armclang C compiler binary"
+	default "armclang"
+	help
+	  The name of the host C compiler when the Arm Compiler is used.
+
+config HOST_ARMCLANG_CXX_BINARY
+	string "Host Armclang C++ compiler binary"
+	default "armclang"
+	help
+	  The name of the host C++ compiler when the Arm Compiler is used.
 
 config HOST_XCODE_PREFIX
 	string "Host Xcode prefix"

--- a/mconfig/target_toolchain.Mconfig
+++ b/mconfig/target_toolchain.Mconfig
@@ -25,9 +25,33 @@ config TARGET_CLANG_PREFIX
 	string "Target Clang compiler prefix"
 	default ""
 
+config TARGET_CLANG_CC_BINARY
+	string "Target Clang C compiler binary"
+	default "clang"
+	help
+	  The name of the target C compiler when Clang toolchain is used.
+
+config TARGET_CLANG_CXX_BINARY
+	string "Target Clang C++ compiler binary"
+	default "clang++"
+	help
+	  The name of the target C++ compiler when Clang toolchain is used.
+
 config TARGET_ARMCLANG_PREFIX
 	string "Target Arm Compiler 6 compiler prefix"
 	default ""
+
+config TARGET_ARMCLANG_CC_BINARY
+	string "Target Armclang C compiler binary"
+	default "armclang"
+	help
+	  The name of the target C compiler when the Arm Compiler is used.
+
+config TARGET_ARMCLANG_CXX_BINARY
+	string "Target Armclang C++ compiler binary"
+	default "armclang"
+	help
+	  The name of the target C++ compiler when the Arm Compiler is used.
 
 config TARGET_XCODE_PREFIX
 	string "Target Xcode prefix"
@@ -47,6 +71,18 @@ config TARGET_SYSROOT
 	  The path to the target's system root directory. This should
 	  contain include and lib directories, with headers and libraries
 	  for the target system.
+
+config TARGET_GNU_CC_BINARY
+	string "Target GNU C compiler binary"
+	default "gcc"
+	help
+	  The name of the target C compiler when the GNU toolchain is used.
+
+config TARGET_GNU_CXX_BINARY
+	string "Target GNU C++ compiler binary"
+	default "g++"
+	help
+	  The name of the target C++ compiler when the GNU toolchain is used.
 
 # The following, despite being only used by Bob, must be defined by
 # the superproject so that it can add any desired defaults, etc:

--- a/mconfig/toolchain.Mconfig
+++ b/mconfig/toolchain.Mconfig
@@ -17,18 +17,6 @@
 
 menu "Toolchain binary names"
 
-config GNU_CC_BINARY
-	string "GNU C compiler binary"
-	default "gcc"
-	help
-	  The name of the C compiler when the GNU toolchain is used.
-
-config GNU_CXX_BINARY
-	string "GNU C++ compiler binary"
-	default "g++"
-	help
-	  The name of the C++ compiler when the GNU toolchain is used.
-
 config AS_BINARY
 	string "GNU and Clang Assembler binary"
 	default "as"
@@ -37,32 +25,6 @@ config AS_BINARY
 	  hand-written assembly code.
 
 ###################################
-
-config CLANG_CC_BINARY
-	string "Clang C compiler binary"
-	default "clang"
-	help
-	  The name of the C compiler when Clang toolchain is used.
-
-config CLANG_CXX_BINARY
-	string "Clang C++ compiler binary"
-	default "clang++"
-	help
-	  The name of the C++ compiler when Clang toolchain is used.
-
-###################################
-
-config ARMCLANG_CC_BINARY
-	string "Armclang C compiler binary"
-	default "armclang"
-	help
-	  The name of the C compiler when the Arm Compiler is used.
-
-config ARMCLANG_CXX_BINARY
-	string "Armclang C++ compiler binary"
-	default "armclang"
-	help
-	  The name of the C++ compiler when the Arm Compiler is used.
 
 config ARMCLANG_LD_BINARY
 	string

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -286,8 +286,8 @@ config STATIC_LIB_TOGGLE
 config GEN_CC
 	string "Compiler"
 	default "$(CLANG) -fuse-ld=lld" if BUILDER_ANDROID_MAKE
-	default HOST_CLANG_PREFIX + CLANG_CC_BINARY + " -fuse-ld=lld" if BUILDER_ANDROID_BP
-	default HOST_GNU_PREFIX + GNU_CC_BINARY
+	default HOST_CLANG_PREFIX + HOST_CLANG_CC_BINARY + " -fuse-ld=lld" if BUILDER_ANDROID_BP
+	default HOST_GNU_PREFIX + HOST_GNU_CC_BINARY
 
 config GEN_AR
 	string "Archiver"
@@ -297,7 +297,7 @@ config GEN_AR
 config KERNEL_CC
 	string "Kernel compiler"
 	default "$(CLANG)" if BUILDER_ANDROID_MAKE
-	default HOST_CLANG_PREFIX + CLANG_CC_BINARY if BUILDER_ANDROID_BP
+	default HOST_CLANG_PREFIX + HOST_CLANG_CC_BINARY if BUILDER_ANDROID_BP
 
 config KERNEL_CLANG_TRIPLE
 	string "Kernel Clang triple"


### PR DESCRIPTION
This commit replaces `(GNU|CLANG|ARMCLANG)_(CC|CXX)_BINARY`
with `HOST_(GNU|CLANG|ARMCLANG)_(CC|CXX)_BINARY`
and `TARGET_(GNU|CLANG|ARMCLANG)_(CC|CXX)_BINARY`
to allow using host and target compilers that do not have
the same base name.

Change-Id: I1a31bbc046a26ad6a468e1c5474f0f1d21f48485
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>