### PR TITLE
Translate Android.mk paths to Soong

### DIFF
--- a/core/android_test.go
+++ b/core/android_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ARM-software/bob-build/internal/utils"
 )
 
 func checkSplit(t *testing.T, path, expectedBase, expectedRel string) {
@@ -39,4 +41,25 @@ func Test_splitAndroidPath(t *testing.T) {
 	checkSplit(t, "$(TARGET_OUT_VENDOR)/lib", "$(TARGET_OUT_VENDOR)/lib", "")
 	checkSplit(t, "$(TARGET_OUT_EXECUTABLES)", "$(TARGET_OUT_EXECUTABLES)", "")
 	checkSplit(t, "$(TARGET_OUT_SHARED_LIBRARIES)/libdir", "$(TARGET_OUT_SHARED_LIBRARIES)", "libdir")
+	checkSplit(t, "unknown/path", "unknown/path", "")
+}
+
+// Ensure that every translatable Android.mk variable and its translation have
+// a corresponding entry in androidInstallLocationSplits.
+func Test_androidMkTranslations(t *testing.T) {
+	checkHasSplit := func(path string) {
+		_, ok := findAndroidInstallLocationSplit(utils.SplitPath(path))
+		assert.True(t, ok, "Could not find split for '"+path+"'")
+	}
+
+	for mkVar, soongPath := range androidMkInstallLocationTranslations {
+		mkVar = "$(" + mkVar + ")"
+		checkHasSplit(mkVar)
+		if soongPath != "" {
+			// TARGET_OUT maps to an empty soong path "", which
+			// can't have a matching split entry.
+			checkHasSplit(soongPath)
+		}
+		assert.Equal(t, soongPath, expandAndroidMkInstallVars(mkVar))
+	}
 }

--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -220,7 +220,7 @@ func addCcLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContex
 	m.AddStringList("export_header_lib_headers", reexportHeaders)
 	m.AddStringList("ldflags", l.Properties.Ldflags)
 
-	_, installRel, ok := getAndroidInstallPath(l.getInstallableProps())
+	_, installRel, ok := getSoongInstallPath(l.getInstallableProps())
 	if ok && installRel != "" {
 		m.AddString("relative_install_path", installRel)
 	}
@@ -231,7 +231,7 @@ func addCcLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContex
 
 func addBinaryProps(m bpwriter.Module, l binary, mctx blueprint.ModuleContext) {
 	// Handle installation
-	if _, installRel, ok := getAndroidInstallPath(l.getInstallableProps()); ok {
+	if _, installRel, ok := getSoongInstallPath(l.getInstallableProps()); ok {
 		// Only setup multilib for target modules.
 		// We support multilib target binaries to allow creation of test
 		// binaries in both modes.

--- a/core/androidbp_resource.go
+++ b/core/androidbp_resource.go
@@ -29,7 +29,7 @@ func (g *androidBpGenerator) resourceActions(r *resource, mctx blueprint.ModuleC
 		return
 	}
 
-	installBase, installRel, _ := getAndroidInstallPath(r.getInstallableProps())
+	installBase, installRel, _ := getSoongInstallPath(r.getInstallableProps())
 
 	var modType string
 	if strings.HasPrefix(installBase+"/", "data/") {


### PR DESCRIPTION
Expand commonly-used Android.mk path variables into a Soong-style
installation path, to allow an incremental transition for existing
builds switching from Android.mk to Android.bp.

Change-Id: Ie72bedd969c92b1c16c8b8a7256a6e4cd99b5ad0
Signed-off-by: Chris Diamand <chris.diamand@arm.com>