### PR TITLE
Regenerate Android.bp on plugin build template change

### DIFF
--- a/core/androidbp_backend.go
+++ b/core/androidbp_backend.go
@@ -210,7 +210,9 @@ func (s *androidBpSingleton) GenerateBuildActions(ctx blueprint.SingletonContext
 	sb := &strings.Builder{}
 
 	// read definitions of plugin packages
-	content, err := ioutil.ReadFile(filepath.Join(getBobDir(), "plugins/Android.bp.in"))
+	pluginTemplate := filepath.Join(getBobDir(), "plugins/Android.bp.in")
+	ctx.AddNinjaFileDeps(pluginTemplate)
+	content, err := ioutil.ReadFile(pluginTemplate)
 	if err != nil {
 		utils.Exit(1, err.Error())
 	}


### PR DESCRIPTION
When Android.bp.in changes, the Android.bp file needs to be
regenerated

Change-Id: Icba33adfb3299156b3087dd3d65375b410c90d55
Signed-off-by: David Kilroy <david.kilroy@arm.com>