### PR TITLE
Allow `whole_static_libs` in `bob_binary`

### DIFF
--- a/core/library.go
+++ b/core/library.go
@@ -699,7 +699,6 @@ func checkLibraryFieldsMutator(mctx blueprint.BottomUpMutatorContext) {
 		b.checkField(len(props.Export_ldflags) == 0, "export_ldflags")
 		b.checkField(len(props.Export_local_include_dirs) == 0, "export_local_include_dirs")
 		b.checkField(len(props.Reexport_libs) == 0, "reexport_libs")
-		b.checkField(len(props.Whole_static_libs) == 0, "whole_static_libs")
 		b.checkField(props.Forwarding_shlib == nil, "forwarding_shlib")
 	} else if sl, ok := m.(*sharedLibrary); ok {
 		props := sl.Properties


### PR DESCRIPTION
This allows support for static registration in static libraries.

This is a common pattern in C++ test frameworks (such as Catch2).

Without linking the static library as a whole the linker can optimise
away the static registration part and there will be no tests registered.

See https://github.com/catchorg/Catch2/issues/720

Change-Id: I778a6cfbfe44acdf7d01eb34f144c4a1b5bb1db6
Signed-off-by: Matthew Clarkson <matthew.clarkson@arm.com>