### PR TITLE
Android.bp backend install path handling

### DIFF
--- a/core/android.go
+++ b/core/android.go
@@ -91,11 +91,12 @@ var androidInstallLocationSplits = map[string]int{
 	// /data isn't quite so structured, so put most components in the relative_install_path.
 	// Note that $(TARGET_OUT_DATA_EXECUTABLES) etc actually maps to /system, so is handled
 	// the same as the other filetype-specific stuff - this just catches anything else.
-	"data":               1,
-	"$(TARGET_OUT_DATA)": 1,
+	"data":                           1,
+	"$(TARGET_OUT_DATA)":             1,
+	"$(TARGET_OUT_DATA_NATIVE_TEST)": 1,
 
 	// /testcases is unstructured
-	"testcases":               1,
+	"tests":                   1,
 	"$(TARGET_OUT_TESTCASES)": 1,
 }
 
@@ -149,11 +150,12 @@ var androidMkInstallLocationTranslations = map[string]string{
 	"TARGET_OUT_EXECUTABLES":             "system/bin",
 	"TARGET_OUT_SHARED_LIBRARIES":        "system/lib",
 	"TARGET_OUT_SYSTEM":                  "system",
-	"TARGET_OUT_TESTCASES":               "testcases",
+	"TARGET_OUT_TESTCASES":               "tests",
 	"TARGET_OUT_VENDOR":                  "vendor",
 	"TARGET_OUT_VENDOR_ETC":              "vendor/etc",
 	"TARGET_OUT_VENDOR_EXECUTABLES":      "vendor/bin",
 	"TARGET_OUT_VENDOR_SHARED_LIBRARIES": "vendor/lib",
+	"TARGET_OUT_DATA_NATIVE_TEST":        "tests",
 }
 
 func expandAndroidMkInstallVars(path string) string {

--- a/core/android_test.go
+++ b/core/android_test.go
@@ -38,6 +38,7 @@ func Test_splitAndroidPath(t *testing.T) {
 	checkSplit(t, "vendor/bin", "vendor/bin", "")
 	checkSplit(t, "data/nativetest/mytests", "data", "nativetest/mytests")
 	checkSplit(t, "$(TARGET_OUT_DATA)/nativetest", "$(TARGET_OUT_DATA)", "nativetest")
+	checkSplit(t, "$(TARGET_OUT_DATA_NATIVE_TEST)/mytests", "$(TARGET_OUT_DATA_NATIVE_TEST)", "mytests")
 	checkSplit(t, "$(TARGET_OUT_VENDOR)/lib", "$(TARGET_OUT_VENDOR)/lib", "")
 	checkSplit(t, "$(TARGET_OUT_EXECUTABLES)", "$(TARGET_OUT_EXECUTABLES)", "")
 	checkSplit(t, "$(TARGET_OUT_SHARED_LIBRARIES)/libdir", "$(TARGET_OUT_SHARED_LIBRARIES)", "libdir")

--- a/core/android_test.go
+++ b/core/android_test.go
@@ -33,11 +33,14 @@ func checkSplit(t *testing.T, path, expectedBase, expectedRel string) {
 }
 
 func Test_splitAndroidPath(t *testing.T) {
-	checkSplit(t, "vendor/lib/", "vendor/lib", "")
-	checkSplit(t, "vendor/bin/binsubdir", "vendor/bin", "binsubdir")
-	checkSplit(t, "vendor/bin", "vendor/bin", "")
-	checkSplit(t, "data/nativetest/mytests", "data", "nativetest/mytests")
-	checkSplit(t, "$(TARGET_OUT_DATA)/nativetest", "$(TARGET_OUT_DATA)", "nativetest")
+	checkSplit(t, "bin/binsubdir", "bin", "binsubdir")
+	checkSplit(t, "lib/egl", "lib", "egl")
+	checkSplit(t, "etc/firmware", "etc/firmware", "")
+	checkSplit(t, "firmware/subdir", "firmware", "subdir")
+	checkSplit(t, "etc/subdir", "etc", "subdir")
+	checkSplit(t, "tests/subdir", "tests", "subdir")
+	checkSplit(t, "data/nativetest/mytests", "data/nativetest", "mytests")
+	checkSplit(t, "$(TARGET_OUT_DATA)/nativetest", "$(TARGET_OUT_DATA)/nativetest", "")
 	checkSplit(t, "$(TARGET_OUT_DATA_NATIVE_TEST)/mytests", "$(TARGET_OUT_DATA_NATIVE_TEST)", "mytests")
 	checkSplit(t, "$(TARGET_OUT_VENDOR)/lib", "$(TARGET_OUT_VENDOR)/lib", "")
 	checkSplit(t, "$(TARGET_OUT_EXECUTABLES)", "$(TARGET_OUT_EXECUTABLES)", "")

--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -300,6 +300,11 @@ func (g *androidBpGenerator) binaryActions(l *binary, mctx blueprint.ModuleConte
 			modType = "cc_test"
 		}
 	} else {
+		if installBase != "" && installBase != "bin" {
+			panic(fmt.Errorf("Unknown base install location for %s (%s)",
+				l.Name(), installBase))
+		}
+
 		switch l.Properties.TargetType {
 		case tgtTypeHost:
 			modType = "cc_binary_host"
@@ -341,6 +346,12 @@ func (g *androidBpGenerator) sharedActions(l *sharedLibrary, mctx blueprint.Modu
 		modType = "cc_library_host_shared"
 	case tgtTypeTarget:
 		modType = "cc_library_shared"
+	}
+
+	installBase, _, _ := getAndroidInstallPath(l.getInstallableProps())
+	if installBase != "" && installBase != "lib" {
+		panic(fmt.Errorf("Unknown base install location for %s (%s)",
+			l.Name(), installBase))
 	}
 
 	m, err := AndroidBpFile().NewModule(modType, l.shortName())

--- a/core/androidbp_resource.go
+++ b/core/androidbp_resource.go
@@ -66,8 +66,13 @@ func (g *androidBpGenerator) resourceActions(r *resource, mctx blueprint.ModuleC
 	} else if strings.HasPrefix(installBase+"/", "bin/") {
 		modType = "cc_prebuilt_binary"
 		write = writeCodeResourceModule
-	} else if strings.HasPrefix(installBase+"/", "testcases/") {
-		modType = "prebuilt_testcase_bob"
+	} else if installBase == "tests" {
+		// Eventually we want to install in testcases,
+		// But we can't put binaries there yet.
+		// So place resources in /data/nativetest to align with cc_test.
+		//modType = "prebuilt_testcase_bob"
+		modType = "prebuilt_data_bob"
+		installRel = filepath.Join("nativetest", installRel)
 		write = writeDataResourceModule
 	} else {
 		panic(fmt.Errorf("Could not detect partition for install path '%s'", installBase))

--- a/core/androidbp_resource.go
+++ b/core/androidbp_resource.go
@@ -54,16 +54,16 @@ func (g *androidBpGenerator) resourceActions(r *resource, mctx blueprint.ModuleC
 	// of properties depending on which one is required.
 	var write func(bpwriter.Module, string, string)
 
-	if strings.HasPrefix(installBase+"/", "data/") {
+	if installBase == "data" {
 		modType = "prebuilt_data_bob"
 		write = writeDataResourceModule
-	} else if strings.HasPrefix(installBase+"/", "etc/") {
+	} else if installBase == "etc" {
 		modType = "prebuilt_etc"
 		write = writeDataResourceModule
-	} else if strings.HasPrefix(installBase+"/", "firmware/") {
+	} else if installBase == "firmware" {
 		modType = "prebuilt_firmware"
 		write = writeDataResourceModule
-	} else if strings.HasPrefix(installBase+"/", "bin/") {
+	} else if installBase == "bin" {
 		modType = "cc_prebuilt_binary"
 		write = writeCodeResourceModule
 	} else if installBase == "tests" {

--- a/docs/module_types/bob_install_group.md
+++ b/docs/module_types/bob_install_group.md
@@ -7,6 +7,7 @@ copy outputs after the build completes.
 `bob_install_group` supports [features](../features.md)
 
 ## Full specification of `bob_install_group` properties
+
 ```bp
 bob_install_group {
     name: "custom_name",
@@ -19,8 +20,17 @@ bob_install_group {
 
 ----
 ### **bob_install_group.name** (required)
+
 The unique identifier that can be used to refer to this module.
 
 ----
 ### **bob_install_group.install_path** (optional)
+
 Path to install output of aggregated targets.
+
+Note that on the Android.bp backend, the first path element is treated
+specially, see
+[user guide](../user_guide/android.md#androidbp-backend-install-paths)
+for detail. The path does not reference the system or vendor
+partition, and the item will be installed in system or vendor
+based on whether the `owner` property has been set.

--- a/docs/module_types/bob_resource.md
+++ b/docs/module_types/bob_resource.md
@@ -8,14 +8,16 @@ need while executing.
 This will reference an `bob_install_group` so it gets copied to an appropriate location
 relative to the binaries.
 
-For the Android BP backend, the `install_path` set in the `bob_install_group` must be
-prefixed by a known string to select an appropriate Android directory.
-Currently `data/`, 'firmware/' and `etc/` are supported. The `owner` property also influences
-where the files will be installed.
+For the Android.bp backend, the `install_path` set in the
+`bob_install_group` must be prefixed by a known string to select an
+appropriate directory. Currently `data`, `firmware`, `etc`, `bin` and
+`tests` are supported. The `owner` property also influences which
+partition the files will be installed.
 
 `bob_resource` supports [features](../features.md)
 
 ## Full specification of `bob_resource` properties
+
 For general common properties please
 [check detailed documentation](common_module_properties.md).
 
@@ -47,18 +49,23 @@ bob_resource {
 
 ----
 ### **bob_resource.name** (required)
+
 The unique identifier that can be used to refer to this module.
 
 ----
 ### **bob_resource.srcs** (optional)
+
 Source files to copy to the installation directory.
 
 ----
 ### **bob_resource.add_to_alias** (optional)
+
 Adds this module to an alias.
 
 ----
 ### **bob_module.owner** (optional)
+
 Value to use on Android for `LOCAL_MODULE_OWNER`
-If set, then the module is considered proprietary. For the Android BP backend this will
-usually be installed in the vendor partition.
+
+If set, then the module is considered proprietary. For the Android.bp
+backend this will usually be installed in the vendor partition.

--- a/docs/user_guide/android.md
+++ b/docs/user_guide/android.md
@@ -36,3 +36,37 @@ minimal. Notably, if something links against a forwarding library,
 `--copy-dt-needed-entries` is applied across the whole link and
 the resultant binary will have `DT_NEEDED` symbols propagated from all
 shared libraries it links against.
+
+Android.bp Backend Install Paths
+===
+
+Soong restricts the install locations of its module types. In addition,
+use of the system and vendor partitions is controlled via the
+`proprietary`/`vendor` properties.
+
+The Android.bp backend will recognize the identifiers below at the
+beginning of the install path. The first three are chosen to agree
+with what might be used in the Linux backend, to simplify configuration.
+
+| Identifier | Description |
+| --- | --- |
+| `bin` | Executables to be installed in `<partition>/bin` |
+| `lib` | Shared libraries to be installed in `<partition>/lib` |
+| `etc` | Configuration to be installed in `<partition>/etc` |
+| `firmware` | Firmware to be installed in `<partition>/etc/firmware` |
+| `data` | Resources to be installed in `data` |
+| `tests` | Test executables will be installed in an appropriate directory[1] |
+
+[1] Ideally `tests` should be installed in `testcases`, which is not
+in any of the Android images. This is not currently possible, so they
+are installed to `data/nativetest` in `userdata.img`. The intention is
+that tests are not flashed to the board, and they are copied to the
+board when you want to run them. Please avoid relying on tests being
+in the userdata image.
+
+Android.mk Transition Support
+===
+
+Bob contains support to translate Android.mk install paths (using
+Android make variables) to Android.bp backend install paths. This is
+expected to be temporary.


### PR DESCRIPTION
Document how Android.bp install paths are intended to work.

Implement a mechanism for tests (and their resources) to be output to a known location.

Various tweaks to make things work as desired