### PR TITLE
Support different partitions in genrule

### DIFF
--- a/core/androidbp_kernel_module.go
+++ b/core/androidbp_kernel_module.go
@@ -105,9 +105,29 @@ func (g *androidBpGenerator) kernelModuleActions(l *kernelModule, mctx blueprint
 		l.Properties.Make_args,
 	)
 
-	installPath, ok := l.getInstallableProps().getInstallPath()
+	installBase, installRel, ok := getSoongInstallPath(l.getInstallableProps())
 	if ok {
-		bpmod.AddString("install_path", installPath)
+		switch installBase {
+		case "data":
+			bpmod.AddBool("install_in_data", true)
+		case "tests":
+			/* Eventually we want to install in testcases,
+			 * but we can't put binaries there yet:
+			 * bpmod.AddBool("install_in_testcases", true)
+			 * So place resources in /data/nativetest to align with cc_test.
+			 *
+			 * `nativetest` has no corresponding `InstallIn...` method,
+			 * so request the `/data` partition and add the `nativetest`
+			 * part in as another relative component. */
+			bpmod.AddBool("install_in_data", true)
+			installRel = filepath.Join(installRel, "nativetest")
+		default:
+			/* Paths like `lib/modules` are implicitly in /system, or /vendor, but
+			 * unlike e.g. a library, which would add the `lib` for us, we need to add
+			 * it ourselves here - so the whole path is used as the relative part. */
+			installRel = filepath.Join(installBase, installRel)
+		}
+		bpmod.AddString("install_path", installRel)
 	}
 
 }

--- a/plugins/genrulebob/genrule.go
+++ b/plugins/genrulebob/genrule.go
@@ -54,6 +54,9 @@ type commonProps struct {
 	// if install path is not empty, module will be installed onto partition,
 	// it should contain path relative to partition root
 	Install_path *string
+	// Partition selection options
+	Install_in_data      bool
+	Install_in_testcases bool
 }
 
 type genruleProps struct {
@@ -618,4 +621,12 @@ func (m *genrulebobCommon) AndroidMkEntries() []android.AndroidMkEntries {
 // required to generate ninja rule for copying file onto partition
 func (m *genrulebobCommon) InstallBypassMake() bool {
 	return m.Properties.Install_path != nil
+}
+
+func (m *genrulebobCommon) InstallInData() bool {
+	return m.Properties.Install_in_data
+}
+
+func (m *genrulebobCommon) InstallInTestcases() bool {
+	return m.Properties.Install_in_testcases
 }


### PR DESCRIPTION
Add support to the custom generated module for installation in `data`,
`data/nativetest` and `testcases`.

Change-Id: I3ecc79df04fbbca1a999fab35b36b6c444fd5f06
Signed-off-by: Chris Diamand <chris.diamand@arm.com>