### PR TITLE
Proprietary tests in data/nativetest

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -294,7 +294,7 @@ func androidLibraryBuildAction(sb *strings.Builder, mod blueprint.Module, ctx bl
 
 	writeListAssignment(sb, "LOCAL_MODULE_TAGS", m.Properties.Tags)
 	writeListAssignment(sb, "LOCAL_EXPORT_C_INCLUDE_DIRS", exportIncludeDirs)
-	if m.Properties.Owner != "" {
+	if m.Properties.isProprietary() {
 		sb.WriteString("LOCAL_MODULE_OWNER := " + m.Properties.Owner + "\n")
 		sb.WriteString("LOCAL_PROPRIETARY_MODULE := true\n")
 	}
@@ -523,7 +523,7 @@ func (g *androidMkGenerator) resourceActions(m *resource, ctx blueprint.ModuleCo
 		sb.WriteString("LOCAL_MODULE_RELATIVE_PATH := " + installRel + "\n")
 		writeListAssignment(sb, "LOCAL_MODULE_TAGS", m.Properties.Tags)
 		sb.WriteString("LOCAL_SRC_FILES := " + file + "\n")
-		if m.Properties.Owner != "" {
+		if m.Properties.isProprietary() {
 			sb.WriteString("LOCAL_MODULE_OWNER := " + m.Properties.Owner + "\n")
 			sb.WriteString("LOCAL_PROPRIETARY_MODULE := true\n")
 		}
@@ -1084,7 +1084,7 @@ func (g *androidMkGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.
 		sb.WriteString("LOCAL_UNINSTALLABLE_MODULE := true\n")
 	}
 	sb.WriteString("LOCAL_MODULE_SUFFIX := .ko\n")
-	if m.Properties.Owner != "" {
+	if m.Properties.isProprietary() {
 		sb.WriteString("LOCAL_MODULE_OWNER := " + m.Properties.Owner + "\n")
 		sb.WriteString("LOCAL_PROPRIETARY_MODULE := true\n")
 	}

--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -111,7 +111,7 @@ func (l *library) getGeneratedHeaderModules(mctx blueprint.BaseModuleContext) (h
 }
 
 func addProvenanceProps(m bpwriter.Module, props AndroidProps) {
-	if props.Owner != "" {
+	if props.isProprietary() {
 		m.AddString("owner", props.Owner)
 		m.AddBool("vendor", true)
 		m.AddBool("proprietary", true)

--- a/core/androidbp_kernel_module.go
+++ b/core/androidbp_kernel_module.go
@@ -120,7 +120,12 @@ func (g *androidBpGenerator) kernelModuleActions(l *kernelModule, mctx blueprint
 			 * so request the `/data` partition and add the `nativetest`
 			 * part in as another relative component. */
 			bpmod.AddBool("install_in_data", true)
-			installRel = filepath.Join(installRel, "nativetest")
+			if l.Properties.isProprietary() {
+				// Vendor modules need an additional path element to match cc_test
+				installRel = filepath.Join("nativetest", "vendor", installRel)
+			} else {
+				installRel = filepath.Join("nativetest", installRel)
+			}
 		default:
 			/* Paths like `lib/modules` are implicitly in /system, or /vendor, but
 			 * unlike e.g. a library, which would add the `lib` for us, we need to add

--- a/core/androidbp_resource.go
+++ b/core/androidbp_resource.go
@@ -72,7 +72,12 @@ func (g *androidBpGenerator) resourceActions(r *resource, mctx blueprint.ModuleC
 		// So place resources in /data/nativetest to align with cc_test.
 		//modType = "prebuilt_testcase_bob"
 		modType = "prebuilt_data_bob"
-		installRel = filepath.Join("nativetest", installRel)
+		if r.Properties.isProprietary() {
+			// Vendor modules need an additional path element to match cc_test
+			installRel = filepath.Join("nativetest", "vendor", installRel)
+		} else {
+			installRel = filepath.Join("nativetest", installRel)
+		}
 		write = writeDataResourceModule
 	} else {
 		panic(fmt.Errorf("Could not detect partition for install path '%s'", installBase))

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -116,6 +116,10 @@ type AndroidProps struct {
 	Owner string
 }
 
+func (p *AndroidProps) isProprietary() bool {
+	return p.Owner != ""
+}
+
 // AndroidPGOProps defines properties used to support profile-guided optimization.
 type AndroidPGOProps struct {
 	Pgo struct {


### PR DESCRIPTION
Add an accessor function to AndroidProps to identify if the module is
proprietary/vendor. This encapsulates the test on Owner.

Update all callers.

Update Android.bp backend resource handling to put tests in
data/nativetest/vendor if the module is proprietary. Setting the
vendor property doesn't change the behaviour of the prebuilt_data_bob
module

Fix the kernel install path when targetting `tests` - nativetest
should come before installRel. Also add vendor when the module is
proprietary.

Change-Id: I807bbef78c49512c8435817d87ac291eb8485c31
Signed-off-by: David Kilroy <david.kilroy@arm.com>