### PR TITLE
Error when `post_install_cmd` is used on Android.bp

### DIFF
--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -239,6 +239,13 @@ func addCcLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContex
 	addProvenanceProps(m, l.Properties.Build.AndroidProps)
 	addPGOProps(m, l.Properties.Build.AndroidPGOProps)
 	addRequiredModules(m, l, mctx)
+
+	if l.Properties.Post_install_cmd != nil ||
+		l.Properties.Post_install_args != nil ||
+		l.Properties.Post_install_tool != nil {
+		panic(fmt.Errorf("Module %s has post install actions - this is not supported on Android.bp",
+			mctx.ModuleName()))
+	}
 }
 
 func addBinaryProps(m bpwriter.Module, l binary, mctx blueprint.ModuleContext) {

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -325,7 +325,7 @@ be placed in a separate file (Linux only).
 
 ----
 ### **bob_module.post_install_tool** (optional)
-Script used during post install.
+Script used during post install. Not supported on Android.bp.
 
 ----
 ### **bob_module.post_install_cmd** (optional)
@@ -337,10 +337,12 @@ are substituted into the command:
 - `${bob_config}` - the Bob configuration file.
 - `${args}` - arguments from `post_install_args`
 
+Not supported on Android.bp.
+
 ### **bob_module.post_install_args** (optional)
 
 Arguments to insert into `post_install_cmd`. This allows arguments to
-added based on features and defaults.
+added based on features and defaults. Not supported on Android.bp.
 
 ----
 ### **bob_module.target_supported** (optional)

--- a/docs/user_guide/android.md
+++ b/docs/user_guide/android.md
@@ -31,6 +31,8 @@ whether it is in the vendor partition or not.
 The Android make backend does not support [build
 wrappers](wrappers.md) or [library versioning](versioning.md).
 
+The Android.bp backend does not support post install actions.
+
 Support for [forwarding libraries](forwarding.md) on Android is
 minimal. Notably, if something links against a forwarding library,
 `--copy-dt-needed-entries` is applied across the whole link and

--- a/docs/user_guide/build_output.md
+++ b/docs/user_guide/build_output.md
@@ -111,14 +111,14 @@ subdirectory, so that it's easier to setup more complicated
 heirarchies without lots of install groups. Here `libdrm.so` actually
 gets copied to `install/lib/libdrm/libdrm.so`.
 
-If you need to post-process the binary, use `post_install_cmd`. The
-related `post_install_tool` will add a dependency on a script which
-can be referred to in `post_install_cmd` as `${tool}`. An example of
-post-processing is to strip libraries of debug information. For any
-library it's advised to just run a single script to cover all post
-install actions. If different actions need to be taken in different
-circumstances, use `post_install_args` to pass the necessary arguments
-to the script (based on enabled features).
+If you need to post-process the binary, use `post_install_cmd` (not
+supported on Android.bp). The related `post_install_tool` will add a
+dependency on a script which can be referred to in `post_install_cmd`
+as `${tool}`. An example of post-processing is to strip libraries of
+debug information. For any library it's advised to just run a single
+script to cover all post install actions. If different actions need to
+be taken in different circumstances, use `post_install_args` to pass
+the necessary arguments to the script (based on enabled features).
 
 When installing libraries and binaries, their dependencies are also
 installed. You can specify additional dependencies with


### PR DESCRIPTION
Post-install actions are not supported on Android.bp.

Change-Id: I1ea994b04f1091f68d591c16d279a7586fc33b68
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>