### PR TITLE
Use v1.6.1 of github.com/stretchr/testify in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,11 @@ before_script:
   - export GOROOT=$(go env GOROOT)
   - export BOB_WORKSPACE=$TRAVIS_WORK_DIR/bob_workspace
   - export GOPATH=${BOB_WORKSPACE}
-  - go get github.com/stretchr/testify
+  - go get -d github.com/stretchr/testify
+  - cd $GOPATH/src/github.com/stretchr/testify
+  - git checkout v1.6.1
+  - go install github.com/stretchr/testify
+  - cd -
 
 matrix:
   include:


### PR DESCRIPTION
Later versions do not support Go 1.10-1.12, so use v1.6.1.

Change-Id: I10d77320784f9c04ea1a7d75c2e5e9e0549ecadb
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>