### PR TITLE
Update manifest

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -2,70 +2,69 @@
 <manifest>
   <remote fetch="https://android.googlesource.com/" name="aosp" review="https://android-review.googlesource.com/"/>
 
-  <default remote="aosp" revision="refs/tags/android-r-preview-2" sync-j="4"/>
+  <default remote="aosp" revision="master" sync-j="4"/>
 
   <manifest-server url="http://android-smartsync.corp.google.com/android.googlesource.com/manifestserver"/>
 
-  <project groups="device,yukawa,pdk" name="device/amlogic/yukawa" revision="f704c3ce2a7bf00ec2e4ea47256f397b7ebe97fd" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="2" groups="device,yukawa,pdk" name="device/amlogic/yukawa-kernel" revision="90dc515e490b2cd481a0b1bdb36cd605a010c27a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk" name="device/common" revision="1332d8b9851af5ec38d43796e49757cb9b672539" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/arm64" revision="b2aea8576e3928e9add8b616740e56c1c5a811d2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/armv7-a-neon" revision="66a3702708ca934117f1217950d4d5abca05380f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/art" revision="7690f44d09180954226514403880f6f1f6df9b57" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/car" revision="96ca24806dc620d2830f161edcd636631d16eccb" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/common" revision="754ecb765b523baf6a284db336c1823998f6dda7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/goldfish" revision="2ec6502a3648527f1fa26437d38d94906dc5be0f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/goldfish-opengl" revision="f02c30629ed52d2a91b09853efe66e57822f11c7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/mini-emulator-arm64" revision="672958caf7187fb355149546d886bf5f556ba3e6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/mini-emulator-armv7-a-neon" revision="8c906010786b63d1549ea76e0dba2e0c0abc399b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/mini-emulator-x86" revision="dc0e1610a68c17e4aaf3a2b06bf18062e8e5e4d0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/mini-emulator-x86_64" revision="0e0dc9eefb1226163a215ac3bac16dedf15d88f9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/opengl-transport" revision="4157616ba2a705a6c8c50f3f7c73582e78587a4c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/qemu" revision="c8ce4857daa7c8044765bb4b99069f8ce1273bb8" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/trusty" revision="20d11f80a1a630cc4687e9f3a2daa477ef808fdc" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,pdk" name="device/generic/uml" revision="5fe965e13174c9eb6833f60dd398ced5b9fe19ca" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/x86" revision="7a73a1f8e9fd691cb8f45aa9de303f3c39c3837a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/generic/x86_64" revision="506952733fdebb5a2ef086b519ceebe86a95ae31" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,broadcom_pdk,generic_fs,pdk" name="device/google/atv" revision="a9bbff2a3029d702e65a25362dd24bbaf3e39d4c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,bonito" name="device/google/bonito" revision="c352f53fecf98c99c66a25c4894159fab99acba4" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="device,bonito" name="device/google/bonito-kernel" revision="40112b89bb6d461ee42a28c952b886caf3aa83a9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,bonito" name="device/google/bonito-sepolicy" revision="d6ffe0a3a8b5c4805d10c3bba8a6f9f507732e17" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,pdk" name="device/google/contexthub" revision="675f10e0e17e159392251156255583645684d6b3" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,coral" name="device/google/coral" revision="e7a2f830c511657d22d61d872fd9b3d62cf85eab" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="device,coral" name="device/google/coral-kernel" revision="3faa0ae96eb23edb82bfdc4926e525eae6574310" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,coral" name="device/google/coral-sepolicy" revision="75bd11b68ab88caba011981763b425ca93f6dc7c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,crosshatch,generic_fs" name="device/google/crosshatch" revision="087ec9a68fe9ff87852c6df79f8953d6fa23c82c" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="device,crosshatch,generic_fs" name="device/google/crosshatch-kernel" revision="4a98559b8ea2afdeaffb4f83da0fe932758bca2b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,crosshatch,generic_fs" name="device/google/crosshatch-sepolicy" revision="f482f278a07fd9c88a6e474ec878c6fba5e73c12" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,pdk" name="device/google/cuttlefish" revision="3751274ad917b783a90e754b19a16bd572c706ad" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="device,pdk" name="device/google/cuttlefish_kernel" revision="e78e91b5ab5c29bc24227deec49154718db7df14" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="device,pdk" name="device/google/cuttlefish_vmm" revision="036b31d939f2f09fb49f7229317a906cf7fe8688" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device" name="device/google/fuchsia" revision="bd27589b2b24d0975261e0b400c60b74bd18dfd4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,generic_fs,muskie" name="device/google/muskie" revision="f8e2fd922c404551025ba95976452edbcf8688bf" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,taimen" name="device/google/taimen" revision="ff36fc3eecf38da6f8e2a7dc47d72f2963745363" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="device/google/vrservices" revision="7cb17e865f59ce40ce0393dfccddbc0807698806" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,generic_fs,wahoo" name="device/google/wahoo" revision="2ece80947b49534569e2e67795f78a7d8502b85c" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="device,generic_fs,wahoo" name="device/google/wahoo-kernel" revision="c8ceca4330b08d70345fb3a715a13b8d256acde6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,generic_fs" name="device/google_car" revision="2f7ad9e79edfeeffcdb9aba5c7fca84f1c6b70b8" upstream="refs/tags/android-r-preview-2"/>
-  <project name="device/linaro/bootloader/OpenPlatformPkg" revision="044ce29a658ec8719ca1e839a4502ff835e0ccb7" upstream="refs/tags/android-r-preview-2"/>
-  <project name="device/linaro/bootloader/arm-trusted-firmware" revision="4a8974da598bde9881f85699fefd69ec776be5b4" upstream="refs/tags/android-r-preview-2"/>
-  <project name="device/linaro/bootloader/edk2" revision="6141238127ffcef8fee2af2cd01757264a95bf09" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,dragonboard,pdk" name="device/linaro/dragonboard" revision="c8a4acf7d45d080c1e618f81dc274df7918c277b" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="device,dragonboard,pdk" name="device/linaro/dragonboard-kernel" revision="613536d9b743155d0f5e075a33adb6fa32e0d5cd" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,hikey,pdk" name="device/linaro/hikey" revision="bbb5c4c78a5bf7ceeb2679a6a3a48ac4e39b122a" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="device,hikey,pdk" name="device/linaro/hikey-kernel" revision="11937728c652b4d006c6c6b6e39a927efcc8f40b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,poplar,pdk" name="device/linaro/poplar" revision="ccabcdbb5be800b96f92a664230343ff04d3f8fd" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="device,poplar,pdk" name="device/linaro/poplar-kernel" revision="d9338d916fee52afdb36115925f2ad570ec0cb19" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="device/sample" revision="9eb09f5c7858fcf1824020a9a04e73e159dd871d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="device,beagle_x15,pdk" name="device/ti/beagle-x15" path="device/ti/beagle_x15" revision="826fa06d1e8031b5a83469b095c85c6237acc4f5" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="device,beagle_x15,pdk" name="device/ti/beagle-x15-kernel" path="device/ti/beagle_x15-kernel" revision="0d99bf0b39100deba5ea9071d6472acb3bc09103" upstream="refs/tags/android-r-preview-2"/>
-  <project name="kernel/build" revision="0daf60d859d8c8b25e00c1cdd9e25df50dd95765" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="kernel/configs" revision="64e78fd9cf7fd467fb2327432ffd7f0360612b0c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="kernel/tests" revision="f34af4764ffd45ae683ae6dc753e4be4b2180490" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/art" path="art" revision="198955af0d596dd87d5398d610dd503cf818db86" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/bionic" path="bionic" revision="2a069b24df1efffde894b186a669b8b95d4f1fc2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/bootable/recovery" path="bootable/recovery" revision="4577dff5a0bb2b008a3454171898527174a71f74" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/build" path="build/make" revision="352e6a4d183759315de61db6a96c110f5e1d4381" upstream="refs/tags/android-r-preview-2">
+  <project dest-branch="master" groups="device,yukawa,pdk" name="device/amlogic/yukawa" revision="e9501ced9a98c9f8097654cb6e8f9089d6c9c5f3" upstream="master"/>
+  <project clone-depth="2" dest-branch="master" groups="device,yukawa,pdk" name="device/amlogic/yukawa-kernel" revision="9bb963db665a0da621f5e9fabcdda4d86d417014" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk" name="device/common" revision="7cc154a9e8dd6b710c9174532751c46419b532d0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/arm64" revision="a46ed223a7f153dd20fbcaeda109d426d085dbe8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/armv7-a-neon" revision="d5115091539779ab9fa4d4247c89d43cbb20dbbe" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/art" revision="c182b2e5fe356fb21c9a8b461f7f19f9a9702794" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/car" revision="db1f74ede81bff81a3d08ff7fd33173614428eac" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/common" revision="b1cb67f6e44fae5e16a1b9b2f01c9f6b0fc89ca3" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/goldfish" revision="e80696f27169eac998f46f021e5aa1a62d17b7c2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/goldfish-opengl" revision="39ef5bd8180a37f52817f06d2492154c8cd5a057" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/mini-emulator-arm64" revision="9ceba60b3bd63579855539b380f79d8997f5184e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/mini-emulator-armv7-a-neon" revision="badf9c65abad10a7d6ca27168001101da850d682" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/mini-emulator-x86" revision="540a2a226bd650f6b15339f8432effdd99916b58" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/mini-emulator-x86_64" revision="bff41129db5bdb6e72196e768db214c5097a5ee2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/opengl-transport" revision="34552eef2d644c7a566acfedbb2596379d1226e2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/qemu" revision="3e8225d3b0b4e6511c389b0e3b3bd066a2aaae1e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/trusty" revision="dda6543abcd1861abb68194bf940756dc926cbab" upstream="master"/>
+  <project dest-branch="master" groups="device,pdk" name="device/generic/uml" revision="a82bd5ee8eeaa403a1f18294f2e8f9e7f7bfa4b2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/x86" revision="3f0ca6ed17e03fb19b8a5d3d30cebe4dff50fa19" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/generic/x86_64" revision="adccc2135d2c69562be3f8cf45be6849c6cd22a8" upstream="master"/>
+  <project dest-branch="master" groups="device,broadcom_pdk,generic_fs,pdk" name="device/google/atv" revision="5142bd21c19b9e7c441ff28e489b2060e8a1c04a" upstream="master"/>
+  <project dest-branch="master" groups="device,bonito" name="device/google/bonito" revision="ef842730e9a522db8240fc37687913409ec0435e" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="device,bonito" name="device/google/bonito-kernel" revision="912f903e0ebc511daea02c858da83d1a211c0896" upstream="master"/>
+  <project dest-branch="master" groups="device,bonito" name="device/google/bonito-sepolicy" revision="a8253888c072b84c51fd38609d2961a5ee08e0c2" upstream="master"/>
+  <project dest-branch="master" groups="device,pdk" name="device/google/contexthub" revision="71b6e4d0f388b87f1b2fce740547b4c7253ff3a8" upstream="master"/>
+  <project dest-branch="master" groups="device,coral" name="device/google/coral" revision="d91cb7764b2e932190b95f2c46d282ed6fce1fea" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="device,coral" name="device/google/coral-kernel" revision="4357bed7e8c36bfaf420477ced9921d5fdc891bf" upstream="master"/>
+  <project dest-branch="master" groups="device,coral" name="device/google/coral-sepolicy" revision="667fc73a5f1fde37a13fbe70700716d8a4037a02" upstream="master"/>
+  <project dest-branch="master" groups="device,crosshatch,generic_fs" name="device/google/crosshatch" revision="ea1f5f334e561363142df6395ac6acf56b821159" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="device,crosshatch,generic_fs" name="device/google/crosshatch-kernel" revision="25cc7aacbbb2aa3319e022bbe4d22d9026e422c9" upstream="master"/>
+  <project dest-branch="master" groups="device,crosshatch,generic_fs" name="device/google/crosshatch-sepolicy" revision="f634a58dea956063e5218a2b24d207091d13be64" upstream="master"/>
+  <project dest-branch="master" groups="device,pdk" name="device/google/cuttlefish" revision="20acd5997207a3a7972771297f73e5d1c83b5f5b" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="device,pdk" name="device/google/cuttlefish_kernel" revision="f5e9dde255adaefafedefc01944118342975ca3e" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="device,pdk" name="device/google/cuttlefish_vmm" revision="888d8442516a3730c6e4bb39cb2ed92c6b31b3c6" upstream="master"/>
+  <project dest-branch="master" groups="device" name="device/google/fuchsia" revision="b9172e6cf28630eccb3ca9b534e44ad7700f3fe1" upstream="master"/>
+  <project dest-branch="master" groups="device,generic_fs,muskie" name="device/google/muskie" revision="4223d690c041237cdac19a9d773a92a5f47fd4a6" upstream="master"/>
+  <project dest-branch="master" groups="device,taimen" name="device/google/taimen" revision="18953b49172bc80ca0196d90a3d873b4ab24386a" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="device/google/vrservices" revision="7cb17e865f59ce40ce0393dfccddbc0807698806" upstream="master"/>
+  <project dest-branch="master" groups="device,generic_fs,wahoo" name="device/google/wahoo" revision="3c21096783119a10769f84de3cae1f746b6ec153" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="device,generic_fs,wahoo" name="device/google/wahoo-kernel" revision="e403d8f05a89cae01d31018bcb6e678ae96b8bf7" upstream="master"/>
+  <project dest-branch="master" groups="device,generic_fs" name="device/google_car" revision="dc1c9c4bff30fea04090b73a652de09a24424e87" upstream="master"/>
+  <project dest-branch="master" name="device/linaro/bootloader/OpenPlatformPkg" revision="c8d103d0295bcf67eca64d74b8c2ec611125240e" upstream="master"/>
+  <project dest-branch="master" name="device/linaro/bootloader/arm-trusted-firmware" revision="e48d9816cf23530327456da2a2ae87ec3eb0514b" upstream="master"/>
+  <project dest-branch="master" name="device/linaro/bootloader/edk2" revision="70739421c7bb36e06a2544a2111ea6d18961fa04" upstream="master"/>
+  <project dest-branch="master" groups="device,dragonboard,pdk" name="device/linaro/dragonboard" revision="ac5ab76ae185210f5eb94a50d9b7ae96fa81b95f" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="device,dragonboard,pdk" name="device/linaro/dragonboard-kernel" revision="6480d56127bc2240fc3bf0a58d51e32e230efe11" upstream="master"/>
+  <project dest-branch="master" groups="device,hikey,pdk" name="device/linaro/hikey" revision="167b5ad557d00d01bb1ed8f851da17af6bb3d935" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="device,hikey,pdk" name="device/linaro/hikey-kernel" revision="116a79898b28bf00390abfc7d73df24fc7905856" upstream="master"/>
+  <project dest-branch="master" groups="device,poplar,pdk" name="device/linaro/poplar" revision="181859a88ffbcd59b0441e77b485421d51c479fc" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="device,poplar,pdk" name="device/linaro/poplar-kernel" revision="d9338d916fee52afdb36115925f2ad570ec0cb19" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="device/sample" revision="0bc8d729bd0ceb91a1ce6c04e252293d078a92f7" upstream="master"/>
+  <project dest-branch="master" groups="device,beagle_x15,pdk" name="device/ti/beagle-x15" path="device/ti/beagle_x15" revision="29a8d8c65aa9222b60d3576d2d41afa34b1ebaca" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="device,beagle_x15,pdk" name="device/ti/beagle-x15-kernel" path="device/ti/beagle_x15-kernel" revision="0d99bf0b39100deba5ea9071d6472acb3bc09103" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="kernel/configs" revision="e4cee088ae80a330d3359fb7f029f2f55e07ba30" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="kernel/tests" revision="b7769d6474435c70b2be16aeb0ae4e268c840968" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/art" path="art" revision="50a454b23485ceb8fe37e102abc0e41e2857876a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/bionic" path="bionic" revision="6ba173a3f66341e06b8f90e60fd7eea25cb8da54" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/bootable/recovery" path="bootable/recovery" revision="dca48443286c0328eb9f321e188b6d244cc1cefe" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/build" path="build/make" revision="38b739a640943a41473297ddf2fd5cc6c9064666" upstream="master">
     <copyfile dest="Makefile" src="core/root.mk"/>
     <linkfile dest="build/CleanSpec.mk" src="CleanSpec.mk"/>
     <linkfile dest="build/buildspec.mk.default" src="buildspec.mk.default"/>
@@ -74,710 +73,792 @@
     <linkfile dest="build/target" src="target"/>
     <linkfile dest="build/tools" src="tools"/>
   </project>
-  <project groups="pdk,tradefed" name="platform/build/blueprint" path="build/blueprint" revision="7a56608b919834534c714702ddedc6044eb18013" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,tradefed" name="platform/build/soong" path="build/soong" revision="2812418eacd35838bb3d3a231621fab013a081c0" upstream="refs/tags/android-r-preview-2">
+  <project dest-branch="master" groups="pdk,tradefed" name="platform/build/blueprint" path="build/blueprint" revision="9b15d1a8886ba2ae81ee14e3bf31395ec35a9579" upstream="master"/>
+  <project dest-branch="master" groups="pdk,tradefed" name="platform/build/soong" path="build/soong" revision="0ec8c508a414619127b6bca3567b90674a45fa86" upstream="master">
     <linkfile dest="Android.bp" src="root.bp"/>
     <linkfile dest="bootstrap.bash" src="bootstrap.bash"/>
   </project>
-  <project groups="pdk" name="platform/compatibility/cdd" path="compatibility/cdd" revision="0c38e67bb06570c7b7928cc6945c6d275f22cf97" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="cts,pdk-cw-fs,pdk-fs" name="platform/cts" path="cts" revision="35cfedab5d90d19570f89bdf12b3d166b6ef0a8e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/dalvik" path="dalvik" revision="1537e27bdc17e87c45e6269546f45ed7fbb91d19" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="developers,pdk" name="platform/developers/build" path="developers/build" revision="6a8a6e64206de0aa11d0221815ac3706f97fff24" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="developers" name="platform/developers/demos" path="developers/demos" revision="03814c35b8ee0a1284c667556260124d97466b28" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="developers" name="platform/developers/samples/android" path="developers/samples/android" revision="9083bced6874c606043ebfb36bb1f71f67090ecc" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="developers,pdk-cw-fs,pdk-fs" name="platform/development" path="development" revision="6e9e6a6c28cdf313f69fa61bd69ac41545fc3017" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/FP16" path="external/FP16" revision="71f087c388c9db78fb8fa4d6602784877a886055" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/FXdiv" path="external/FXdiv" revision="5432d142d5994d3e5f39df551ee2c3e1f5dcebd5" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/ImageMagick" path="external/ImageMagick" revision="a390d3bdbe5eaee0da5e5d7ab561ae50fdcedff4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/OpenCSD" path="external/OpenCSD" revision="e7cc1c910ed38e1e533467577422c3dbd58821f2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/Reactive-Extensions/RxCpp" path="external/Reactive-Extensions/RxCpp" revision="68b9bbe7851c0d5cc02629e13bc263d2462644a0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/XNNPACK" path="external/XNNPACK" revision="5261c034e1187ca8a1c36b2dfbc8d0fbe9c13a6b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/aac" path="external/aac" revision="13d520b193266a610f5ca6b07b0c0f039ddb21b5" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/adeb" path="external/adeb" revision="f061a94fecd30f063b7e02f47044e10c0bfbb13e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/adhd" path="external/adhd" revision="2b1e50dc351087a832e21130087468c36c5798b7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/android-clat" path="external/android-clat" revision="97bd0e95d7ca1a87144868c34b80bd78c4616b74" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/androidplot" path="external/androidplot" revision="b999712946d5141812fa2456e652db6b818d439e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/angle" path="external/angle" revision="e1f3ec6f7382646e4792fdd119174a33246d7d39" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/ant-glob" path="external/ant-glob" revision="45461635647e5481fa67473795782ce232e44fe1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/antlr" path="external/antlr" revision="f207c52043d762d9cfbfd87986b5194c855a318a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/apache-commons-bcel" path="external/apache-commons-bcel" revision="50e755197cd5de9d584414616d6d48877c92c649" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/apache-commons-compress" path="external/apache-commons-compress" revision="5334065cacdd3d1af2688d4617918ec0460708e1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/apache-commons-math" path="external/apache-commons-math" revision="f30081520947ace21933c4f6ade062152c9b99f3" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/apache-harmony" path="external/apache-harmony" revision="f5fd2de0db5c586a1242123977e387884d868d7e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/apache-http" path="external/apache-http" revision="d176d36489b58e75bced0d5234e713abb8c5a847" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/apache-xml" path="external/apache-xml" revision="95e1a12154051ee0aa624e784b5d2f1f4b2bd9f1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vendor" name="platform/external/arm-neon-tests" path="external/arm-neon-tests" revision="bc9bbf361c8cabbd4ae0a215de5871fad527915e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/arm-optimized-routines" path="external/arm-optimized-routines" revision="0290fa0b3675e5ede78fc5c66c204c77c3299202" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/arm-trusted-firmware" path="external/arm-trusted-firmware" revision="780068d4eec8e880d55d58eb348bee2d71580e83" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/external/autotest" path="external/autotest" revision="a91c1eb339eeaab10ef08685ebb24e2a7d744a6d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/avb" path="external/avb" revision="7560b4fc5e786261351afd975a2b53ae258fcfe0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/bc" path="external/bc" revision="e48fc23376fe54014a4b2ee03f6cfddb11f48704" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/bcc" path="external/bcc" revision="0bdd6b3a226e5e50dd245b76a9413a6903a73073" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/blktrace" path="external/blktrace" revision="549b1dd7d9d689543ab8c86ff6adc4313f02b8b3" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/boringssl" path="external/boringssl" revision="0dcd4e8262f521f08a8302051ad6c81489f05754" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/bouncycastle" path="external/bouncycastle" revision="1854476568c6f2feb9eef50343b7e2a18e072e35" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/brotli" path="external/brotli" revision="b4fe2652341b739dfab70d093525878090531831" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/bsdiff" path="external/bsdiff" revision="6037a9bba21af40c7850d48e7788b25ebcc37308" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/bzip2" path="external/bzip2" revision="ef2142980b09fa899806433fff413c67a81b94f6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/caliper" path="external/caliper" revision="89cb92050512ed307a9896a07444e7c12cf0a3ee" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/capstone" path="external/capstone" revision="f1f1cbc054db7021d4167a96b55783e087e1b7b4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/catch2" path="external/catch2" revision="a8f1a3dea29dbd45c1b7f3422c0aa29d5f06dbda" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/cblas" path="external/cblas" revision="61ee00692011385347a5dd1ad872556899a5cf7a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/cbor-java" path="external/cbor-java" revision="432de00e4b018966cf0aff3dd204eb4a97fd0de6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/chromium-libpac" path="external/chromium-libpac" revision="ae88e3df0e2d2779c1b8c7ff9a17ef34c0bf23e6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/chromium-trace" path="external/chromium-trace" revision="26d0b602b1501917a84e34ad331e22a4a27fe2fd" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/external/chromium-webview" path="external/chromium-webview" revision="a04f8d03177d2667299915b125bdce93422c9e2b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/clang" path="external/clang" revision="f482f355345a3e42e41be48861075aeef690a78d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/cldr" path="external/cldr" revision="bbe3f1a6ffdef81c1fe1d392529abcc7cbbd94b8" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/cn-cbor" path="external/cn-cbor" revision="d581c0ae70655e4c18ff00182867c81600f408a8" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/compiler-rt" path="external/compiler-rt" revision="54b43ff2d8e92841cb46f2162f4fa1489719ff27" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/conscrypt" path="external/conscrypt" revision="c08e870957cba9cda3c6e451fbc7fa76954b12c4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/cpu_features" path="external/cpu_features" revision="813aadc6c7ece543af4b8a7207e4e4b403f2d492" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/cpuinfo" path="external/cpuinfo" revision="fbbf17e168c56a99512f9db5241b80860dfcdb2c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/crcalc" path="external/crcalc" revision="405d67056bf4a5f9e46761a3909f0cdf866f5b6b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/cros/system_api" path="external/cros/system_api" revision="2e466f96bc18eae60093d55ae8eb800d61a7ac4e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/crosvm" path="external/crosvm" revision="2508eb3397a41100a6408f2fa69258c3508ec877" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/curl" path="external/curl" revision="9126f3ec9d6c9df6e7a64a72956b1603a0738a47" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/dagger2" path="external/dagger2" revision="3809f3dd127716a59f14536b19fe5cab0e0a445e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/external/deqp" path="external/deqp" revision="393a348317e8e94e06a4f17ed130d6c2d30839b3" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/external/deqp-deps/SPIRV-Headers" path="external/deqp-deps/SPIRV-Headers" revision="33de1aef825029c0cf7927a72df63ebe79745c6f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/external/deqp-deps/SPIRV-Tools" path="external/deqp-deps/SPIRV-Tools" revision="2e6244127648ea760172bf07ecf687a59ee7bd17" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/external/deqp-deps/glslang" path="external/deqp-deps/glslang" revision="91b452070b219d80a82d98deb46c1514dc67f4b8" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/desugar" path="external/desugar" revision="3041d69a3395243035260e72e56b43835c70a6cd" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/dexmaker" path="external/dexmaker" revision="d2a09b882a9db481a48d22887aa45af55ac1953d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/dlmalloc" path="external/dlmalloc" revision="3a9d0af27a9f8fe533931a9e7ca843fd8e5b54f1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/dng_sdk" path="external/dng_sdk" revision="bf24c2ce5160fc7a04d44dac8cd564c2d9ea62e5" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/dnsmasq" path="external/dnsmasq" revision="bfce4be5569c60687509a40c4f2304f2962182cb" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/doclava" path="external/doclava" revision="7102169baa03cabde1b2615f9300d64a0b9b1da6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/dokka" path="external/dokka" revision="ac5ec5dde25e5c9558b3fed5741cc9f097f6461a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="drm_hwcomposer,pdk-fs" name="platform/external/drm_hwcomposer" path="external/drm_hwcomposer" revision="dedb1edb343f7c3ca032f179d3020bb01c0dc070" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/drrickorang" path="external/drrickorang" revision="0d71c83b891b1eb88e25bb945244cb00a85b2b6e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/dtc" path="external/dtc" revision="c7db36e4961918d5f0715984f6d28484e635ece3" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/dynamic_depth" path="external/dynamic_depth" revision="eeaf88354ff22ff67f82a9cdc0fda4132c8da3a8" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/e2fsprogs" path="external/e2fsprogs" revision="2d8ca6d6ec8a3926cc490879aa46d6dd0e8f110f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/easymock" path="external/easymock" revision="afd503b419c6c25d6804e137f2642217f10ee980" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/eigen" path="external/eigen" revision="18d7fe6ad434c258583c33f0ac7d1c7837cd704b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/elfutils" path="external/elfutils" revision="14c6e51ec2f456affb25aebb7b844ed6e361fe61" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/emma" path="external/emma" revision="c2aa4d22fc24295761a9c588836531a7b3d3d519" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/error_prone" path="external/error_prone" revision="b4f4d485f957a0508434dfc60dd0ccf6df2c9c1e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/ethtool" path="external/ethtool" revision="861c56b1422927e74292bb6dab30690dfed53db5" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/expat" path="external/expat" revision="9060df1c8101801e0bebcddc13816ae435686019" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/f2fs-tools" path="external/f2fs-tools" revision="42383167940cb32ceb475817f6413d4538db561d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/fastrpc" path="external/fastrpc" revision="e517e6dfae809fc753bf93bb8fbe38b1c33b38d7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/fdlibm" path="external/fdlibm" revision="3eea558350ee7509b210f3bfa91bb9f318121e31" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/fec" path="external/fec" revision="7049b92008752b4f939425ad91bf2aea86133216" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/flac" path="external/flac" revision="3dccd10bfac7e896533f5bd3405b789d8bd700b9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/flatbuffers" path="external/flatbuffers" revision="420a0a2f2f9474aa5aaa0a877985401539edf1c9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/fmtlib" path="external/fmtlib" revision="a9d1870c85c52a9f64addd7a8115bc616c439525" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/fonttools" path="external/fonttools" revision="60158b797575946005c3ab704ec20f675500ef8e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/freetype" path="external/freetype" revision="0af6612e1b95d523f6120fa86af50a5c0c8297d4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/fsck_msdos" path="external/fsck_msdos" revision="406ddd07abea91fa8d29467862187123fc8e09e9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/fsverity-utils" path="external/fsverity-utils" revision="885c1e4382273e11a62368777c0ddb64dcdb4edf" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/gemmlowp" path="external/gemmlowp" revision="d2a4169edd6e76cc2d3c29c96a720d79c21b4ee7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/gflags" path="external/gflags" revision="f1557386763cb21d266f6ef90f58c074886b54f4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,qcom_msm8x26" name="platform/external/giflib" path="external/giflib" revision="341c85ed68d932afcdd4481d361d9c1e65b453e2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/glide" path="external/glide" revision="bd0082947a4c7b0058049c155d3c2517d462cc81" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/golang-protobuf" path="external/golang-protobuf" revision="e183852c920ef6c36d9fd89a8c4233e98241c776" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/google-benchmark" path="external/google-benchmark" revision="1eec37d671d2138824c8ca450985eebae7cc0f87" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/external/google-breakpad" path="external/google-breakpad" revision="05728773737deb58a10cdbe29750152c13e400bf" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/google-fonts/arbutus-slab" path="external/google-fonts/arbutus-slab" revision="6a62a3a7283256e86faac4b4830e224f64946838" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/google-fonts/arvo" path="external/google-fonts/arvo" revision="bca8c9b2d370ba24ac0280d674b063f647a038bd" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/google-fonts/carrois-gothic-sc" path="external/google-fonts/carrois-gothic-sc" revision="8c54a6b341ce312cb1ef44add56b5fb0183aaf69" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/google-fonts/coming-soon" path="external/google-fonts/coming-soon" revision="477b0ee78ac4bbdf6de0032e903eb4ade0c1de05" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/google-fonts/cutive-mono" path="external/google-fonts/cutive-mono" revision="9178eb37f91560f7f3135489e533101db23d0fff" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/google-fonts/dancing-script" path="external/google-fonts/dancing-script" revision="c2ee745ad605df8e37a181bce60350113228d091" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/google-fonts/lato" path="external/google-fonts/lato" revision="139c627f77933688eeda9c16a575c1421af08808" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/google-fonts/rubik" path="external/google-fonts/rubik" revision="4a650db6c054b9b328eb1364d217a82296143d25" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/google-fonts/source-sans-pro" path="external/google-fonts/source-sans-pro" revision="ea1024073315464fc4ce2c5c0fccaf2ace8e18ac" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/google-fonts/zilla-slab" path="external/google-fonts/zilla-slab" revision="11c07b19edec7867860296950b14cf7b687240bd" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/google-fruit" path="external/google-fruit" revision="83d0f1fed7aa7062f97731cfeb2f17ebbc2c1649" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/google-styleguide" path="external/google-styleguide" revision="5a3fcff118a07214cec8906e5a3e77574a1dee49" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/googletest" path="external/googletest" revision="739d078a704963f0d19345bc6a3491b8b8232b9c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/gptfdisk" path="external/gptfdisk" revision="b8884909ce1c3540c51772b531f8a75e168040ab" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,tradefed" name="platform/external/grpc-grpc" path="external/grpc-grpc" revision="0f6c0d1e46e36f97f21f844a6ec95f1310b6fc61" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,tradefed" name="platform/external/grpc-grpc-java" path="external/grpc-grpc-java" revision="9b4f1a6db99b7cb7d46320e25e32317853b500dc" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/guava" path="external/guava" revision="e4500bcb91dc065d442a3b7eeac47447d6507bc4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/guice" path="external/guice" revision="a0e72c4fb3f95862a7902e7d9e85920eefe67bf9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/gwp_asan" path="external/gwp_asan" revision="a99a3072ac2459c7885664b99899a7e91d44ac22" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/hamcrest" path="external/hamcrest" revision="03971a91bca428d436501f1da5ab91b02a81a216" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,qcom_msm8x26" name="platform/external/harfbuzz_ng" path="external/harfbuzz_ng" revision="56ce75a95141c3ac7055d744ffd9b93e35367b9f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/honggfuzz" path="external/honggfuzz" revision="4da5ca807ec753ef0dba496f8db65738084c42bb" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/hyphenation-patterns" path="external/hyphenation-patterns" revision="0e83a677bc1e5dda389f1750edfe69a6f34e42e5" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/icu" path="external/icu" revision="5b6839845fd1126344bc70fc3d71d6f033408c15" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/igt-gpu-tools" path="external/igt-gpu-tools" revision="423d2e3ba48d8c947b8282c4e0a5a6c5ffc38275" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/image_io" path="external/image_io" revision="135f7c04ae98ce694efcfc6d9a0d2bc38f4c3653" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/ims" path="external/ims" revision="1abbd5e32807a8dc91e469c61c36a4fc9764db7d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/iperf3" path="external/iperf3" revision="14813ef4a3d9e4cfb66be9d6b33799f81a0656c1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/iproute2" path="external/iproute2" revision="fa70aab53138a1dcc4ab038cfd6a186b68286d0c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/ipsec-tools" path="external/ipsec-tools" revision="21841d18260f3247c0189c5157169c862632f0ec" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/iptables" path="external/iptables" revision="55b98937a2de723b7a0e5f9be0c2e6ab15acb204" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/iputils" path="external/iputils" revision="579e2f654ccf730c840940bfa3289ae8460c83b1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/iw" path="external/iw" revision="e55a47ac749af802d894a1a715fa681af6c787e4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/jacoco" path="external/jacoco" revision="d6e4eb2f3e17ce62a2ae410aece3e8c2636ed64e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/jarjar" path="external/jarjar" revision="d6f27420440536c7650e47ddde630f5f93ca27fc" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/javaparser" path="external/javaparser" revision="49d8afb7998edffb82f8ba4388f607ec2c43136e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/javapoet" path="external/javapoet" revision="c679ce9933a802fc637e8f2d69c0ea25cf376f88" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/javasqlite" path="external/javasqlite" revision="c093f72b18ff45bd66c8884ef667399aa5891b9f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/jcommander" path="external/jcommander" revision="c4d97985b3787276d6b391510250246c9ca94541" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/jdiff" path="external/jdiff" revision="53fe6946d8aa7bcc259c2757ab0309f7762a9355" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/jemalloc" path="external/jemalloc" revision="e3ff6769f8262841c98245e21b96dc67536759dc" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/jemalloc_new" path="external/jemalloc_new" revision="94c497862b75d61a5ce4a2156d6ac417f9c51a8c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/jimfs" path="external/jimfs" revision="cef92d673c81daab4b0dad931591947c86e0dc8a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,tradefed,pdk-fs" name="platform/external/jline" path="external/jline" revision="478835d3c4603b43c28feb80912ff33f2c6811a6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/jsilver" path="external/jsilver" revision="241cd1b197ee8e520aa6b04f277c3b29a2ff0fe4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/jsmn" path="external/jsmn" revision="baeaf082cc45afa06562313a2f17b0e7c91d4629" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/jsoncpp" path="external/jsoncpp" revision="870657e4a28fc426a158254ed49c5f4cbdc690c0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/jsr305" path="external/jsr305" revision="7b129a25432c1a1a3d1919499d8e2f583c753b8d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/jsr330" path="external/jsr330" revision="4221d13d2c4079d3299c1d3265ed93564b84c78b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/junit" path="external/junit" revision="ed077a7e067d0b8508cf6b7502fa143f841be579" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/junit-params" path="external/junit-params" revision="ed4bc1eedea9e248f690ed682e4bd1b65863268d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/kernel-headers" path="external/kernel-headers" revision="655b1ac002f5892b2ef370ceb9e0faeed9bdf7ba" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/kmod" path="external/kmod" revision="21724ce2aa1bc3f69809f997b2658ed83476ac01" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/kotlinc" path="external/kotlinc" revision="869635edd36d0ee5860db3c6c781cbd3126922aa" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/kotlinx.coroutines" path="external/kotlinx.coroutines" revision="f5a650cd76b6b4c184715b80e7956e7ba7422583" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/ksoap2" path="external/ksoap2" revision="2e4343c72a45a2a5933288c71e968d6ab6bf6624" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libaom" path="external/libaom" revision="33cd4437e53a12210ec97a2c7f23f80b8923dbbe" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libavc" path="external/libavc" revision="748aa1e4597a2b0e4c20d30867879780648e0f6a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libbackup" path="external/libbackup" revision="be853756f8a215492b11ae545206d12b64d3a03c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libbrillo" path="external/libbrillo" revision="d4a88f4821ed402c6515d3cf5442a90c95c529e6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libcap" path="external/libcap" revision="2db20a0a41de7cf42cc78f4c8a9b0ef2ed47f6b7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libcap-ng" path="external/libcap-ng" revision="e17ed85e2a3b4691efd6975a02f8e56277cc93af" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libchrome" path="external/libchrome" revision="8cb08133c577a7f6b796fa3eae5e5950b4e59b3f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/external/libcups" path="external/libcups" revision="1bd22a1b5e939ab51a234c3f2e5a178a1522ab57" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libcxx" path="external/libcxx" revision="2d6d9ab848d7e0490dfdea52e5ec15beca9a74d8" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libcxxabi" path="external/libcxxabi" revision="9ab5390e62c8a2787bf6f9ad5be927e133c151bb" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libdaemon" path="external/libdaemon" revision="433dd14cb58a66737e158ad1331c02162a80f43f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libdivsufsort" path="external/libdivsufsort" revision="abb3a16c4986c5f7dda62580c4f53c1930d4d1b9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libdrm" path="external/libdrm" revision="e1e5fd5572088342ab7ba66694411b08a3ad7c6e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libepoxy" path="external/libepoxy" revision="ff18e5a9bed2e8ba1f9c6ea4f9dfaeb080959998" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libese" path="external/libese" revision="f5c8a1639e2ffa84327c8026342462a858e64f02" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libevent" path="external/libevent" revision="4b01342e43b8b4c74f7aa58a9ed3bede66a6e056" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libexif" path="external/libexif" revision="24eb5c6758b645317a6fa85cf6594556332218a5" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libffi" path="external/libffi" revision="ee0c7e65609748000dcf323c8cddb6a2b9b7d5fe" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libfuse" path="external/libfuse" revision="c92466fe1d1612825e16c604bff91408d015e0dd" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libgav1" path="external/libgav1" revision="7f6a1063bebabcc9fad0d191a6042034573f7f58" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libgsm" path="external/libgsm" revision="1321c574befc82fd21a8ac38d36e1da1f3ffb336" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libhevc" path="external/libhevc" revision="579f4d362b11772e33e29e19eef9b5bda322ec34" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libjpeg-turbo" path="external/libjpeg-turbo" revision="d45e9de55f69a08a9c39733e3c23206770efe669" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libkmsxx" path="external/libkmsxx" revision="c09def76c347eda08c3405fe5a4f238f2438aaa9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libldac" path="external/libldac" revision="93195ee38bd08ea8d9f87cbfa550635923f213de" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libmpeg2" path="external/libmpeg2" revision="a1ae85b3092a877d08954ec7949e0c0cf085cb02" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libnetfilter_conntrack" path="external/libnetfilter_conntrack" revision="a44a0c25fa5eb2575df464bd4d9e3e5c7da9ccf6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libnfnetlink" path="external/libnfnetlink" revision="ac537e1d43625a99d8b266a362f4735762a42b66" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libnl" path="external/libnl" revision="173d924eceaa33fe7f731dfc692dd1e1cace80f3" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libogg" path="external/libogg" revision="2f56a5cccbfdfb3b443123d57a78a00a25ebe3de" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libopus" path="external/libopus" revision="6ce1e4a7b5348fab143184357031c70bec8f337b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libpcap" path="external/libpcap" revision="83f31e5d5e7c2268becdf04f3f17a51956a2790c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libphonenumber" path="external/libphonenumber" revision="41e3b486d597b3519058729b54dc760b585ca5fa" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libpng" path="external/libpng" revision="7c18265dd9b2969e957a0029cf3a86736e2a8b9a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libprotobuf-mutator" path="external/libprotobuf-mutator" revision="42dad0bfc87bd87ceb8b88fbfa11f9491d18cf31" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libsrtp2" path="external/libsrtp2" revision="1904160d088401788daf6b5d1130819f087ff946" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libtextclassifier" path="external/libtextclassifier" revision="57002254c3c689c50f9691ff3a99c5943c50063a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libunwind" path="external/libunwind" revision="595f4a2c04419f3c004c39671a551868165bc1f5" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libunwind_llvm" path="external/libunwind_llvm" revision="98d90944b3ef000dd6716c57a480f52a6726749d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libusb" path="external/libusb" revision="e486a629e38d567d271f38f50deeccdac6b7fc62" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libutf" path="external/libutf" revision="385496803c2652ad5228e54c262052abc6420482" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libvpx" path="external/libvpx" revision="8d476e951e7ebf91bbb98f759763d3c264cd963f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libvterm" path="external/libvterm" revision="2caab416f758b648c4034e9f22cb7b76c37203f0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libxaac" path="external/libxaac" revision="a4398eccb889bef19a607fd8d8c8c91a3deeede1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/libxkbcommon" path="external/libxkbcommon" revision="c733e88d8ebad5105544b3e269fa29775c1b1103" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,libxml2" name="platform/external/libxml2" path="external/libxml2" revision="72ac6cf5b8ed69b2c05dcf5ba970b3fcdd4c1c4a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,libyuv" name="platform/external/libyuv" path="external/libyuv" revision="89330bce50a357e32dd12e28363cd7dc64f1924c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/external/linux-kselftest" path="external/linux-kselftest" revision="db3a9fa235b35199b31b6e056c5e853e017554fc" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/llvm" path="external/llvm" revision="c10415f4fb599cbb121fdd4919014b4801e9e0cc" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/lmfit" path="external/lmfit" revision="3d36ea54c2216475d5e21da31ee0db4af24ebed1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/external/ltp" path="external/ltp" revision="d4f7339199c6a97146c786542f8372f7425e159f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/lua" path="external/lua" revision="14d22e8befb9bf4c4f6eef84b23f7028d15af9e3" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/lz4" path="external/lz4" revision="478a1a22f0e71a162c3699265fa44be43914e4dd" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/lzma" path="external/lzma" revision="cb0b0185115eae47250b491cff5f8ad0dad75606" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/markdown" path="external/markdown" revision="41a03193095447f4ff110690171574ed8b721292" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/mdnsresponder" path="external/mdnsresponder" revision="2d7b4e7379ce5b27456539a9b720852b9bc2149f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/external/mesa3d" path="external/mesa3d" revision="71a3c6e1a0cdd6be31c003bff550d664750b2ed6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/mime-support" path="external/mime-support" revision="ff89528c1b7192f464f39643dfd0cb84c5f4dcfe" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/minigbm" path="external/minigbm" revision="51990ce15443fed0a9ca3136916fd80a5b1f2ea0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/minijail" path="external/minijail" revision="84ffabcf488bf0935f00930a9a23bbce1f34d79f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/mksh" path="external/mksh" revision="63d55d82e77906d4a8a3901938b17b261876765f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/mockftpserver" path="external/mockftpserver" revision="1f487440520b7264f9134079441bce0adcf05af0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/mockito" path="external/mockito" revision="9a71c9cc1945cc60ad886c253257f0f1ede5379c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/mockwebserver" path="external/mockwebserver" revision="deaedfdb8ca26ec22231727e076ae2cf4e4e944a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/modp_b64" path="external/modp_b64" revision="d7b108300ecb0b669d6be1653e77adef2f7cca4a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/mp4parser" path="external/mp4parser" revision="91052b1c78aaf57b0db28a0b1e4f7b91e5d8fda6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/ms-tpm-20-ref" path="external/ms-tpm-20-ref" revision="98e0d43362b19f5a9b3598b693c5d91f1e8acecf" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/mtpd" path="external/mtpd" revision="106b0e350ac2912c3ca0dae9896eddae5d0cd1c0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/nanohttpd" path="external/nanohttpd" revision="9e6fdd3de9cf7ebc3a16c614147a28e63e62485e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/nanopb-c" path="external/nanopb-c" revision="07c127e075f66a33ffc6dedfa490a2fd1b9d693c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/naver-fonts" path="external/naver-fonts" revision="37ba854a88b1721057585111c7a1d7e5fd02b556" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/neon_2_sse" path="external/neon_2_sse" revision="7dff91633c4faf01e78427a0d1626853d96289ab" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/neven" path="external/neven" revision="07b172807c1a4607997d1f72c62bbe9caa025aa2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/newfs_msdos" path="external/newfs_msdos" revision="6cbd5a634d77914c907cdc00b5bb9fdb1fbc438d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/nfacct" path="external/nfacct" revision="da41b2d4c2089f96a7fcb81a8b686046e635da7d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/nist-pkits" path="external/nist-pkits" revision="de4e73ff904513e82c5533e09bcadec488616ba9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/nist-sip" path="external/nist-sip" revision="d0a7687d3a0fff06ea6c1fe7d11cbff9864beb99" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pixel" name="platform/external/nos/host/generic" path="external/nos/host/generic" revision="584eecb1f669a76ab24b280c103e972096d2df00" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/noto-fonts" path="external/noto-fonts" revision="486f71253fd8dce3156f36f0007c81b4315405a3" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/oauth" path="external/oauth" revision="2f79a0fdace446afd17a6b539b391be92214fd47" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/objenesis" path="external/objenesis" revision="1595b2de78c5290bdcb425c293e0c6a08c9f060a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/oj-libjdwp" path="external/oj-libjdwp" revision="9c0694cb148807337b3bf9b26d5644e3e3190ad7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/okhttp" path="external/okhttp" revision="7ade36b9f28d6a35357449ffd4d4803081b82f62" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/one-true-awk" path="external/one-true-awk" revision="37da4decf06bbff96e8cea26300ff5314d6b3daa" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,tradefed" name="platform/external/opencensus-java" path="external/opencensus-java" revision="610a17c2139830070c0dc56540d35aeb64222ec7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/oss-fuzz" path="external/oss-fuzz" revision="0d80d30b2b23d5129a19f174ce94541b12677d37" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/owasp/sanitizer" path="external/owasp/sanitizer" revision="062866cd9bb19a038a7365a7bf7f4cdee2e3f441" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/parameter-framework" path="external/parameter-framework" revision="a15aee3613733ea43d1afe2b25c0ee6b37ebe8b4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/pcre" path="external/pcre" revision="5a8c54003e6070401460e269350bb355804eb45f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/pdfium" path="external/pdfium" revision="e17209343c448a816dc59579ed416a95136352b0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/perfetto" path="external/perfetto" revision="89b43b4ed35b63e22aac87ed108abeaa7f0c0891" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/piex" path="external/piex" revision="b693afb4579d0744585f1ff9d6eaa20e4044a6b0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/ply" path="external/ply" revision="0dc471014dfe6d1565c57403fefa47729c18e1e7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/ppp" path="external/ppp" revision="f39a656871ed774e290150e3d007d418858bdb27" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/proguard" path="external/proguard" revision="4049237427905fe053ec217c082ce222f9edc814" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/protobuf" path="external/protobuf" revision="247616f2154f29f8cd1894dec24452fafa9563fd" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/psimd" path="external/psimd" revision="72429076ab18d2249e22f80991a50dc0be8fb393" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/pthreadpool" path="external/pthreadpool" revision="ae9ca1488eebd5c06bb4d056e18fdc7025f7b26b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/puffin" path="external/puffin" revision="ce7d7051ea6cb48ad014f8f091a9d8eb795678cb" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/python/apitools" path="external/python/apitools" revision="e027b2ceb01acc71072baf7b8c24b0a8cb59eabe" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/python/asn1crypto" path="external/python/asn1crypto" revision="67a55d70b5793782d570553f94212d3d0e8b9fbc" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/python/cffi" path="external/python/cffi" revision="21570b8f71e3cf7f1597b30e87dc1e58196306c5" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/python/cpython2" path="external/python/cpython2" revision="edba983036eab94d6c8eb211198f5ae5a874b7b0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/python/cpython3" path="external/python/cpython3" revision="37ac67f501dc80fd96f51a6bf98d4ef32e2e580a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/python/cryptography" path="external/python/cryptography" revision="e892a62257eb19888144f842fd03eb70ccabe8bb" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/python/dateutil" path="external/python/dateutil" revision="40335301327f754f205eee4b7b417e21f9c3e118" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/external/python/enum34" path="external/python/enum34" revision="4b4e6198d4de0c94526c820e6a25d5d46d83237e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/python/funcsigs" path="external/python/funcsigs" revision="29a2df658e8890145edb72ebf82c30155d66c701" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/external/python/futures" path="external/python/futures" revision="89a8fe6ab75db54c27ab073acda54b57b3a1187b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/external/python/google-api-python-client" path="external/python/google-api-python-client" revision="112498337e4b2cb1f5fbce7341c39d3d4fa772ca" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/external/python/httplib2" path="external/python/httplib2" revision="661c9493f76e2dc46a026db304fff0c349877a5c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/python/ipaddress" path="external/python/ipaddress" revision="ec5fa84d0c78d8038e26c77f334b9a4aecb35d9a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/python/mock" path="external/python/mock" revision="3381fde74146dd5d07917b7ec8e74ecd1945d193" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/external/python/oauth2client" path="external/python/oauth2client" revision="447d07451b2e5cfd0f165c8f49f28ba9da66fcdc" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/external/python/pyasn1" path="external/python/pyasn1" revision="364883d819d55d173639d3747a204108c3582159" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/external/python/pyasn1-modules" path="external/python/pyasn1-modules" revision="eeb43cc103f86efb51a0be45c93198e8364511c7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/python/pybind11" path="external/python/pybind11" revision="9946bf3a509dc8c10255c1a64718624ecc537b0d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/python/pycparser" path="external/python/pycparser" revision="2d9dbc9f306462644b502c8e1f4d564659bf0a9c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/python/pyfakefs" path="external/python/pyfakefs" revision="76ea9f5c8da24f4b2ffba9147af1ea5158252c2e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/python/pyopenssl" path="external/python/pyopenssl" revision="437d7a3e9369b32c669c8451e9410a0278d2140c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/external/python/rsa" path="external/python/rsa" revision="cc30821f4245fcc2a8168e8b49cb066c651a13fa" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/external/python/setuptools" path="external/python/setuptools" revision="513ec3d6bb6f7786d02caf51720497a118b8f4be" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/external/python/six" path="external/python/six" revision="9cf9865a7e2cbb67f26c9574d72be7575e334b2d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/external/python/uritemplates" path="external/python/uritemplates" revision="8bbe7cd57d5ac0d5d64cfd25c729dc190a407ee9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/rappor" path="external/rappor" revision="24abc025df68928ce97749b18521c4dbfa3faaf7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/replicaisland" path="external/replicaisland" revision="9d7ae289b1769756044a0060f06b5264f992f4e6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/rmi4utils" path="external/rmi4utils" revision="eab13882ca581b5ef579eeeca311957f5fa2eada" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/external/robolectric-shadows" path="external/robolectric-shadows" revision="b035cad6ac8808d5ab350e7530e568ecc6313a6f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/roboto-fonts" path="external/roboto-fonts" revision="c83d9308a20aac7f872710c12a56d2a20cc9ddc7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/rootdev" path="external/rootdev" revision="2b38487945c95283b77047a5470aa750af02f847" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/rust/crates/bitflags" path="external/rust/crates/bitflags" revision="efaa09589f5e508e9dd325dfd83b66f7d80304bd" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/rust/crates/byteorder" path="external/rust/crates/byteorder" revision="38c3e288c6aae8e4fa4682a40f85bcf97eaa8f8e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/rust/crates/libc" path="external/rust/crates/libc" revision="fe4baf3e89866923d56b00b83f8857859bbe99dc" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/rust/crates/proc-macro2" path="external/rust/crates/proc-macro2" revision="d3e41e5eb0f2661531b2bf1ef7f6fc4f912f1417" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/rust/crates/quote" path="external/rust/crates/quote" revision="e174d73a7f7c80b98a22bfb2c4c6af4bed77ec86" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/rust/crates/remain" path="external/rust/crates/remain" revision="3095d1536defaeecd3bda0e10483589a2ebc1428" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/rust/crates/syn" path="external/rust/crates/syn" revision="63ebae0e99c74e1c9170a005b561f0994bb0a906" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/rust/crates/unicode-xid" path="external/rust/crates/unicode-xid" revision="a665ab8f120fc5449b2772d062afb77db3bed704" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/external/scapy" path="external/scapy" revision="2c6d26c6fc374a6b26b012ff4523a24e903d8329" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/scrypt" path="external/scrypt" revision="d6114db148b1ededd120de0cf2d1fc73ba1611ac" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/scudo" path="external/scudo" revision="6a8384a4f5362728cd520107719b182188dfa098" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/seccomp-tests" path="external/seccomp-tests" revision="f109fb9e5705801c4ab8400df9cc9d68d8132022" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/selinux" path="external/selinux" revision="8cd947563158ed698957654e6370a38ed90da825" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/setupcompat" path="external/setupcompat" revision="17dbf182a83d7fcd6c6802ea17138fead2d1b7de" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/setupdesign" path="external/setupdesign" revision="688e6f06f084d0d92e989b7dfad68c24aeef625f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,qcom_msm8x26" name="platform/external/sfntly" path="external/sfntly" revision="bc071c31d8c1c6b263e323fa777e556e672b25c5" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/shaderc/spirv-headers" path="external/shaderc/spirv-headers" revision="bf179e4aa294d6abaf62296f233638101fd159e1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/shflags" path="external/shflags" revision="6d6812d19da2747fdbee25421af1bd3583d75bf0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,qcom_msm8x26" name="platform/external/skia" path="external/skia" revision="d5e0cd82dc9250515e5910677c26b48a9111604d" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="cts" name="platform/external/skqp" path="external/skqp" revision="2ec7447d4401ecd7dd039568a581205543415939" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/sl4a" path="external/sl4a" revision="a89b5fd86a85f6b8143a75b8d26664d5bd90a2f2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/slf4j" path="external/slf4j" revision="4cd3f35de15e9270f3d5822c3f04a7c2b02189ea" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/smali" path="external/smali" revision="b45eb8f09a2f77cb8a522b04b481d69304c55117" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/snakeyaml" path="external/snakeyaml" revision="5df2ff5ed7c5eebfaff21a8299019e21f648b0f6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/sonic" path="external/sonic" revision="043398f5c456fc78cd8f5f2057e3a2e767eebfca" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/sonivox" path="external/sonivox" revision="eface7c316660a746092378f78f555a7b4e5cce8" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/speex" path="external/speex" revision="9284f2c6bc7eb98db40ee32bb78c682943bd280b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/sqlite" path="external/sqlite" revision="5df6d01fec036b0e6954b4e0e79adbea982a3020" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/squashfs-tools" path="external/squashfs-tools" revision="26929f59a759b06cb01c539ba45630958a8e3a76" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/strace" path="external/strace" revision="92f5c658da5d0044b11d859490128811be5a69e2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/stressapptest" path="external/stressapptest" revision="d621bdcd9a15346a0c9a7234deebb82972925792" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/external/subsampling-scale-image-view" path="external/subsampling-scale-image-view" revision="5fb46aa47bd8d0ca763b7f17033a6f842e57d4f9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/swiftshader" path="external/swiftshader" revision="aff33406dc766eb794ff606931bb17203f389701" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/tagsoup" path="external/tagsoup" revision="80c9aa0ff8916d26f163e7bad20b42616e42ffb4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/tcpdump" path="external/tcpdump" revision="f50b8b00f4d40eaaeb7e0e3a398d441d27e63d54" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/tensorflow" path="external/tensorflow" revision="ec63214f098a2bfc87b628219ad0718750d4e930" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/testng" path="external/testng" revision="74aac3e648e789b5f462bd42debc34a16507dbad" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/tinyalsa" path="external/tinyalsa" revision="7a9faa352dcee96bf2617d6dfa72ac4d5b550a7e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/tinycompress" path="external/tinycompress" revision="0d22775e991f172e0215ec098812f9664ea99eae" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/tinyxml" path="external/tinyxml" revision="354bbb9275d67a3dde9f1b6aa0464b60e53585c9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/tinyxml2" path="external/tinyxml2" revision="2b0e573d9f7b2148ef6ca85ad629cd1c2f406b87" upstream="refs/tags/android-r-preview-2"/>
-  <project name="platform/external/toolchain-utils" path="external/toolchain-utils" revision="c6166ac212048a5a83f5e450377088648c27e048" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/toybox" path="external/toybox" revision="320b7269bab7bbe7f88e80dd1aff6cecde25da63" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/tpm2-tss" path="external/tpm2-tss" revision="1365217e0129aa876e3d55789a3776183d478fbf" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/tremolo" path="external/tremolo" revision="4796b31d95d7f3f9bc5ca611aaa7efc80b0224a2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/turbine" path="external/turbine" revision="05598c0046e176a2057b3eed7ef9186a3cacd360" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/u-boot" path="external/u-boot" revision="685955f3d2c70ee6ba7e4415a458d669fb9c28a1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/ukey2" path="external/ukey2" revision="cd9c844bd676ff9ff69a74bc49e157149a7f0918" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/unicode" path="external/unicode" revision="76611169d15eb196b4adcdbac2c795a9cfaf781f" upstream="refs/tags/android-r-preview-2"/>
-  <project name="platform/external/universal-tween-engine" path="external/universal-tween-engine" revision="507b8885296104d7efe1bc16efbc07e2d22ef66d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/v4l2_codec2" path="external/v4l2_codec2" revision="b260c87aeab18435d2f63b52f7e12d5c04f13283" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/v8" path="external/v8" revision="850df249e17efd8857463449eab5d52152b23c99" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vboot,pdk-fs" name="platform/external/vboot_reference" path="external/vboot_reference" revision="df6d6b6e5280520b096fb1f565b758948bc872ee" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/virglrenderer" path="external/virglrenderer" revision="55e81ab18eda2cf4724bab631975346bf5e87585" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/vixl" path="external/vixl" revision="24c0a1eebd3409e415c4dccca1216b41f819aad4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/vogar" path="external/vogar" revision="9a9a89642d428d43b13ece05e349aa0d54d11a1e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/volley" path="external/volley" revision="ab93ab6a714a5529afe10502f8065a0eb7fa3f87" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/vulkan-headers" path="external/vulkan-headers" revision="4706e793a3e24e211244dc48a5049cb8f767c3e9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/vulkan-validation-layers" path="external/vulkan-validation-layers" revision="7a051caedfe620bf590741053be4913cd8508751" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/walt" path="external/walt" revision="53c47a96bc0d6129d3dad8219a9a1a793c3da963" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/wayland" path="external/wayland" revision="fe6a8acb93c9f6c345a0637bfe91c09576b0277b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/wayland-protocols" path="external/wayland-protocols" revision="d5f2093d3411bdf04b25ec92b622282448473c78" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,qcom_msm8x26" name="platform/external/webp" path="external/webp" revision="c15a3524ca533d266acaac6aa38e14ac9b3fd30a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/webrtc" path="external/webrtc" revision="7856f35eded86652026789af0069e6402a1bbbb8" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/wpa_supplicant_8" path="external/wpa_supplicant_8" revision="05994afb607f792fba21c7e19b3fd1319a4ba992" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/wycheproof" path="external/wycheproof" revision="d3ed1708ab87b1f922d8c4f8127e08c3b97efd17" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/xmp_toolkit" path="external/xmp_toolkit" revision="44d7e4d00ef6da63a75bf3a4f9296872cc4d2ac1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/xz-embedded" path="external/xz-embedded" revision="51923a98b0af813e3db6a027d64471ee8710a4f2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/xz-java" path="external/xz-java" revision="bd7892bb8927360cd34805bc332039154a2110e0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,projectarch,pdk" name="platform/external/yapf" path="external/yapf" revision="45d923c40605a71867d174abcd04a1db76945651" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/zlib" path="external/zlib" revision="7dfceb664ec662810451feb60912bdf8068ea81a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/zopfli" path="external/zopfli" revision="7723d6077849ae5c66e105b232ddfbfc11faa09b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/external/zxing" path="external/zxing" revision="65193280855e46d11bf5b44f1a7e49ec0c7bd57e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/frameworks/av" path="frameworks/av" revision="bc0f22e33fa5adc5a8873489a5270ba93f94b5a1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/base" path="frameworks/base" revision="5b5bd31eb39480c419446b012b32d02b2f88bc7c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/frameworks/compile/libbcc" path="frameworks/compile/libbcc" revision="72df1bfdec830469932e330ca636bd6245aefa5f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/frameworks/compile/mclinker" path="frameworks/compile/mclinker" revision="f44921e7d4a53e60816df832636457f52eb22f5e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/frameworks/compile/slang" path="frameworks/compile/slang" revision="39dd076e4ffb489ab396a99c473dd40509e52977" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/ex" path="frameworks/ex" revision="e27051b33ccc6ff9e7ce3f883147215fecd3badf" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/frameworks/hardware/interfaces" path="frameworks/hardware/interfaces" revision="31c9f78b315d76c664203e6dad4048d2e1538ad8" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/layoutlib" path="frameworks/layoutlib" revision="595041b399969b67059d842056955b25003413bd" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/libs/net" path="frameworks/libs/net" revision="029a7f0dc038e002087fd9846873aa08c51c2d86" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/minikin" path="frameworks/minikin" revision="ccb441309e11b0abe0b5b7c166baddf265705532" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/frameworks/ml" path="frameworks/ml" revision="8dcf6fc311a7434abb26420d5c9b0aaf0b78fbca" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/multidex" path="frameworks/multidex" revision="85015412f25c08bb7adfe12050f742f344b1ada2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/frameworks/native" path="frameworks/native" revision="8ba800fd3d9ba2389d911c6e6b891e2cd9df866e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/frameworks/opt/bitmap" path="frameworks/opt/bitmap" revision="e9850af1278e499e427d08dbf40244f3622bd6db" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/calendar" path="frameworks/opt/calendar" revision="1aea8315ebe9cca6e9462ab02e9f4caf20c8cd58" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/frameworks/opt/car/services" path="frameworks/opt/car/services" revision="a99bb6d755a4cadf28d9721998c81a2eb9695027" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/frameworks/opt/car/setupwizard" path="frameworks/opt/car/setupwizard" revision="4edad3bb73918b5d4c4d9b29e7558f2181c527e6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/chips" path="frameworks/opt/chips" revision="558c496c8f51ee586d0f0cf0e0371c25c7ceca31" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/colorpicker" path="frameworks/opt/colorpicker" revision="7890ecd4bc418a422f02c0ab32406049b9117707" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/frameworks/opt/net/ethernet" path="frameworks/opt/net/ethernet" revision="e260e8593a6f6db92d3da4c965100585e6ed8ae7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/frameworks/opt/net/ike" path="frameworks/opt/net/ike" revision="e649e5dc38220283387c9c995ec266ed5163e496" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="frameworks_ims,pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/net/ims" path="frameworks/opt/net/ims" revision="c9d85cf60a882157b6924cdb0e229bf869792125" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/net/voip" path="frameworks/opt/net/voip" revision="4fd8a47d3ea5670371bd7eb8a7df12b1a9e09d43" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/frameworks/opt/net/wifi" path="frameworks/opt/net/wifi" revision="363919bc936ff2354672015c3357056c666b7485" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/photoviewer" path="frameworks/opt/photoviewer" revision="80dca034d73543634c9363a4d89603039797d17b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/setupwizard" path="frameworks/opt/setupwizard" revision="481c220b0b15b5ab5808e4f0d648333c9b772307" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/frameworks/opt/telephony" path="frameworks/opt/telephony" revision="50f500bd2f52064c7dce426827f54f429db00741" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/timezonepicker" path="frameworks/opt/timezonepicker" revision="7330b31178d3ca509bf710bf435ed85785b4e8ea" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/vcard" path="frameworks/opt/vcard" revision="60f1b62e68cb324b66d24580660e7dc5478d3305" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/frameworks/rs" path="frameworks/rs" revision="b177df2af4f8771622f3a8567ae5b7d884e26ec6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/wilhelm" path="frameworks/wilhelm" revision="1ae27fa06db35ee105063075119f0fcac613867d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/hardware/broadcom/libbt" path="hardware/broadcom/libbt" revision="40c99d7f10f7ca533de1dc4c0f21c921c8a7ccce" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,broadcom_wlan" name="platform/hardware/broadcom/wlan" path="hardware/broadcom/wlan" revision="b0a55cf0ceda7d42763c05c3f71fbe5b07c74c33" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/hardware/google/apf" path="hardware/google/apf" revision="1cc9d2f7932f09865812e25a29cc5f708db609bf" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/hardware/google/av" path="hardware/google/av" revision="f48d6708df1c1cc6eb71ecfa7c3be7048d85dd91" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,easel" name="platform/hardware/google/easel" path="hardware/google/easel" revision="c0289b1adae580846436ef2fabeb46c3a4cbf840" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/hardware/google/interfaces" path="hardware/google/interfaces" revision="35ee1140254be6d8eb5bb73c6d543c2da01e7984" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="generic_fs,pixel" name="platform/hardware/google/pixel" path="hardware/google/pixel" revision="56ed76601d2fa5f1a1e6f7f24d79975a69f43a39" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="generic_fs,pixel" name="platform/hardware/google/pixel-sepolicy" path="hardware/google/pixel-sepolicy" revision="a3af99c63f21e27cba689f811c15c2b10f638fea" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/hardware/interfaces" path="hardware/interfaces" revision="775bd7cb9a5faaca03893bea3b5d7c83bf94a9ea" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="invensense,pdk" name="platform/hardware/invensense" path="hardware/invensense" revision="a51c32c7d16d32462fcd2d3fc61474bb0ec56864" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="coral" name="platform/hardware/knowles/athletico/sound_trigger_hal" path="hardware/knowles/athletico/sound_trigger_hal" revision="3c287d5a139ee9bc6bf130f46ffeb8660938fe96" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/hardware/libhardware" path="hardware/libhardware" revision="353924555ed8dfdea437d7f5833573963e0755b4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/hardware/libhardware_legacy" path="hardware/libhardware_legacy" revision="f2a03b676273c57b01e1ac5bc45fd8ee0f73fdaa" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/hardware/nxp/nfc" path="hardware/nxp/nfc" revision="1a15c61d2f880737c581f3ff6cd53266fd7c20db" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/hardware/nxp/secure_element" path="hardware/nxp/secure_element" revision="415b9c170f8f17d42fca196b9e495ef9e305370b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom,qcom_audio,pdk-qcom" name="platform/hardware/qcom/audio" path="hardware/qcom/audio" revision="2d4e92a7f5631a7344f33e760665cc8453ab84db" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-qcom" name="platform/hardware/qcom/bootctrl" path="hardware/qcom/bootctrl" revision="4e5d4010484ae58b169f00d036efff78546a3def" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom,pdk-qcom" name="platform/hardware/qcom/bt" path="hardware/qcom/bt" revision="60cd73f453bb6d4920cf2d2aa3b0f455a404de04" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_camera,pdk-qcom" name="platform/hardware/qcom/camera" path="hardware/qcom/camera" revision="9ddd2b5c8bd6b7c2abaaafa0230f2a6a2ee7bede" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom,pdk-qcom" name="platform/hardware/qcom/data/ipacfg-mgr" path="hardware/qcom/data/ipacfg-mgr" revision="afb3ff1954f9cfdb3cb30c5b8ceead63bffdb3d9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-qcom,qcom,qcom_display" name="platform/hardware/qcom/display" path="hardware/qcom/display" revision="5b3e1c2cb842cd5097706bead8828ae359b4fe3f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom,qcom_gps,pdk-qcom" name="platform/hardware/qcom/gps" path="hardware/qcom/gps" revision="87f7523616fbe4dc383e5d8f1e240f235530cdd4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom,qcom_keymaster,pdk-qcom" name="platform/hardware/qcom/keymaster" path="hardware/qcom/keymaster" revision="ecfe142948adf4f82083d7333b6c778f3993842b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom,pdk-qcom" name="platform/hardware/qcom/media" path="hardware/qcom/media" revision="ff39d325a6d1688575fddebd3a4665d5c4d4c4d1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_msm8960,pdk-qcom" name="platform/hardware/qcom/msm8960" path="hardware/qcom/msm8960" revision="c25a431842a26b5756b58a9d4a42c776e0457ba2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_msm8994,pdk-qcom" name="platform/hardware/qcom/msm8994" path="hardware/qcom/msm8994" revision="8e0383f6f41a2c49461f381c8d066ea21b20c674" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_msm8996,pdk-qcom" name="platform/hardware/qcom/msm8996" path="hardware/qcom/msm8996" revision="f0e7ce67121940312eaffeda9c4add56d63bf4e1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_msm8998,pdk-qcom" name="platform/hardware/qcom/msm8998" path="hardware/qcom/msm8998" revision="e504d3feeb25220780c1674dc870a1a45e0cf55b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_msm8x09" name="platform/hardware/qcom/msm8x09" path="hardware/qcom/msm8x09" revision="c88c67109844def18fef4941e39bebb8f8981e39" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_msm8x26,pdk-qcom" name="platform/hardware/qcom/msm8x26" path="hardware/qcom/msm8x26" revision="85c1a5282ae28663335e55ce96a4c0487de6c578" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_msm8x27,pdk-qcom" name="platform/hardware/qcom/msm8x27" path="hardware/qcom/msm8x27" revision="8ff5c0057cbdecfa09410c1710ba043e191a2862" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_msm8x84,pdk-qcom" name="platform/hardware/qcom/msm8x84" path="hardware/qcom/msm8x84" revision="582b414269d8472d17eef65d8a8965aa8105042f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="wahoo" name="platform/hardware/qcom/neuralnetworks/hvxservice" path="hardware/qcom/neuralnetworks/hvxservice" revision="09fd7dd7e4475a5e8d6852fe76099bcdb6f62b79" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom,pdk-qcom" name="platform/hardware/qcom/power" path="hardware/qcom/power" revision="c9165f0cb184fcaf6888b7921b55033e8b50836c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/bt" path="hardware/qcom/sdm845/bt" revision="29c8a55bb6e521089ebd80a64afc893f8822aad2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="generic_fs,vendor,qcom_sdm845" name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" path="hardware/qcom/sdm845/data/ipacfg-mgr" revision="a82a6f86c4654775a66de52af4c4e42e118b51e6" upstream="refs/tags/android-r-preview-2">
+  <project dest-branch="master" groups="pdk" name="platform/compatibility/cdd" path="compatibility/cdd" revision="30d5862b67bc41e5e9fc18253680a09018cbe865" upstream="master"/>
+  <project dest-branch="master" groups="cts,pdk-cw-fs,pdk-fs" name="platform/cts" path="cts" revision="94e2362881c8702114fa35550d203ca56de26c4c" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/dalvik" path="dalvik" revision="d236cfb4cf2b757c6ed728688a9034ef88338fc6" upstream="master"/>
+  <project dest-branch="master" groups="developers,pdk" name="platform/developers/build" path="developers/build" revision="6a8a6e64206de0aa11d0221815ac3706f97fff24" upstream="master"/>
+  <project dest-branch="master" groups="developers" name="platform/developers/demos" path="developers/demos" revision="03814c35b8ee0a1284c667556260124d97466b28" upstream="master"/>
+  <project dest-branch="master" groups="developers" name="platform/developers/samples/android" path="developers/samples/android" revision="9083bced6874c606043ebfb36bb1f71f67090ecc" upstream="master"/>
+  <project dest-branch="master" groups="developers,pdk-cw-fs,pdk-fs" name="platform/development" path="development" revision="06a46b45a5f53099f02ba6f192b2e87d276040ce" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/FP16" path="external/FP16" revision="6321f9ece6de2c375a9a3e9fc5213addee2d187a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/FXdiv" path="external/FXdiv" revision="dba5619fc6fd63d8ea355879ceabcece683aad81" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/ImageMagick" path="external/ImageMagick" revision="d65c43ff7e19a4a08d4c041d5f30deac688d23eb" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/OpenCSD" path="external/OpenCSD" revision="b13c2dbf7947158c581c3bc742e45da0e7ecd56d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/Reactive-Extensions/RxCpp" path="external/Reactive-Extensions/RxCpp" revision="e1911558a963dd6d531ea5690c3c7b669b737221" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/XNNPACK" path="external/XNNPACK" revision="4f2126367b2966f530172dca411380970d742825" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/aac" path="external/aac" revision="760e8921c22c0185bc68f8a9884f0e8ddb7a25a4" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/abseil-cpp" path="external/abseil-cpp" revision="f194138dceced5005962a11ad5bda7f485f05282" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/adhd" path="external/adhd" revision="409b221d5802c6d6d64f7ce74675aafd9b5fa697" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/android-clat" path="external/android-clat" revision="c786b7409032050721021583236de8608ac8948e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/androidplot" path="external/androidplot" revision="934267aac685318a07d81f4be6ce9570f680db6a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/angle" path="external/angle" revision="c5f24132a2359a1785f31729a185caf04a1f4127" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/ant-glob" path="external/ant-glob" revision="82cf4fe5a6b15ac35b731c00741c47b9ef596113" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/antlr" path="external/antlr" revision="581e666e25bb4c1e934a1bd9225e66319d2e01a2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/apache-commons-bcel" path="external/apache-commons-bcel" revision="7bc65fcf0acbd82386c038e98c9870e3166e5d13" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/apache-commons-compress" path="external/apache-commons-compress" revision="fe57d998587dbcedc0389d1b3a99ecf90289ef5a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/apache-commons-math" path="external/apache-commons-math" revision="30c8d5d492c594d3dd736368fbf9f7970371134d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/apache-harmony" path="external/apache-harmony" revision="540806da4a7adf167b1a7050b66c54ef1aa86707" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/apache-http" path="external/apache-http" revision="55b5ba17afdc82151d0a1887dd44714f89c7d963" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/apache-xml" path="external/apache-xml" revision="2086faacd79ed8b8283a96b276a2353165662d55" upstream="master"/>
+  <project dest-branch="master" groups="vendor" name="platform/external/arm-neon-tests" path="external/arm-neon-tests" revision="f3d72fcbc0aabdd329edeb7041847a4239fd401f" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/arm-optimized-routines" path="external/arm-optimized-routines" revision="5bde7af22aec08b657b85f41e30395f3a108ab69" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/arm-trusted-firmware" path="external/arm-trusted-firmware" revision="a73922dd3563716cb58944e0585b33dbaf26ff08" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/auto" path="external/auto" revision="8d0c8f812ffa1c0ba1573e4e8c225f9ea874831d" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/external/autotest" path="external/autotest" revision="960ddf17c4588fdd7226959370824b1e57c86949" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/avb" path="external/avb" revision="28d0d9d821c75cd54c795cad2c6739a5d3db4d53" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/bc" path="external/bc" revision="77f89687b4c551d58003431962af111160c37028" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/bcc" path="external/bcc" revision="fd247435dfdfe9a6daa159620127f2724f6d1d7a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/blktrace" path="external/blktrace" revision="d1d8f301c0f97048dbc3431c1a58a6d7313aa153" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/boringssl" path="external/boringssl" revision="ba9db8781ec11859132f543aebff5d6093214751" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/bouncycastle" path="external/bouncycastle" revision="c62b2d68553fbd3c7cd9b9053f812bf36bd9e63d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/brotli" path="external/brotli" revision="4bf7087b5c7e33361469ed86c1de90df8450ce88" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/bsdiff" path="external/bsdiff" revision="c62b211329f251ca43d2dcb419384bc747f72944" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/bzip2" path="external/bzip2" revision="a75d53c4bac5db59bad722678f1c231ef2d92543" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/caliper" path="external/caliper" revision="f0a3eafc7ecccfa7adbb08dcf455545ace087a43" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/capstone" path="external/capstone" revision="f1f1cbc054db7021d4167a96b55783e087e1b7b4" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/catch2" path="external/catch2" revision="976d18eee9e452380d6a8725d894cd083ba6a482" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/cblas" path="external/cblas" revision="48c69ccaa4f0d3894335125d37e919ea655769c2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/cbor-java" path="external/cbor-java" revision="3d7fde33f9364c80cabd241c6560b33ae4c83c7e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/chromium-libpac" path="external/chromium-libpac" revision="9fba6d0933c72d61b8025bc730a6ee1ac9902c3c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/chromium-trace" path="external/chromium-trace" revision="fe6a5051c854157fb8579d4139adcaa31f319b40" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/external/chromium-webview" path="external/chromium-webview" revision="d3f0768ab7566dacfc7cadfc4f661ab30d8ecba0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/clang" path="external/clang" revision="382efa3f0dd36a342e30e8bf06af717e0664de3f" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/cldr" path="external/cldr" revision="09ea71c1137e922826e9c5d60d3307b8b2b73fef" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/cn-cbor" path="external/cn-cbor" revision="8f258525f7792d5beefa7fdb2ea064f51651f565" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/compiler-rt" path="external/compiler-rt" revision="83c5095a0c8a7a90930e2ba427fdb64115402e21" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/conscrypt" path="external/conscrypt" revision="8ebc95684c24078ff04643f0f656f80c3fa8e277" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/cpu_features" path="external/cpu_features" revision="22499193e0470a947ed5189cefb9b0537f461fbe" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/cpuinfo" path="external/cpuinfo" revision="edde61d708c2af26a5ae9c542785850b0ca3c11a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/crcalc" path="external/crcalc" revision="86481d30939166237ecd8d2ebb73ac85da3488ec" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/cros/system_api" path="external/cros/system_api" revision="1f322ad4c14baac5d33033be7f57cb7ef65c8f38" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/crosvm" path="external/crosvm" revision="8683d23b0520c52190e40af191fb0ca7c9ce756d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/curl" path="external/curl" revision="23abcba8890bbe842707ffe8d777aeb50adfd89d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/dagger2" path="external/dagger2" revision="3ea05b789ebea6b0b1c726cd19600ebf822aa1f2" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/external/deqp" path="external/deqp" revision="ee2101f344ad88ceee4e15ce4afcf2eab2df3c9d" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/external/deqp-deps/SPIRV-Headers" path="external/deqp-deps/SPIRV-Headers" revision="fd44500f60ca16d4e9ffede30efb945cab3a7240" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/external/deqp-deps/SPIRV-Tools" path="external/deqp-deps/SPIRV-Tools" revision="49378ae8cb471ba551c4db0a8eaf0f09884c9217" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/external/deqp-deps/glslang" path="external/deqp-deps/glslang" revision="4aefaf749acac904835dfb6ca2db580e706d05c8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/desugar" path="external/desugar" revision="12b1f91034819c58bd6f96eac01fee2b80d1ebfa" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/dexmaker" path="external/dexmaker" revision="461fe849522042af0d82cdf5b1dbedc249091f1a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/dlmalloc" path="external/dlmalloc" revision="86a59f3d28c853ef8b45ee64825d4fd6a9a1b298" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/dng_sdk" path="external/dng_sdk" revision="84de511df4f08157042517717a1162ecb2cf31ca" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/dnsmasq" path="external/dnsmasq" revision="b4504cce43b8013c67ca2052ef5120f4dd89ed8b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/doclava" path="external/doclava" revision="696f76f1d7a523ae9663ebecd7035e459fe89d19" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/dokka" path="external/dokka" revision="9b8280a227848c53045cabc5a86cd013d720c63c" upstream="master"/>
+  <project dest-branch="master" groups="drm_hwcomposer,pdk-fs" name="platform/external/drm_hwcomposer" path="external/drm_hwcomposer" revision="37b57553a14517b4be01ea98ff9a165e2d05214f" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/drrickorang" path="external/drrickorang" revision="f1a513d32bbdeaa358991f95a157de9c0a14afe8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/dtc" path="external/dtc" revision="b734cfd607de2050b9c477d2ede4941bd549e51d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/dynamic_depth" path="external/dynamic_depth" revision="fca207ba92c3fead9cd93d08fc3ad9ed445d1f04" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/e2fsprogs" path="external/e2fsprogs" revision="f03942a7b735ddf568fc137a25617c8466e583f2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/easymock" path="external/easymock" revision="6a93dfcd7e2ab4a661d40641a70982da6967b2a1" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/eigen" path="external/eigen" revision="6d1df66700d01a07243d97c46705244ac7e0d04d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/elfutils" path="external/elfutils" revision="197f13f7a0bdd4c7274032197329eac70d99bb61" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/emma" path="external/emma" revision="6e14649fb4b4eed576870ce5feddf881d6cd109d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/error_prone" path="external/error_prone" revision="9bfe7c610d1cb9f5da773ed16ff3e05a69105077" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/escapevelocity" path="external/escapevelocity" revision="959711e574e3c12b4d7e4b71858372de9489eeae" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/ethtool" path="external/ethtool" revision="25ebc5901417ef3020ed39d2f81f7a202551d962" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/expat" path="external/expat" revision="3f5ade9e323e15b6526c1b812797875b76201f51" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/f2fs-tools" path="external/f2fs-tools" revision="31b8f380dbad17e36fa43f436fbb35b837ac4bc1" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/fastrpc" path="external/fastrpc" revision="8a30933a85303af3c4f7747d58b3ae85e0f55df4" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/fdlibm" path="external/fdlibm" revision="ecde95f0e8908e1c0c552954d8f27a44612df27c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/fec" path="external/fec" revision="f76ec3955db8c868f41f4c2a8590fdb9d77e9223" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/flac" path="external/flac" revision="0be0e05ec588e5a5a15cb955ba7750b4689e9b53" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/flatbuffers" path="external/flatbuffers" revision="e87b31da8ecbc05a9a12d817cba3a2c79f653758" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/fmtlib" path="external/fmtlib" revision="3f9c7e3871cce490b1305ee7c0002269c9c6c0c5" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/fonttools" path="external/fonttools" revision="a7ee29ebd4c9d39d29ee03f7746bb6af1c3f7e6b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/freetype" path="external/freetype" revision="deb9aaa78155f93efcecb6f47b85ec77190c6f16" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/fsck_msdos" path="external/fsck_msdos" revision="2f294595d964f2b1ae21dfd02ba58e9ee1e839ca" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/fsverity-utils" path="external/fsverity-utils" revision="7b8d3d5ce84e02a3c441ff335c3873a8fa7f1139" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/gemmlowp" path="external/gemmlowp" revision="ca41a583fa4faa3c8fa560c7ce52b2a130519979" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/gflags" path="external/gflags" revision="6827298aeef132e2545279ed2ac5d0b74fa18e7a" upstream="master"/>
+  <project dest-branch="master" groups="pdk,qcom_msm8x26" name="platform/external/giflib" path="external/giflib" revision="efb0f5c4b88455acfcf19f4a42c9bdaa5deb5233" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/glide" path="external/glide" revision="305446b544892451a5fbcfffd481236d175b2a73" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/golang-protobuf" path="external/golang-protobuf" revision="b34db27e38b1b60c83ab7c3a1985203c3f98281b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/google-benchmark" path="external/google-benchmark" revision="1c12faf75d74e933af10361bb5d264f28dad4747" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/external/google-breakpad" path="external/google-breakpad" revision="ba746a803abbb11df24e35735dfef38f73f3a4b5" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/google-fonts/arbutus-slab" path="external/google-fonts/arbutus-slab" revision="a4585df413033fd56cc9d1be870441f51be3bf60" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/google-fonts/arvo" path="external/google-fonts/arvo" revision="69e476290ceb1a490635253a6c406ca04077e731" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/google-fonts/carrois-gothic-sc" path="external/google-fonts/carrois-gothic-sc" revision="ef8b4dd6b9f8c0705bc77891b872c4ca105a003c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/google-fonts/coming-soon" path="external/google-fonts/coming-soon" revision="3c2ee6fd489d0d327167639dfa44761d85b36a11" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/google-fonts/cutive-mono" path="external/google-fonts/cutive-mono" revision="829ed98efce47267f5e97e9e481a3e409343ef0a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/google-fonts/dancing-script" path="external/google-fonts/dancing-script" revision="9598bd198400dc0d641846e2ae6d7ce175ed2808" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/google-fonts/lato" path="external/google-fonts/lato" revision="f77b1a4f33a17a7e3512de6ae6515e2288c47da9" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/google-fonts/rubik" path="external/google-fonts/rubik" revision="82064b902d3b3d5aab81a9b2c248e7fc046b9cf6" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/google-fonts/source-sans-pro" path="external/google-fonts/source-sans-pro" revision="b22b4bea8200f20bbf6df4a5f4798b76bd8e8846" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/google-fonts/zilla-slab" path="external/google-fonts/zilla-slab" revision="646ccf753dd1a4101b4f13d002c03a407bec55bf" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/google-fruit" path="external/google-fruit" revision="59888e7910bfe28018b88b3c6fef2942ac43d381" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/google-java-format" path="external/google-java-format" revision="7aef6bcfd33e998e4cee84f80e0af3c16e864a94" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/google-styleguide" path="external/google-styleguide" revision="c8c1424155e07f3773b731510b08f1dcd5855c76" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/googletest" path="external/googletest" revision="e87584ebb141cd532f4688556835903c44563292" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/gptfdisk" path="external/gptfdisk" revision="f00572f20bf48fb47d90a3d71c1dbd5a7c97f8b0" upstream="master"/>
+  <project dest-branch="master" groups="pdk,tradefed" name="platform/external/grpc-grpc" path="external/grpc-grpc" revision="e5624b1eaec69e9c6c27f4c14ed0eb6a126c013c" upstream="master"/>
+  <project dest-branch="master" groups="pdk,tradefed" name="platform/external/grpc-grpc-java" path="external/grpc-grpc-java" revision="332041b0592239d4bfe59bfd316f28c02f523570" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/guava" path="external/guava" revision="76e1cfd9dd039013e7edc101dbd40e70e83c0a85" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/guice" path="external/guice" revision="362cdb1e951d12da4a7b2489ab8eedb327f92538" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/gwp_asan" path="external/gwp_asan" revision="d2ac860fa64716566fa046827b9364e9422abdeb" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/hamcrest" path="external/hamcrest" revision="c3f6da7e6510ccb68c55332ba9deee09e714c506" upstream="master"/>
+  <project dest-branch="master" groups="pdk,qcom_msm8x26" name="platform/external/harfbuzz_ng" path="external/harfbuzz_ng" revision="ce643e153b5f9179744d1027fad2e274a041a9b5" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/honggfuzz" path="external/honggfuzz" revision="4da5ca807ec753ef0dba496f8db65738084c42bb" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/hyphenation-patterns" path="external/hyphenation-patterns" revision="061d892d99db8594ab858ada1b34ef9935b1c7af" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/icu" path="external/icu" revision="59b93bdba792e0a6363022dbda0c796f3da9e6f7" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/igt-gpu-tools" path="external/igt-gpu-tools" revision="c231060e4dbd680c770a0682e6b37ee875c0faf5" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/image_io" path="external/image_io" revision="878cbe0d3f24cac6f00905c541b65d0dc0427b34" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/ims" path="external/ims" revision="918a6a4f587aeec2fd71e63bdd106f6d71d1f4c5" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/iperf3" path="external/iperf3" revision="25e8e69eee58ae9cf5e35e4235ac9159d580fa8b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/iproute2" path="external/iproute2" revision="d6e38af5a74427c46e91147f6e39f0ebb11af199" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/ipsec-tools" path="external/ipsec-tools" revision="956806ac158bf4ac800967adafab9d46273ff0dc" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/iptables" path="external/iptables" revision="5858660f64fa3850aaf4e251b18f032bb7168f99" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/iputils" path="external/iputils" revision="d5f5073532c7d0fc91a331b75684dfb820bf9aaf" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/iw" path="external/iw" revision="c958c9feaeb637ce5a577057350b74c24d011219" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/jacoco" path="external/jacoco" revision="bdbfb7047d87e8e790260a0fffb1afdf37ed3dc8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/jarjar" path="external/jarjar" revision="f5f35e26f783c4a986a2c145d0743a4aa4171a9b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/javaparser" path="external/javaparser" revision="ae622838617fa95231962c609dfa85b6a7c37d95" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/javapoet" path="external/javapoet" revision="fc695240b7ec6ac465e155b3202dc691527b29c3" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/javasqlite" path="external/javasqlite" revision="1bfc2ec47cc265c1ebbfcdeb9fd92e3c29199896" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/jcommander" path="external/jcommander" revision="ee1e7b936f71a499707693d8820a27347b1267f3" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/jdiff" path="external/jdiff" revision="1508d2b9c7a9cf06ad6460155e82e18b6f4d9cf7" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/jemalloc" path="external/jemalloc" revision="ecdbccc7cb3d9d8e986019db37a21552324e7c1f" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/jemalloc_new" path="external/jemalloc_new" revision="b32ec89beb19643bc0f68b6e9495b9369e3da15f" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/jimfs" path="external/jimfs" revision="b1bfb99b28a67b98287a475c5dce9344f0cc18ab" upstream="master"/>
+  <project dest-branch="master" groups="pdk,tradefed,pdk-fs" name="platform/external/jline" path="external/jline" revision="619aadcb7088db71bfc701f881ac41413463e89f" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/jsilver" path="external/jsilver" revision="8d887a8f13fab888dd7c18254742856fbebfc3cd" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/jsmn" path="external/jsmn" revision="d876b9096dbc2b3b18ecca027af9c74890b54b72" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/jsoncpp" path="external/jsoncpp" revision="60f1d4392708db183229cdc306d299404794f4a5" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/jsr305" path="external/jsr305" revision="9fe096ad55e1718466e37a0601c010078f33a98b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/jsr330" path="external/jsr330" revision="5209aa2c7c1da68683ca9ff4d18c221126230262" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/junit" path="external/junit" revision="6fac8fec6c62ff66cb950b312ae09f7f6ef865e0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/junit-params" path="external/junit-params" revision="96cef880fa30fdf0c6c1275a6e0d3228c9efde66" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/kernel-headers" path="external/kernel-headers" revision="e58316e074fd9f2ea8ad5eff9d29517cf61b31a8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/kmod" path="external/kmod" revision="e62d44322d84833a2cf5b4ee649d65481504b7ae" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/kotlinc" path="external/kotlinc" revision="f301753662be558ac183ea762a89e7450d48e104" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/kotlinx.atomicfu" path="external/kotlinx.atomicfu" revision="fe5a26f975cc0867bf67f58faac0d5100aecde73" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/kotlinx.coroutines" path="external/kotlinx.coroutines" revision="d24bc80ff29c00647d0ea072913d380dad7e2787" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/kotlinx.metadata" path="external/kotlinx.metadata" revision="44866ae7e2062808c87fa331f17792ade5ea809b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/ksoap2" path="external/ksoap2" revision="c5e0fcb70cdf6faaf073f7d676aab8184501ac7d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libaom" path="external/libaom" revision="bfefc374b39b023a3722f7d378cdb06016f8d478" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libavc" path="external/libavc" revision="a0036e742b076775cd39aa21822a0c858592323b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libbackup" path="external/libbackup" revision="3559a596e471ac1082431fc7dc7f23a0598cfd82" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libbrillo" path="external/libbrillo" revision="16430c43b2ebe933f5991887f0ff77dd0056b78f" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libcap" path="external/libcap" revision="d3106b3008811589a68aee30919d041793cdb09d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libcap-ng" path="external/libcap-ng" revision="fe30cea9f3a21cdb96bff75a49837b6b7bba4420" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libchrome" path="external/libchrome" revision="edddb73384356911190b33bbce56ffacedc85da2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libcppbor" path="external/libcppbor" revision="00e2c7c93606ad8dfb1913d8ced74e3a0f049e38" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/external/libcups" path="external/libcups" revision="46f00591066f458594bd77b31f2abd3ba218568b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libcxx" path="external/libcxx" revision="1447d718cab6c1a5b6a2b66ab77a39148b2caf13" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libcxxabi" path="external/libcxxabi" revision="72a9c9f1f20747fa2899b964d30c8d117de54a04" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libdivsufsort" path="external/libdivsufsort" revision="9da4324328e728be1e99bf318623e4fd9861de41" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libdrm" path="external/libdrm" revision="06b698c2b81637b803c3467f57ab511d44fe8090" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libepoxy" path="external/libepoxy" revision="4b204d7bfef89bb435ce9566ed1ac828d15f4fbd" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libese" path="external/libese" revision="aaaf87dd1f9d3f08768a67e62957f33968a82f7d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libevent" path="external/libevent" revision="f0077b80a031634c5c62cffa0a238923db77d45a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libexif" path="external/libexif" revision="49232eccdc24b72e3a3716c515ad7cd70dfe8e45" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libffi" path="external/libffi" revision="004e55c74517edc7db707429390d2d07a5df4bb4" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libfuse" path="external/libfuse" revision="4db6b5519adceb891de3e05324565faa24e56e2d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libgav1" path="external/libgav1" revision="901e60222112bc27912c704a8cc83837b0c9fc52" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libgsm" path="external/libgsm" revision="3faa49540d779c8d36d7b4d7e5ac0a7769835b0c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libhevc" path="external/libhevc" revision="c0ed31e9bf5c7eac0f30f1f65b652bcdde8a0c15" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libjpeg-turbo" path="external/libjpeg-turbo" revision="fdfd06bfabc924fe875d98d9f858d6b10f42daa8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libkmsxx" path="external/libkmsxx" revision="db553c26484cc38daa54a5d8f43c564a82c5a8cc" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libldac" path="external/libldac" revision="ed310a0d66278e4d23c1ba4b2d087b9068d2c851" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libmpeg2" path="external/libmpeg2" revision="41abcf9aebd2c0317fd37fc8d9ab15b7a394ca94" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libnetfilter_conntrack" path="external/libnetfilter_conntrack" revision="3d75fb70ef9cc05f2a18215b44a9a4e2151a8ad3" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libnfnetlink" path="external/libnfnetlink" revision="0a11f848c03f2dabd6b54588060ad6bffea2619b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libnl" path="external/libnl" revision="4aa55aaed61e20a05d7f84c8eb9fa9dfc7bf7598" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libogg" path="external/libogg" revision="88ab2345a65b8eaec9157a6b3812a50fd60be610" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libopus" path="external/libopus" revision="5dfde48061c4177ac150c492d085a1825b30e1ba" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libpcap" path="external/libpcap" revision="061669a9e338f41bd2a50ea1dbdbe272f4c21ef2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libphonenumber" path="external/libphonenumber" revision="127fc89c7fc3bb01b93fd69387a10cc476ccba86" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libpng" path="external/libpng" revision="d6c453834e5295de0714f8c7ebb7d4feb002c500" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libprotobuf-mutator" path="external/libprotobuf-mutator" revision="f0bf6bdf2e02492ae9920c6131706a0cc60f87db" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libsrtp2" path="external/libsrtp2" revision="d8f04c502bc1eba2f85305e3c2f62b53f5874a82" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libtextclassifier" path="external/libtextclassifier" revision="a25f7792dc3c220528817650f4dc3db053a28546" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libunwind" path="external/libunwind" revision="2674521dff29c84e9b37b28243fdaf9ca24620cd" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libunwind_llvm" path="external/libunwind_llvm" revision="b2aff48eedb8ca162aa438135add08d915540925" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libusb" path="external/libusb" revision="117ebfb3c94058b37308e1aa4f60a5c705348fcf" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libutf" path="external/libutf" revision="bda0a6cb778f4ca1f8c6c0e69c9eae0e2c0fa15d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libvpx" path="external/libvpx" revision="d53de4257603f3292c5928d74d59aa0e3259efd7" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libvterm" path="external/libvterm" revision="10b4d7643bcb3335f79eff5052eca63981e32d88" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libwebsockets" path="external/libwebsockets" revision="0b7c9f713c72c68d2d55154258d400cad92d3c99" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libxaac" path="external/libxaac" revision="a4cd8c6bf67849e36384c55fbf30185c0c23fbd0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/libxkbcommon" path="external/libxkbcommon" revision="bbdf3993463b2d792d3d56085c7e6e7d957ddaf6" upstream="master"/>
+  <project dest-branch="master" groups="pdk,libxml2" name="platform/external/libxml2" path="external/libxml2" revision="0793c203602155220d00e079d075b6b5d2c8b381" upstream="master"/>
+  <project dest-branch="master" groups="pdk,libyuv" name="platform/external/libyuv" path="external/libyuv" revision="2ee3028b36ac61abed29cbb379a411a98fe31677" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="vts,pdk" name="platform/external/linux-kselftest" path="external/linux-kselftest" revision="3e6bd6b610f818a9f491fae0fded5ac53cf073b5" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/llvm" path="external/llvm" revision="472bc9a55da4405a32a82cf38657d8ae3ac7ea05" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/lmfit" path="external/lmfit" revision="215e9f8136e415f986fbb1c4818c31dad08b8486" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/external/ltp" path="external/ltp" revision="e328e82112e84baad7c5aa8a7176d15e0956f790" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/lua" path="external/lua" revision="81fe03fc67903444ae1bd49595758c5d8772f0ed" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/lz4" path="external/lz4" revision="91afe2b67975a02d1b5f7bd9ffff57d66ac60b1e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/lzma" path="external/lzma" revision="b320dbbac4bc8a0d3f757c90a3c19e82da8bef30" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/marisa-trie" path="external/marisa-trie" revision="dd2e2803599b525509897a1c92d842d645179672" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/markdown" path="external/markdown" revision="24b5e54d6f880b9562a0542ed003798686f5b2c3" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/mdnsresponder" path="external/mdnsresponder" revision="a809837a94aa8a412abd45babb6b415817a980b6" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/external/mesa3d" path="external/mesa3d" revision="f20360908a5653be4826678cd2b8b471ca98588d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/mime-support" path="external/mime-support" revision="194d5579b66a8cb867e90fb1cc01c91575bdb11a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/minigbm" path="external/minigbm" revision="cbd768f2b30664f32cede8a982a9996fa28079d0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/minijail" path="external/minijail" revision="85d797ecbfd7aefbb9486afeaed3cf5f74858562" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/mksh" path="external/mksh" revision="efb93a535d09dced0c9d563fd0a1760550954184" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/mockftpserver" path="external/mockftpserver" revision="03695f685f192180268ee675f9e57a06f26d2b11" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/mockito" path="external/mockito" revision="370ee71047efd4b30af757307fadff5c611cbd43" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/mockwebserver" path="external/mockwebserver" revision="78f39a0b3dbccad698027acdc61b1d4b472bee3b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/modp_b64" path="external/modp_b64" revision="2569ec99b0883c885b896a967c1ca514df6b975e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/mp4parser" path="external/mp4parser" revision="47c6ee108cd8c883db6694495db42eed7c5de4ae" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/ms-tpm-20-ref" path="external/ms-tpm-20-ref" revision="08e3b32e71987a6fe4fec4e1697eae7de9476435" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/mtpd" path="external/mtpd" revision="e32bc00d9b6a8ef3bff5ab1dcb73dbacd1a40f3e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/nanohttpd" path="external/nanohttpd" revision="ff84149c71b11732ea2af0dd475c14f03265f4a4" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/nanopb-c" path="external/nanopb-c" revision="74741d77d4a4a7dd9147f4a7ce968752ab2b7f42" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/naver-fonts" path="external/naver-fonts" revision="5dab610e91607c20c90ae568f08b044e5ff3cee4" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/neon_2_sse" path="external/neon_2_sse" revision="b4f8cb4dff471a8bdb85b54e10a17b6dbb43f6fc" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/neven" path="external/neven" revision="9fbdbb4e33becfb9b4886117748cefe717382bd8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/newfs_msdos" path="external/newfs_msdos" revision="ec6dda9d4dfc974d00dc2ee5f96554e703b4b21f" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/nist-pkits" path="external/nist-pkits" revision="80560f8de66d08455e7bd736686e40610087a1f2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/nist-sip" path="external/nist-sip" revision="4c5b69a5876f2986f1db692ad0763ee49a700a13" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/nos/host/generic" path="external/nos/host/generic" revision="393e0ef4633c6c8a075452dc0d550f17fad079d1" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/noto-fonts" path="external/noto-fonts" revision="b635f6273c1e393fde83609aa4b46cbcae92825e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/oauth" path="external/oauth" revision="d1acf194b6d9a230bc9ab30462ad850fa7ec7b2d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/objenesis" path="external/objenesis" revision="e5b2a52dfdae6fc3ddca23b43c66620a335fb036" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/oj-libjdwp" path="external/oj-libjdwp" revision="091ceb2bb2d4af87e3eb4ccdcfff3ad41db025ca" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/okhttp" path="external/okhttp" revision="c7003d30ef11d6d9845e1b77245365c41392d627" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/one-true-awk" path="external/one-true-awk" revision="58e430dccdccef632e5f0e446bf03b6bbf372fc6" upstream="master"/>
+  <project dest-branch="master" groups="pdk,tradefed" name="platform/external/opencensus-java" path="external/opencensus-java" revision="65f84045ca1d01b0e1851d65e9fd3eb82b9d38f7" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/oss-fuzz" path="external/oss-fuzz" revision="8c011a1095fed0dbafbb53b4ad33f3b15b15d439" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/owasp/sanitizer" path="external/owasp/sanitizer" revision="d05deef05265ed83bf1e34d717d62161a846a87b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/parameter-framework" path="external/parameter-framework" revision="b89422dfbb19bf8d6a4e6d25c404a6cc7f27dce6" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/pcre" path="external/pcre" revision="594ea567316acea9c34e521e1cbf0d420bf10e8c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/pdfium" path="external/pdfium" revision="ca58c0ff1a35820edb48190412621e0af34afaa9" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/perfetto" path="external/perfetto" revision="66b08c31f94a3f358204d600610bf1a8d9ac22f5" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/pffft" path="external/pffft" revision="651d7f074901b683784bf148646229d4b218fa27" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/piex" path="external/piex" revision="d26a14360f1b3bb546934467a50039ab09e50ad8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/ply" path="external/ply" revision="36da259d1145bf2e83b9908a4629768c205f20ec" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/ppp" path="external/ppp" revision="28eb3e4f8379ebc738e41a3f25d7056a4498d206" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/proguard" path="external/proguard" revision="57a78f10095e6ab402a4a14cb994e95e875be3f4" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/protobuf" path="external/protobuf" revision="61802769fdb4ef36599d1beeedb5acb9b7c43d50" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/psimd" path="external/psimd" revision="f53ac1dfca8b2703d5667bd186f0284a05510d11" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/pthreadpool" path="external/pthreadpool" revision="94500f81562850b9b727e3426d241fddcdfe0a60" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/puffin" path="external/puffin" revision="e41898ff7ac51f174dba9d2fea092b7f169f3bd1" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/python/apitools" path="external/python/apitools" revision="9b6a69032d2a520ae6816ad1f58e985d25ed3164" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/python/asn1crypto" path="external/python/asn1crypto" revision="e601bdffcfd2d1d152f62b174843033cd9c4833e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/python/cffi" path="external/python/cffi" revision="cb16c1f6ccbe6b48d75fd1ad0a575696e3d6b2eb" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/python/cpython2" path="external/python/cpython2" revision="6a4b58d73dbe1ac4749a5084b4fca8adb03d3294" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/python/cpython3" path="external/python/cpython3" revision="f6ed9b4958fa74a3689f0a0d7b576a78788c37cf" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/python/cryptography" path="external/python/cryptography" revision="7dee80aacf672502e4f2a482c7a1cdce37e1b0bb" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/python/dateutil" path="external/python/dateutil" revision="b84c56b4c0ac9aab601bba55dd8853936ebe4735" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/external/python/enum34" path="external/python/enum34" revision="63fe0ccce104a639e52df98ead5b9c3f766aad7b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/python/funcsigs" path="external/python/funcsigs" revision="855e4480247a81307befa291fd4dc8b84780af87" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/external/python/futures" path="external/python/futures" revision="fbc97b3d628d077e305243076a22164fe73bdef8" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/external/python/google-api-python-client" path="external/python/google-api-python-client" revision="c89967c96a4726ac35dc3c183bb23a7954639d7e" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/external/python/httplib2" path="external/python/httplib2" revision="312ef219b4f48b7081b5426d84f4f26eb58331e5" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/python/ipaddress" path="external/python/ipaddress" revision="472a1c3569aa11ab5646a73a0cb88e8366d42e35" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/python/mock" path="external/python/mock" revision="1a26ddc3d8f6d748996b3542faec05cf7154d573" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/external/python/oauth2client" path="external/python/oauth2client" revision="02d18ad09f36019212e0fc342ca9f1563b62efe1" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/external/python/parse_type" path="external/python/parse_type" revision="3b83d2bbf7d5c035fae60ad20bcf85fbaf55b824" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/external/python/pyasn1" path="external/python/pyasn1" revision="a2a2211e999ff689d2a1fa11b89c5330bd9279f2" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/external/python/pyasn1-modules" path="external/python/pyasn1-modules" revision="94bce09cfaa114b3182ecac4e85eaf9d4e5af8dc" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/python/pybind11" path="external/python/pybind11" revision="85da470ae4893f8425fd406ef0635b1d8a7615dd" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/python/pycparser" path="external/python/pycparser" revision="dee39841b46ee90a30a49ae76f73d106ed49fc43" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/python/pyfakefs" path="external/python/pyfakefs" revision="bdcd7c74a67b95fb791e7a4a561b9d52fb71873d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/python/pyopenssl" path="external/python/pyopenssl" revision="93db1979ffb49a985612aa620751dfbc0364b5e4" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/external/python/rsa" path="external/python/rsa" revision="70615f0491ec1dafe7302d863a49b6714a01166b" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/external/python/setuptools" path="external/python/setuptools" revision="8071e9702a76e00784614c5e8b2a41cad067c57d" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/external/python/six" path="external/python/six" revision="3c3dcf66d38a890d514cee3af26918065b7a49af" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/external/python/uritemplates" path="external/python/uritemplates" revision="830eeb749d91cded576cac5b4732d8c3ed01953f" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rappor" path="external/rappor" revision="78b7807811112422a2ee4e684578f6e80f7116b8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/replicaisland" path="external/replicaisland" revision="f5e2eba7a1a4f1bcf2a9cd0ddc2aa3f7a3584b5b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rmi4utils" path="external/rmi4utils" revision="7df67699dd12c735d795b041983a7f2ac134c28a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rnnoise" path="external/rnnoise" revision="8bb5ddeee0d3a1736e245043538b32c92124efa2" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/external/robolectric-shadows" path="external/robolectric-shadows" revision="6c3c5b224f2b8e69642ec38c0c03bdb3bde6a052" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/roboto-fonts" path="external/roboto-fonts" revision="9cdb1e8c1f52c28b4b22ac23ffb62deb20e77c00" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rootdev" path="external/rootdev" revision="83ea168ed50e11192a101ffe1deba658247fef76" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/aho-corasick" path="external/rust/crates/aho-corasick" revision="4fa3c48a1f9a4f7dcd7a44c639eabca7d7b067c6" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/android_log-sys" path="external/rust/crates/android_log-sys" revision="0d0b5b7f1efc10f2f525a709eff2e3bcf6e8ca36" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/android_logger" path="external/rust/crates/android_logger" revision="b5d680ccbff60e2ae00bb50b8d34aad9b8412cac" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/anyhow" path="external/rust/crates/anyhow" revision="f8b20d96bedb02aa577138d25a9a2803e46e54a6" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/bindgen" path="external/rust/crates/bindgen" revision="df4bf953ba17f811f2d1e17012c0b727277b8735" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/bitflags" path="external/rust/crates/bitflags" revision="36d7307a9cff98e3378874daf8a2dc9b1bf72e5c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/bytes" path="external/rust/crates/bytes" revision="293e2aa580e5695f179507500738a4c8fc65ad82" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/cexpr" path="external/rust/crates/cexpr" revision="b03f87edd6b71e72952539b70c100790b2580778" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/cfg-if" path="external/rust/crates/cfg-if" revision="4e7fd597623e83322a5ac74f25b746cb9b4995bc" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/clang-sys" path="external/rust/crates/clang-sys" revision="8b9513ee470ed54bbb4d329556beb62de2038ee8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/clap" path="external/rust/crates/clap" revision="132998842e71c86fd9afc392d4e5a108527d5837" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/codespan-reporting" path="external/rust/crates/codespan-reporting" revision="688e0e8c1f55a91198d38c63a6f0ba1b55954fc1" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/env_logger" path="external/rust/crates/env_logger" revision="ba7afd98e996a8fb13f49f844f313da708d79f9f" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/futures" path="external/rust/crates/futures" revision="87830524ccdd9fabd37f04afabe386b74efb73f6" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/futures-channel" path="external/rust/crates/futures-channel" revision="8898e153d175946e3bffb269c7f9db5f15a47138" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/futures-core" path="external/rust/crates/futures-core" revision="a944bcbf53a3b7fb4782dba8b6a764285dd6589d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/futures-executor" path="external/rust/crates/futures-executor" revision="f1ae163e3aac7d4d0e3f96a4cf6cb7c1a146e809" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/futures-io" path="external/rust/crates/futures-io" revision="5107b8713fda3da90b5b8037e45a7415f806da87" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/futures-macro" path="external/rust/crates/futures-macro" revision="555ec8ac2c69ac3e1d91d5f9a3e2cf994156d3ad" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/futures-sink" path="external/rust/crates/futures-sink" revision="efbe0ef315eec2bc31ac4c0df842e4df723703f2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/futures-task" path="external/rust/crates/futures-task" revision="1807259c44d3a71845694f2edf3e60d65bc0ceec" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/futures-util" path="external/rust/crates/futures-util" revision="99abb8cc837693866fad4c3150edce0769a6eeaa" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/getrandom" path="external/rust/crates/getrandom" revision="70255fc360c4b3b860bbe92f877fe2a67c1ce7f7" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/glob" path="external/rust/crates/glob" revision="12de8ffacea759b2b8058bd52edf99b3bd289860" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/heck" path="external/rust/crates/heck" revision="756195ff099c82ce5c492ae4a201cb1d2ca24001" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/lazy_static" path="external/rust/crates/lazy_static" revision="015d938bc04f7a9d1524099399931a5bb7c9a1cf" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/lazycell" path="external/rust/crates/lazycell" revision="c2da9b8c19fae2731e052f8c4bbda9ad12452457" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/libc" path="external/rust/crates/libc" revision="8af8f151e12e72f9a3c258be6a610d19152c2012" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/libloading" path="external/rust/crates/libloading" revision="e1a834747d201648e0e7e667194dfa0e98c9bed7" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/log" path="external/rust/crates/log" revision="029e59774024f812e8cd01728602f1525df0ccb0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/memchr" path="external/rust/crates/memchr" revision="5497646d768e921000165192435e6280ad7f6e57" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/nom" path="external/rust/crates/nom" revision="ceefd8bbe3d7a06f3dc31e20c852fac4ef779075" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/once_cell" path="external/rust/crates/once_cell" revision="517fe9d8bb8400e7514ff3feb6fe8f451c7768a4" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/paste" path="external/rust/crates/paste" revision="d256e487b415463d517809c52c78528e5d5ae036" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/paste-impl" path="external/rust/crates/paste-impl" revision="bf6b626f909af873c77c156dafd592512a1f18a2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/peeking_take_while" path="external/rust/crates/peeking_take_while" revision="1f1191e14fdddfa4ff77d28c8ba7e514e1a03ecd" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/pin-project" path="external/rust/crates/pin-project" revision="d58366dc4a1a1ec807bb02dfc7928051799130ac" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/pin-project-internal" path="external/rust/crates/pin-project-internal" revision="a51d04878ac35e4e06f4105946b6cce5ae6982fd" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/pin-utils" path="external/rust/crates/pin-utils" revision="8f8d97660e7300820833546bfda156898289450c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/ppv-lite86" path="external/rust/crates/ppv-lite86" revision="8ab91e39f7b5eece97d349c8aec5b61e663dc98b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/proc-macro-error" path="external/rust/crates/proc-macro-error" revision="8ab15242e42ee06d8a0aaaff607242991cb1b54d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/proc-macro-error-attr" path="external/rust/crates/proc-macro-error-attr" revision="ac95cb0a6af88e4ce1e66d2bdcf864dad34f690c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/proc-macro-hack" path="external/rust/crates/proc-macro-hack" revision="f490e91415e81a1ead338b38bd50fbcb6387eb43" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/proc-macro-nested" path="external/rust/crates/proc-macro-nested" revision="ad0828c13210a3590d3e47b6de85170da5708fdc" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/proc-macro2" path="external/rust/crates/proc-macro2" revision="90eb24c97beb718b5b23ee0b6f96662982b3302c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/protobuf" path="external/rust/crates/protobuf" revision="52aa785a3abad9e9579c742b86b06ce91b5dc226" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/protobuf-codegen" path="external/rust/crates/protobuf-codegen" revision="35dedf6a776ce77be6026b45a88fc3710c2209a0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/quote" path="external/rust/crates/quote" revision="d1061a6f15d42da3938bd97a00c4b9d285b9aacf" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/rand" path="external/rust/crates/rand" revision="bb9a33484a8c7390c8f63b2a896b174c8e37c2f4" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/rand_chacha" path="external/rust/crates/rand_chacha" revision="dfcb59bec0732c233b0a7e3b69506f26fbfc8187" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/rand_core" path="external/rust/crates/rand_core" revision="3f5054f5e12dba706096a1180698ab9c272cdda8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/regex" path="external/rust/crates/regex" revision="2e48ab032f10a80931d56abd07616d1b87d2a0e0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/regex-syntax" path="external/rust/crates/regex-syntax" revision="45fef2cd78769c4fcd25576994411246ba5cc275" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/remain" path="external/rust/crates/remain" revision="ec82257245980c58c38039f1d16cbb57be860442" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/rustc-hash" path="external/rust/crates/rustc-hash" revision="ad1f4a661c4e7ce9a4ce6916c4ee999085bbb69b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/shlex" path="external/rust/crates/shlex" revision="25207b9171391d5b7cb8b99d186845e8aaa95a9f" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/slab" path="external/rust/crates/slab" revision="5f8545e2164d5dbaf0dde5b12cbd3ae5dd16e445" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/structopt" path="external/rust/crates/structopt" revision="2058213ca37c983e5e7fe964169f1a19972c0365" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/structopt-derive" path="external/rust/crates/structopt-derive" revision="57375dc9e27174a363681039706665d38d551cd6" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/syn" path="external/rust/crates/syn" revision="c7557ca9511ab1128a51d6f3217201394084125a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/syn-mid" path="external/rust/crates/syn-mid" revision="291c13bec19fdb24a56de517c1aa64efce21fd74" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/termcolor" path="external/rust/crates/termcolor" revision="09efe54441095b2523fcf42fb72ffa678c183869" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/textwrap" path="external/rust/crates/textwrap" revision="32c95abc5aa5dd6b284630f8d6e7eee5b8cf0213" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/thiserror" path="external/rust/crates/thiserror" revision="47490e9cd78ff6e3fba2cd8df2b15ba535925be7" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/thiserror-impl" path="external/rust/crates/thiserror-impl" revision="88e26aa7877e36759e95bd6d001b8016fb820248" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/thread_local" path="external/rust/crates/thread_local" revision="f9dadd41ff646d10e372ba4b993fe5979e3ca1a0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/unicode-segmentation" path="external/rust/crates/unicode-segmentation" revision="a863f6773e9e44dfd7ee1d1875d4218016131cbc" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/unicode-width" path="external/rust/crates/unicode-width" revision="085eaa2d16aebcbab96208ad4116278944de7c4d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/unicode-xid" path="external/rust/crates/unicode-xid" revision="fed503e5e9b6c600a7b625e1d9ba60ad201b37b6" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/crates/which" path="external/rust/crates/which" revision="8b6eb89f36d32d6c35dea1710c284856b67b9293" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/rust/cxx" path="external/rust/cxx" revision="c46c875e902c1216836408be7e4abad616f886ca" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/external/scapy" path="external/scapy" revision="1c94e2d5bb85cb4902bb1e3a5795e86999525b97" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/scrypt" path="external/scrypt" revision="4436f99cac9d4626e465260e8aad6a0ff8aed2cf" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/scudo" path="external/scudo" revision="6fbf5f1b02ecd304771dc42f61b96e119a727ef4" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/seccomp-tests" path="external/seccomp-tests" revision="1e1986f0dbd1790d142cdae476e08bbaf108869c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/selinux" path="external/selinux" revision="468cc0e9906b0c51acaa4642534fb7b06d0f3e1e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/setupcompat" path="external/setupcompat" revision="4a6e4e804f30dfac6c250685a3453e8fb5c2ee32" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/setupdesign" path="external/setupdesign" revision="ca77fb97d2f18998cc1a6875165b8ada6d697800" upstream="master"/>
+  <project dest-branch="master" groups="pdk,qcom_msm8x26" name="platform/external/sfntly" path="external/sfntly" revision="fffe41ea62e1d28dae7d246453706700bb8cf894" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/shaderc/spirv-headers" path="external/shaderc/spirv-headers" revision="b8530f4af8fa45712a2c869b0ebb81f2c5be0969" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/shflags" path="external/shflags" revision="3dac286b93162f3ea66f52c2f4dd094c87fd755b" upstream="master"/>
+  <project dest-branch="master" groups="pdk,qcom_msm8x26" name="platform/external/skia" path="external/skia" revision="efdb3fb8a591beabdea4aa9240b3a6c9e10567c4" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="cts" name="platform/external/skqp" path="external/skqp" revision="25bec16283807e794c3425dcad8ee81c669faa6b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/sl4a" path="external/sl4a" revision="e68776ccc6a32da8806b30eb8fe26465c7d580e9" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/slf4j" path="external/slf4j" revision="ba26eda702513d3c4594b9a3e8ea71849dd7de86" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/smali" path="external/smali" revision="2da1720fb501e38495e342882f83bdafdf9ec812" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/snakeyaml" path="external/snakeyaml" revision="ae7416a6fc1e45582e78e9612e328bae92466ec9" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/sonic" path="external/sonic" revision="6cfc159731330085acf6744093aea30e208762ea" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/sonivox" path="external/sonivox" revision="e700ed155e181c19ae6cf7c0333ba2c12e795207" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/speex" path="external/speex" revision="3621ece4451055ee97c5d56f9ca35ef06d3d092a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/sqlite" path="external/sqlite" revision="fac00184473f1d8553eb527c0eade2c4060c40b6" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/squashfs-tools" path="external/squashfs-tools" revision="b27e9296bdf70d85b02af711d93c11ec85b8522c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/strace" path="external/strace" revision="e862cfa113f17f40b911c8e58b3babbb98e67263" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/stressapptest" path="external/stressapptest" revision="4ac7a2a986e54029c100630c61e91e7edb4f8948" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/external/subsampling-scale-image-view" path="external/subsampling-scale-image-view" revision="ba09fe21ff5114f27aae1e5476dce9cf11530f46" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/swiftshader" path="external/swiftshader" revision="770764a21333107567a8022bbb025c623ef94dfd" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/tagsoup" path="external/tagsoup" revision="8d79f4b5dead5a59c57a8b0604f0fcc294ce6886" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/tcpdump" path="external/tcpdump" revision="01e0162be7fddf789e79e05a3312fc9b7f2ebe52" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/tensorflow" path="external/tensorflow" revision="238eeca9461f65010b19e176c0eab98176498598" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/testng" path="external/testng" revision="be3ab79b9188e8168fa95f94ab80e7a6fd39fbaf" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/tinyalsa" path="external/tinyalsa" revision="17dbe121ba3113b5868a68373360f700f9fe9241" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/tinycompress" path="external/tinycompress" revision="f7b937d32da1e4486c68893f0b0bda4f69b2b41a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/tinyxml" path="external/tinyxml" revision="74d07fafdc71a85d30f57c24bec44a51b8d6b1ad" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/tinyxml2" path="external/tinyxml2" revision="0ad38bb14c0bea2bcfda371bdceb5627350e417e" upstream="master"/>
+  <project dest-branch="master" name="platform/external/toolchain-utils" path="external/toolchain-utils" revision="b8e15db27661a92ec12ae2af66bc6987929c87f8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/toybox" path="external/toybox" revision="ea2cddf6e87e3d97f2784114abe9ba14029d1ef6" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/tpm2-tss" path="external/tpm2-tss" revision="13b6223a586bc61841018c824cfba6fd99fc9071" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/tremolo" path="external/tremolo" revision="98a36dee8ee933b4e9287994b8a321d4f166328c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/turbine" path="external/turbine" revision="b4330c4fd8d6e2d0c996d61561bbda575f8ec362" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/u-boot" path="external/u-boot" revision="9a7fc96d202d97176325e1cdc1e122187a08350d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/ukey2" path="external/ukey2" revision="85debd146d63e58dfefea5b5392d7b988ee8149d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/unicode" path="external/unicode" revision="14a6c6a89cd98d7946b087cac82307e22fc5f810" upstream="master"/>
+  <project dest-branch="master" name="platform/external/universal-tween-engine" path="external/universal-tween-engine" revision="b2ad896a29d685f14252f1cea90304d98cf1151e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/usrsctp" path="external/usrsctp" revision="398ff28110c4976eae10c44f68803b0a0e8c014d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/v4l2_codec2" path="external/v4l2_codec2" revision="c4a6d6e39e36512179235a2f66cd240632f82e19" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/v8" path="external/v8" revision="a84742873671f2586071ee1a2b54147f43c82ae2" upstream="master"/>
+  <project dest-branch="master" groups="vboot,pdk-fs" name="platform/external/vboot_reference" path="external/vboot_reference" revision="b6b998eb942028c70e5baa7300f9a924e3912bcf" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/virglrenderer" path="external/virglrenderer" revision="4c605a07e2d30e225cc908b48596e10450dea979" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/vixl" path="external/vixl" revision="54f58fb13dade10ffabdc72415cee5d4a746c017" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/vogar" path="external/vogar" revision="6e3ba4530367dcbff5392952b8e487090cd58b40" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/volley" path="external/volley" revision="c60e1cfe5bae249f520b5a4fca35e4f9155198c1" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/vulkan-headers" path="external/vulkan-headers" revision="9cb71ab35167cbd3f2d744835352eedab9fd4091" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/vulkan-validation-layers" path="external/vulkan-validation-layers" revision="28f8a95f08b8aa4a9f4ccad4096736b50e283473" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/walt" path="external/walt" revision="b45616374afe02fc04da21636503d034c9c8c8dc" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/wayland" path="external/wayland" revision="347c7cd153ed6547eb3a54956e9b7d2bdb96228a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/wayland-protocols" path="external/wayland-protocols" revision="6a3453e2cc730e7a36a152ef811dc5aa4a05f394" upstream="master"/>
+  <project dest-branch="master" groups="pdk,qcom_msm8x26" name="platform/external/webp" path="external/webp" revision="e1bc8b4508110e89aee708f04af91ce5421fb4cb" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/webrtc" path="external/webrtc" revision="f92ec5a27c2401e445679e6ff47ba58d41e99ed7" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/wpa_supplicant_8" path="external/wpa_supplicant_8" revision="2ecf09724e23a3c8d96a2c64e92cf9d826ce9b63" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/wycheproof" path="external/wycheproof" revision="8a6152b03aac5cccb92cc88fd9af6e2b739b96c8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/xmp_toolkit" path="external/xmp_toolkit" revision="4eafdf35a193cd3068bf77d8d00038be1d9b39b2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/xz-embedded" path="external/xz-embedded" revision="ff3dce8e7f46fa2283e15f8048caa4b00f45d896" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/xz-java" path="external/xz-java" revision="bd7892bb8927360cd34805bc332039154a2110e0" upstream="master"/>
+  <project dest-branch="master" groups="vts,projectarch,pdk" name="platform/external/yapf" path="external/yapf" revision="10b199108ab23e5658c35197164c6bec93352070" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/zlib" path="external/zlib" revision="28320305b90e717b351c5538358a840ec3620bc0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/zopfli" path="external/zopfli" revision="b481a8f686da1cb148ff09eb10ca02198c6bdb49" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/zstd" path="external/zstd" revision="da821d773bfbad63841ecf7a765d56d19acfe47d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/external/zxing" path="external/zxing" revision="dcb3fa2622a5aab0fc99fcf044e6ec64131ee4fc" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/frameworks/av" path="frameworks/av" revision="3fd4dee8960cd6bccbb21227d43dfef839d33875" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/base" path="frameworks/base" revision="da4dc882af417f4564144fbcdb67e98dc17adbc7" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/frameworks/compile/libbcc" path="frameworks/compile/libbcc" revision="b9dd85106656d969dd2227be1eefa1d190988781" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/frameworks/compile/mclinker" path="frameworks/compile/mclinker" revision="da5dd7a6e1abc232e01b6c5d3210bcf040027c9f" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/frameworks/compile/slang" path="frameworks/compile/slang" revision="2ca80320839b85cae89313da524211c001c9006f" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/ex" path="frameworks/ex" revision="d535f66f7e026f0bb19aaa39b91d83e05bd4b0ff" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/frameworks/hardware/interfaces" path="frameworks/hardware/interfaces" revision="5afdf463e2e4cf1edc728e71644ead58ebf6269a" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/layoutlib" path="frameworks/layoutlib" revision="67c869948535f0f49a2ce16c6d7f3a5b173b91e5" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/frameworks/libs/native_bridge_support" path="frameworks/libs/native_bridge_support" revision="3414fdb1c586f30b8a6cd6517323c6eac943eb43" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/libs/net" path="frameworks/libs/net" revision="5e80310c267296ea12816564188d8b45a261d0aa" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/minikin" path="frameworks/minikin" revision="485f24291298efd5cecf5c0a9898a35ba241e0b0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/frameworks/ml" path="frameworks/ml" revision="b202a995ad94a5a1466883748c92bfe8d258298f" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/multidex" path="frameworks/multidex" revision="70cd958708d114be38febd015485f582f1165bee" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/frameworks/native" path="frameworks/native" revision="2054ee3feeacf53c10e428b6515992d3cf26e481" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/frameworks/opt/bitmap" path="frameworks/opt/bitmap" revision="e9850af1278e499e427d08dbf40244f3622bd6db" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/calendar" path="frameworks/opt/calendar" revision="1aea8315ebe9cca6e9462ab02e9f4caf20c8cd58" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/frameworks/opt/car/services" path="frameworks/opt/car/services" revision="e01e933a67ce40bdb266b4cf2c6a63036132958a" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/frameworks/opt/car/setupwizard" path="frameworks/opt/car/setupwizard" revision="c8268620f9d220c573ae3de3bf3b5f5a95fd38fd" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/chips" path="frameworks/opt/chips" revision="e337b2037dda34bb2a2c98d01c8b6ea18cc8179a" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/colorpicker" path="frameworks/opt/colorpicker" revision="e3c6e799edbff3f633f03f0f0f394a74b2065d36" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/frameworks/opt/net/ethernet" path="frameworks/opt/net/ethernet" revision="67c1ef1f1ff26cbf02dbb880ab7d27f06f7188cb" upstream="master"/>
+  <project dest-branch="master" groups="frameworks_ims,pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/net/ims" path="frameworks/opt/net/ims" revision="c41c0c299c0d3c538a72af04c044bbf079ae6dd0" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/net/voip" path="frameworks/opt/net/voip" revision="9d0f1c35dfa4b56d7a74dc8748790205f58626bc" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/frameworks/opt/net/wifi" path="frameworks/opt/net/wifi" revision="a13ac6cba7bee14cf4f81a5e0d400585930e44d4" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/photoviewer" path="frameworks/opt/photoviewer" revision="c250535f2ec9716d9bd3bccd6cc87dd2fa309277" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/setupwizard" path="frameworks/opt/setupwizard" revision="481c220b0b15b5ab5808e4f0d648333c9b772307" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/frameworks/opt/telephony" path="frameworks/opt/telephony" revision="54914a51c98a94e528d5f7d083b351c343ee2e32" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/timezonepicker" path="frameworks/opt/timezonepicker" revision="3b85bbb68431e734ea266499053661f1c7734564" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/opt/vcard" path="frameworks/opt/vcard" revision="d2dde212b349a1088ad9a4f064f3c7fca50f62f3" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/frameworks/rs" path="frameworks/rs" revision="c165403fe039b144d9fa666b5e957eb1d4098590" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/frameworks/wilhelm" path="frameworks/wilhelm" revision="9f3a699ded133cc94390c365ec91a409291860e5" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/hardware/broadcom/libbt" path="hardware/broadcom/libbt" revision="33ab16ebcd5f6e434ff0f5479367ef76db3bac1e" upstream="master"/>
+  <project dest-branch="master" groups="pdk,broadcom_wlan" name="platform/hardware/broadcom/wlan" path="hardware/broadcom/wlan" revision="ef6b231056bb1bdcea293429c939d6c4396714f0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/hardware/google/apf" path="hardware/google/apf" revision="82f4e345aef14aafec68cc40fbd8dc7dce50b852" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/hardware/google/av" path="hardware/google/av" revision="fdebb8f14e38395fdce40be9c917beab42aea42c" upstream="master"/>
+  <project dest-branch="master" groups="pdk,easel" name="platform/hardware/google/easel" path="hardware/google/easel" revision="792d8b327c17c8581d1ea0a3a9a1eaf128c19788" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/hardware/google/interfaces" path="hardware/google/interfaces" revision="b1e4020a6a53e9face5bd93bc89ae59c98803bab" upstream="master"/>
+  <project dest-branch="master" groups="generic_fs,pixel" name="platform/hardware/google/pixel" path="hardware/google/pixel" revision="7a489f84aba93b2f6da99afabd6554045f6252bd" upstream="master"/>
+  <project dest-branch="master" groups="generic_fs,pixel" name="platform/hardware/google/pixel-sepolicy" path="hardware/google/pixel-sepolicy" revision="a3af99c63f21e27cba689f811c15c2b10f638fea" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/hardware/interfaces" path="hardware/interfaces" revision="96f358efda7654650ae347ae3a954059ae1175ed" upstream="master"/>
+  <project dest-branch="master" groups="invensense,pdk" name="platform/hardware/invensense" path="hardware/invensense" revision="52e51c22ac7e111fad6e6e8e175bfe0e486f4979" upstream="master"/>
+  <project dest-branch="master" groups="coral" name="platform/hardware/knowles/athletico/sound_trigger_hal" path="hardware/knowles/athletico/sound_trigger_hal" revision="ff09cebd77687bd1ab64c2e0eeeeabcabbe6b4c4" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/hardware/libhardware" path="hardware/libhardware" revision="bbdbd7856af12fd3bc063225fa364510d8608ea0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/hardware/libhardware_legacy" path="hardware/libhardware_legacy" revision="a44935a15e3d239d5c692d7de3118fea290ceac9" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/hardware/nxp/nfc" path="hardware/nxp/nfc" revision="c3e97676d6db769b773fb8c85051f55a1aaa8537" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/hardware/nxp/secure_element" path="hardware/nxp/secure_element" revision="f431470d1a2677bac9e30aba0773a3c6cee46658" upstream="master"/>
+  <project dest-branch="master" groups="qcom,qcom_audio,pdk-qcom" name="platform/hardware/qcom/audio" path="hardware/qcom/audio" revision="c14a73d03387afc939988f2874648bdf491e2884" upstream="master"/>
+  <project dest-branch="master" groups="pdk-qcom" name="platform/hardware/qcom/bootctrl" path="hardware/qcom/bootctrl" revision="2151057a4c74e8465b64c45ad5878f0b0ae62159" upstream="master"/>
+  <project dest-branch="master" groups="qcom,pdk-qcom" name="platform/hardware/qcom/bt" path="hardware/qcom/bt" revision="42cbe7d5ea1fa264fd375033f77f99e5e21768f6" upstream="master"/>
+  <project dest-branch="master" groups="qcom_camera,pdk-qcom" name="platform/hardware/qcom/camera" path="hardware/qcom/camera" revision="3e6a4459d0d8fbae17cc1b5510dc08238435c70e" upstream="master"/>
+  <project dest-branch="master" groups="qcom,pdk-qcom" name="platform/hardware/qcom/data/ipacfg-mgr" path="hardware/qcom/data/ipacfg-mgr" revision="f66ff27d7fff545d48dd2d584d9e8bee5f3bfa25" upstream="master"/>
+  <project dest-branch="master" groups="pdk-qcom,qcom,qcom_display" name="platform/hardware/qcom/display" path="hardware/qcom/display" revision="427cda410f238ff6e31aac0c9f300e5315d5bd52" upstream="master"/>
+  <project dest-branch="master" groups="qcom,qcom_gps,pdk-qcom" name="platform/hardware/qcom/gps" path="hardware/qcom/gps" revision="75acba49ec2f1f1a08f1de96d8842c43986935ee" upstream="master"/>
+  <project dest-branch="master" groups="qcom,qcom_keymaster,pdk-qcom" name="platform/hardware/qcom/keymaster" path="hardware/qcom/keymaster" revision="5b3b21c6fbc3ec9ca185e913ea1e9cb5c597fe30" upstream="master"/>
+  <project dest-branch="master" groups="qcom,pdk-qcom" name="platform/hardware/qcom/media" path="hardware/qcom/media" revision="5a55889bc09d9972e188287e60f1f8f616c09d1b" upstream="master"/>
+  <project dest-branch="master" groups="qcom_msm8960,pdk-qcom" name="platform/hardware/qcom/msm8960" path="hardware/qcom/msm8960" revision="2aa4e417ed24fcbfcb213323aa8dd3884d66a763" upstream="master"/>
+  <project dest-branch="master" groups="qcom_msm8994,pdk-qcom" name="platform/hardware/qcom/msm8994" path="hardware/qcom/msm8994" revision="ebe7f25619aebac5bf434efc6734e1536f7deb71" upstream="master"/>
+  <project dest-branch="master" groups="qcom_msm8996,pdk-qcom" name="platform/hardware/qcom/msm8996" path="hardware/qcom/msm8996" revision="cc08ad088854b7685b4122a025a62a75d09fb63d" upstream="master"/>
+  <project dest-branch="master" groups="qcom_msm8998,pdk-qcom" name="platform/hardware/qcom/msm8998" path="hardware/qcom/msm8998" revision="f4ee2902784a367223762fa4634274d4ca8e6adf" upstream="master"/>
+  <project dest-branch="master" groups="qcom_msm8x09" name="platform/hardware/qcom/msm8x09" path="hardware/qcom/msm8x09" revision="08163b9a53a33f6f11cc4528ebf23000b36a4505" upstream="master"/>
+  <project dest-branch="master" groups="qcom_msm8x26,pdk-qcom" name="platform/hardware/qcom/msm8x26" path="hardware/qcom/msm8x26" revision="17396438c3fb92a679cbf5987fdd1c3c283cace4" upstream="master"/>
+  <project dest-branch="master" groups="qcom_msm8x27,pdk-qcom" name="platform/hardware/qcom/msm8x27" path="hardware/qcom/msm8x27" revision="b4ac8a86e484a558fda8bc56a0af544b8d170bd5" upstream="master"/>
+  <project dest-branch="master" groups="qcom_msm8x84,pdk-qcom" name="platform/hardware/qcom/msm8x84" path="hardware/qcom/msm8x84" revision="90c998820b637a145f39ae0af8436876c1dc2e41" upstream="master"/>
+  <project dest-branch="master" groups="wahoo" name="platform/hardware/qcom/neuralnetworks/hvxservice" path="hardware/qcom/neuralnetworks/hvxservice" revision="6b303dd7f406808bb4f9eb731011495c3e4a4769" upstream="master"/>
+  <project dest-branch="master" groups="qcom,pdk-qcom" name="platform/hardware/qcom/power" path="hardware/qcom/power" revision="65a28615fce48a8518aa10d840d59b32410b3fb3" upstream="master"/>
+  <project dest-branch="master" groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/bt" path="hardware/qcom/sdm845/bt" revision="dfbc3ec5fcf4d576ceff7c9e891452b0d55b6865" upstream="master"/>
+  <project dest-branch="master" groups="generic_fs,vendor,qcom_sdm845" name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" path="hardware/qcom/sdm845/data/ipacfg-mgr" revision="071154a6932222f0c06c9aecc59b20528e10ef85" upstream="master">
     <linkfile dest="hardware/qcom/sdm845/Android.mk" src="os_pickup.mk"/>
     <linkfile dest="hardware/qcom/sdm845/Android.bp" src="os_pickup.bp"/>
   </project>
-  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/display" path="hardware/qcom/sdm845/display" revision="fed335836c01838cdb8b1344d2ca9579978ec2bd" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/gps" path="hardware/qcom/sdm845/gps" revision="2175c408dc60a6cf22a869b3829d8d0ba6cf957d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/media" path="hardware/qcom/sdm845/media" revision="507841ed486153fd14cbc1f4a9a6ffad12385254" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/thermal" path="hardware/qcom/sdm845/thermal" revision="5c1c45ebedbce6edc86159b4e97d980759552285" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/vr" path="hardware/qcom/sdm845/vr" revision="0e06489f538d99656ba2594d1d1aa6f24ba825f4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/data/ipacfg-mgr" path="hardware/qcom/sm8150/data/ipacfg-mgr" revision="5c50b64f697d7ac4661cd5f69ccc5186eb3a25d0" upstream="refs/tags/android-r-preview-2">
+  <project dest-branch="master" groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/display" path="hardware/qcom/sdm845/display" revision="f671eefd766c4e60b20b9aa41524ee6b4cae269b" upstream="master"/>
+  <project dest-branch="master" groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/gps" path="hardware/qcom/sdm845/gps" revision="7cc48ad849b5d4fe06248f7b87c7994337af9ebf" upstream="master"/>
+  <project dest-branch="master" groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/media" path="hardware/qcom/sdm845/media" revision="d5ea805862a31ad5fc2afe0763c2f5965afb3738" upstream="master"/>
+  <project dest-branch="master" groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/thermal" path="hardware/qcom/sdm845/thermal" revision="069704a519fa98f9f1be9736bce8d528bf72e7ff" upstream="master"/>
+  <project dest-branch="master" groups="generic_fs,qcom_sdm845" name="platform/hardware/qcom/sdm845/vr" path="hardware/qcom/sdm845/vr" revision="1e564be447be00e064191557dfa5b46ecbfbf86f" upstream="master"/>
+  <project dest-branch="master" groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/data/ipacfg-mgr" path="hardware/qcom/sm8150/data/ipacfg-mgr" revision="d278ff3f28f011ee40dd60caac3a2e487f6e8e95" upstream="master">
     <linkfile dest="hardware/qcom/sm8150/Android.mk" src="os_pickup.mk"/>
     <linkfile dest="hardware/qcom/sm8150/Android.bp" src="os_pickup.bp"/>
   </project>
-  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/display" path="hardware/qcom/sm8150/display" revision="c81971c53ae7f375919de20a9562d568aa2ba02d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/gps" path="hardware/qcom/sm8150/gps" revision="84f7ef4712ea508a15bb5a725bd4d2d7dc80f8df" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/media" path="hardware/qcom/sm8150/media" revision="4aa3dcb2b9000c4b1414aeee80b65a6c8b62b7e9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/thermal" path="hardware/qcom/sm8150/thermal" revision="015a5444dae8fed21ebbc23878c5c460ab10ee45" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/vr" path="hardware/qcom/sm8150/vr" revision="83c0155ec713872c7096a7610683e0c99e1f9803" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="qcom_wlan,pdk-qcom" name="platform/hardware/qcom/wlan" path="hardware/qcom/wlan" revision="db4bd178589558fdf63c7ce52b754c7219568d82" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/hardware/ril" path="hardware/ril" revision="1f9ebb19717e5a1d2dee987ed0edf62b00967cc9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/hardware/st/nfc" path="hardware/st/nfc" revision="e66bed746f3d685cb3df9cfc61beec5ed9b35080" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/hardware/st/secure_element" path="hardware/st/secure_element" revision="7efa833cdaf48eebccefc174ace67756e82e050f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/hardware/ti/am57x" path="hardware/ti/am57x" revision="2fb5135b44a11ea3b586d7cbf1d6bb99940c6044" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/libcore" path="libcore" revision="66083558ed9321e68afda9d91f4f1e8a714e617f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/libnativehelper" path="libnativehelper" revision="209c218d24857894cd28f9b5a29c7b047a7fb4f3" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/BasicSmsReceiver" path="packages/apps/BasicSmsReceiver" revision="eba2cfeb735825fd433cedf46b5c15913ab58543" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/Bluetooth" path="packages/apps/Bluetooth" revision="1a78b17f01e3d2e918c8e95bd918050f0fe096e9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Browser2" path="packages/apps/Browser2" revision="37652f79d1a115bc2d920a68ad6846a23107c660" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Calendar" path="packages/apps/Calendar" revision="dba170b33f5e5b607bd2d98b3f5bbda9bb68ad0e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Camera2" path="packages/apps/Camera2" revision="1eecb545d05126c250a686227ca0d10b8ef20e22" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Cluster" path="packages/apps/Car/Cluster" revision="201a0667b38db0ef2c09bf1dac216d5983501898" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Dialer" path="packages/apps/Car/Dialer" revision="531786268d2800ebb4e476a33109e32835a99b2d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Hvac" path="packages/apps/Car/Hvac" revision="383d6caa20abadef0810676685e952af7a3ef1a9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/LatinIME" path="packages/apps/Car/LatinIME" revision="3cf79c7e126dcc52a99ea6f2932717d6917df665" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Launcher" path="packages/apps/Car/Launcher" revision="c1b369808c4fa5101ab7f66447fbcaa2ff893e46" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/LensPicker" path="packages/apps/Car/LensPicker" revision="577467677743ead552d45ec88688e14ac2c11066" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/LinkViewer" path="packages/apps/Car/LinkViewer" revision="f21549ef464c73d389e70fffd49568be4045d1aa" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/LocalMediaPlayer" path="packages/apps/Car/LocalMediaPlayer" revision="2c0d6f6e6615cffd5a386e04929de9433bb4ab8e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Media" path="packages/apps/Car/Media" revision="949f991f36c8ef12d582f4efc57e83bb7e20d00d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Messenger" path="packages/apps/Car/Messenger" revision="119d567a09ed591a08036f670684afe62834ee1c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Notification" path="packages/apps/Car/Notification" revision="b6b77ef7b1828eed7ebf6219f5270f29b3c1626a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Overview" path="packages/apps/Car/Overview" revision="18069cf7b505946bdf5d1eb3566c7c8f201b1b9d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Radio" path="packages/apps/Car/Radio" revision="09bd54bc606d7a8545a713e4531dded9ed7f96aa" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Settings" path="packages/apps/Car/Settings" revision="08b430cd07bd36b8d6088347bc3a98b66394f1a2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/Stream" path="packages/apps/Car/Stream" revision="65fcbceb6cadefcd715b7b61c0d08c8279408343" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/SystemUpdater" path="packages/apps/Car/SystemUpdater" revision="ad64abe7c7ada0deca3d861a68d72ca770b333ff" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/libs" path="packages/apps/Car/libs" revision="b060f81aa18c7a86df6e0372d476eba0837c8c2f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Car/tests" path="packages/apps/Car/tests" revision="614c639c73544813d59ee0490a2b934cae7210b5" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/CarrierConfig" path="packages/apps/CarrierConfig" revision="11cd811e5440615bd94b5f633b545c540a64e8a2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/CellBroadcastReceiver" path="packages/apps/CellBroadcastReceiver" revision="5582bbbad446f36039d0590b35dbacb35e03d2ad" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/CertInstaller" path="packages/apps/CertInstaller" revision="dc69e17d4f15525c8ba3d3edfef8446139e7c7fd" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Contacts" path="packages/apps/Contacts" revision="6b25dfb8823b9a702c168bcaa5f819b00f6af030" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/DeskClock" path="packages/apps/DeskClock" revision="81665216b1b4332dff01cd0639aaa7a827942e0b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/packages/apps/DevCamera" path="packages/apps/DevCamera" revision="451c252993bad8bda17ae8e9224b863eca7e4668" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Dialer" path="packages/apps/Dialer" revision="9cbdb82e0d061084cc9c6cf8e80768711350a541" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/DocumentsUI" path="packages/apps/DocumentsUI" revision="c4d16b31985ceea7ea4a2b6511050b62b9d3aae0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/EmergencyInfo" path="packages/apps/EmergencyInfo" revision="3cca84dff99da9b8fcfad5d3edecd33131b2a2d8" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Gallery" path="packages/apps/Gallery" revision="391d25e4a27dd73f38a5bc20d96717360e09626f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Gallery2" path="packages/apps/Gallery2" revision="dd8c3a44c794023394750778a0b9287dd281f220" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/HTMLViewer" path="packages/apps/HTMLViewer" revision="10a42cbd4d9993c7da4cbe15c2f20e7e145e8b3b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/KeyChain" path="packages/apps/KeyChain" revision="7704eee9d1604a25d3bfab2c2cb14f17e7ff8226" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Launcher3" path="packages/apps/Launcher3" revision="83fce3a3c634fd6dd9cc6aaedd30fbb14f713e18" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/LegacyCamera" path="packages/apps/LegacyCamera" revision="8a3c835ccadf8e1978f0b87cdfd86d3c5c73040b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/ManagedProvisioning" path="packages/apps/ManagedProvisioning" revision="189515d52354cb72336c3e3d1d709f041c350e2d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Messaging" path="packages/apps/Messaging" revision="f19e916a0d4ffd95e36c5203f5e04887e47a087e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Music" path="packages/apps/Music" revision="17f7086ed297f7b067571cd1ba4cee042f4b8d44" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/MusicFX" path="packages/apps/MusicFX" revision="c7ce7324e34c37f10d68563eaf28057185ae4487" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="apps_nfc,pdk-fs" name="platform/packages/apps/Nfc" path="packages/apps/Nfc" revision="3338647f4bd90bda21f14b918c7dd6dc3b0f8f5c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/OneTimeInitializer" path="packages/apps/OneTimeInitializer" revision="737b0d2daabf33a458ed754e045b2f0e2b65da70" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/PackageInstaller" path="packages/apps/PermissionController" revision="8ccc0d9973bf7173f4da21b62a9f6f0f3ecef582" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/PhoneCommon" path="packages/apps/PhoneCommon" revision="55752cad3b0b8694d3ff3fd312a7e3ca7c7803a8" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Protips" path="packages/apps/Protips" revision="277f2db1a9099d5aaf96d4f3ca8daaeeeeef4e6f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Provision" path="packages/apps/Provision" revision="7623fb5bc7c81b6b1f4d0ac498a256b31ca3988a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/QuickSearchBox" path="packages/apps/QuickSearchBox" revision="5fd7ab4b450b89cd2322949f52866f6fef70a884" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/SafetyRegulatoryInfo" path="packages/apps/SafetyRegulatoryInfo" revision="ee11b572bcdbcaaae96c32bafc0fd5b3122ddb90" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/SampleLocationAttribution" path="packages/apps/SampleLocationAttribution" revision="414210769cbe3ab244ec4af9eef1648e4933f863" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="apps_se,pdk-fs" name="platform/packages/apps/SecureElement" path="packages/apps/SecureElement" revision="d87a6d2ea638759849ad7b7da12ae79664c9f054" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Settings" path="packages/apps/Settings" revision="177ce8f0171d21067af478d8ece9c510ad4f9dc1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/SettingsIntelligence" path="packages/apps/SettingsIntelligence" revision="093fef6b5cdff666c92c9a3cad7a79408c2499c9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/SoundRecorder" path="packages/apps/SoundRecorder" revision="9a077af94ced8144ec87ec758c378da9b30274fa" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/SpareParts" path="packages/apps/SpareParts" revision="f3d46ceeecd71c5555939f32643c18c78ae7909f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="apps_stk,pdk-fs" name="platform/packages/apps/Stk" path="packages/apps/Stk" revision="d5ecab587493e3ca973f733bbd43437fffae373c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/StorageManager" path="packages/apps/StorageManager" revision="02a1b39c931f6dcba726e958828b7c634b87a914" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/packages/apps/TV" path="packages/apps/TV" revision="c2f5cf30d34099f33c9f8ca3e1bca2db2cab8bed" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Tag" path="packages/apps/Tag" revision="2b4278b9a4c3b4ca3521acdc1cc3ab24447b4bad" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Terminal" path="packages/apps/Terminal" revision="4d4e9490fdd512668ac0d47764f3eeb19504a6d2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/packages/apps/Test/connectivity" path="packages/apps/Test/connectivity" revision="4ca008b37a6273463818432584fa6f437671bacb" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/ThemePicker" path="packages/apps/ThemePicker" revision="91fbf0a0a13b42bb750e030dcc77c5e33ca4c45a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/packages/apps/TimeZoneData" path="packages/apps/TimeZoneData" revision="fe56ba08845f1d6d7aa5edb6efde71e6fe31c8f1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/packages/apps/TimeZoneUpdater" path="packages/apps/TimeZoneUpdater" revision="409af215603faf242cfa66d61125b7f40e32e69f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/Traceur" path="packages/apps/Traceur" revision="81bc752ebb3e943fe8908ea7bbbb9bed7f49d6a2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/TvSettings" path="packages/apps/TvSettings" revision="ef324dc7ebd668ea86f065b3e242083d62a9e3f8" upstream="refs/tags/android-r-preview-2"/>
-  <project name="platform/packages/apps/UniversalMediaPlayer" path="packages/apps/UniversalMediaPlayer" revision="73aa04b4639688674712d18b65b3121a7f49e20a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/WallpaperPicker" path="packages/apps/WallpaperPicker" revision="3252a805b696085ec0667449415e7cb93422d7aa" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/apps/WallpaperPicker2" path="packages/apps/WallpaperPicker2" revision="ef69302aa0f4a933f01106734f96d2540487e39b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/inputmethods/LatinIME" path="packages/inputmethods/LatinIME" revision="fc2bc1053014d88a1052fcec9b206845bcf5ab4e" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/inputmethods/LeanbackIME" path="packages/inputmethods/LeanbackIME" revision="e61d19e1b6695d83d77516061934bfbbe1bfbfd4" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/packages/modules/ArtPrebuilt" path="packages/modules/ArtPrebuilt" revision="491a40e7de77dac8666f05aab45e6e71e57ceb49" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/CaptivePortalLogin" path="packages/modules/CaptivePortalLogin" revision="d7985142ab683cdbffb2b1636b2be9b52ec5cfa3" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/packages/modules/CellBroadcastService" path="packages/modules/CellBroadcastService" revision="65ba9fdbfbe87eb320c3aa66d721736dc1802aa2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/Cronet" path="packages/modules/Cronet" revision="436325eb5c8fbe70975fe0546afe88d5288ff3ec" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/DnsResolver" path="packages/modules/DnsResolver" revision="361bf8b3e0465cc8b87b8a6960b73b1cb9f202d1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/ExtServices" path="packages/modules/ExtServices" revision="24702c49bd002df93a34ce6b2b375a5de3d62518" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/packages/modules/ModuleMetadata" path="packages/modules/ModuleMetadata" revision="bf198f3182e53f3d1dc9d061f558656e59f5d4c8" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/NetworkPermissionConfig" path="packages/modules/NetworkPermissionConfig" revision="83bdb339c9e5781eb9f37209e8ec58d000081fb5" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/NetworkStack" path="packages/modules/NetworkStack" revision="3fdd605b8e26a764dc1eab7aa0de7a8e884561c9" upstream="refs/tags/android-r-preview-2"/>
-  <project name="platform/packages/modules/TestModule" path="packages/modules/TestModule" revision="3523a2f0f9b12d4e60374af63aae14f75a2b4c10" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/vndk" path="packages/modules/vndk" revision="90677a3e0a3617fabc2e632c717872e56c026ef9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/providers/BlockedNumberProvider" path="packages/providers/BlockedNumberProvider" revision="4e72370ad033e4754ba71520a01dc9743b4cc59f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/providers/BookmarkProvider" path="packages/providers/BookmarkProvider" revision="66d866abdf7184af7a98edce18012fc33c41b623" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/CalendarProvider" path="packages/providers/CalendarProvider" revision="305f57acae3db551f90971ed7c635fea7647ed66" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/providers/CallLogProvider" path="packages/providers/CallLogProvider" revision="b17d05f2f416a4992e08184935a729b5e88e1fc2" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/ContactsProvider" path="packages/providers/ContactsProvider" revision="c6e8d21247c1ebf745833ed8ea9d5e7af539395a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/DownloadProvider" path="packages/providers/DownloadProvider" revision="3ebb0957aeb2e11f11ae19dc868130bc70daaae8" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/MediaProvider" path="packages/providers/MediaProvider" revision="84ad2d4e371dca6809b5a9d1d62fb4081bd09d81" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/providers/PartnerBookmarksProvider" path="packages/providers/PartnerBookmarksProvider" revision="9c3b541b4357011de2047a2e24f92a63c6d8d8a0" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/TelephonyProvider" path="packages/providers/TelephonyProvider" revision="1fc9a4694f60cd04b3ae29df9b549a76240955a1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/providers/TvProvider" path="packages/providers/TvProvider" revision="0c3aa5356b0a385b1bc74bd8a14d22943100f293" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/UserDictionaryProvider" path="packages/providers/UserDictionaryProvider" revision="2150129aba45306e8414fbd1088086bc5ced1691" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/screensavers/Basic" path="packages/screensavers/Basic" revision="c8c79a5cc2d34ffc8f1caaee96f2acf26990f3ff" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/screensavers/PhotoTable" path="packages/screensavers/PhotoTable" revision="3996832dee995b9570279d5d448eac7f5341d890" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/AlternativeNetworkAccess" path="packages/services/AlternativeNetworkAccess" revision="27bb99ed09b02550ddacc80e1790ea1a06039172" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/BuiltInPrintService" path="packages/services/BuiltInPrintService" revision="63a08c4baff048870e8fb32f09e56e67d46b5938" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Car" path="packages/services/Car" revision="d92dbcf817c50b5a8b193ff024f8ea67db62e9a7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Mms" path="packages/services/Mms" revision="20ea0d453647812b6aef981af279c1064f4f0a5c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Telecomm" path="packages/services/Telecomm" revision="e2c6f6798fbf7d23387a76eaae720ad4c5f38cd3" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Telephony" path="packages/services/Telephony" revision="67be8c1973a96ed1a56e0baa6b7bcb8a682dc746" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs" name="platform/packages/wallpapers/LivePicker" path="packages/wallpapers/LivePicker" revision="b9c3420f97fca7f83ab2bb6880c145541508fad3" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/pdk" path="pdk" revision="59deedc9c468ce8ae0f10e9c30742fd6f3ac82b7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-fs,pdk-cw-fs,cts" name="platform/platform_testing" path="platform_testing" revision="c625f5c792f10144d142e959d2bee308beafff46" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/abi-dumps/ndk" path="prebuilts/abi-dumps/ndk" revision="6adfc3ebeda6a5e80cea7cec249188f0b6e5d5b9" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/abi-dumps/platform" path="prebuilts/abi-dumps/platform" revision="4d2645a962ad6a3d5d9b13e66a13d8bc93195b6b" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/abi-dumps/vndk" path="prebuilts/abi-dumps/vndk" revision="f0f548cc48d18c9e07e6dd6675340f83cc12bf0b" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/android-emulator" path="prebuilts/android-emulator" revision="5b8315ad2903b941d436dc53d6560440983247f1" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/asuite" path="prebuilts/asuite" revision="eeb9d4f086eef086bf6bf2ec7b920f2ce98dbb7a" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/build-tools" path="prebuilts/build-tools" revision="6327989d4a9236f59b0db23d43dfeab8ab304d92" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/bundletool" path="prebuilts/bundletool" revision="9ff8e33f4be34cf9f0bfbfb618f9b60d26cfd66e" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/checkcolor" path="prebuilts/checkcolor" revision="f61c4b89ebb01a5841dee71a534e9d602b9a7377" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/checkstyle" path="prebuilts/checkstyle" revision="2e69c77cd636a442ea9f13c5b256cb0ae773efaf" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/clang-tools" path="prebuilts/clang-tools" revision="58d9f7e35de5e35249747223c1acc573d6c08581" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk,darwin" name="platform/prebuilts/clang/host/darwin-x86" path="prebuilts/clang/host/darwin-x86" revision="a7cc8f166048f3570c3296d3bbc63765789e8c1a" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/clang/host/linux-x86" path="prebuilts/clang/host/linux-x86" revision="99a57e03ec6100787d672d09690b0cdd1ce86931" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/devtools" path="prebuilts/devtools" revision="bc11a72a91685bb0a35e7ecf10ffcba4e07558bd" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/fuchsia_sdk" path="prebuilts/fuchsia_sdk" revision="12c41f24a38aefda3c5dda0dd513945b616cd765" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk,darwin,arm" name="platform/prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9" path="prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9" revision="b9c851f0e94537656849e1c839020459250bb274" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk,darwin,arm" name="platform/prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9" path="prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9" revision="24f28106e56e066850673590024592b17468fb32" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk,darwin" name="platform/prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1" path="prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1" revision="b616fc20ee024ace07f39b13a1f5a2bbdb67f8f7" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk,darwin,mips" name="platform/prebuilts/gcc/darwin-x86/mips/mips64el-linux-android-4.9" path="prebuilts/gcc/darwin-x86/mips/mips64el-linux-android-4.9" revision="03335dbecf7acbe1abbf77cb6f148498b5f25133" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk,darwin,x86" name="platform/prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9" path="prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9" revision="5f6784551ded13db5cb9894acc9ec2a1090cb65c" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk,linux,arm" name="platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" revision="2db20c200c5fae57489ffbfce40dc501e8fb0722" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk,linux,arm" name="platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9" path="prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9" revision="5dda5880238707c790ead9be6dde1d5fe79cce09" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk,linux" name="platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" revision="4533a4d0efa68949dc3c0dfec00214feaddd6c7b" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk-fs" name="platform/prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8" path="prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8" revision="3cbae8d4e0140abbfa0e120567ef1d5b24b3f8d2" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk,linux,mips" name="platform/prebuilts/gcc/linux-x86/mips/mips64el-linux-android-4.9" path="prebuilts/gcc/linux-x86/mips/mips64el-linux-android-4.9" revision="c3db20db1154efe9ae3460f40f654783f79c7e97" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk,linux,x86" name="platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" path="prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" revision="516fb636454e34e39c2ee7729183b07194bfe7c0" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="darwin,pdk" name="platform/prebuilts/gdb/darwin-x86" path="prebuilts/gdb/darwin-x86" revision="284b55fac5598bcd1f986e69b7556befdd663c53" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="linux,pdk" name="platform/prebuilts/gdb/linux-x86" path="prebuilts/gdb/linux-x86" revision="9453bfa625bc14025e6aa50dc296dd82ebbfb8c6" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="darwin,pdk,tradefed" name="platform/prebuilts/go/darwin-x86" path="prebuilts/go/darwin-x86" revision="3d0e53b900fd8e721733b7d54a1acef694a47333" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="linux,pdk,tradefed" name="platform/prebuilts/go/linux-x86" path="prebuilts/go/linux-x86" revision="3affa1d2632b48f9589ab4c91ca1b825d7c73a87" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk,pdk-cw-fs,pdk-fs" name="platform/prebuilts/gradle-plugin" path="prebuilts/gradle-plugin" revision="87ea0d25547bb9461641dd137f9f82ae6a31dd92" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/jdk/jdk11" path="prebuilts/jdk/jdk11" revision="bffdb0223ff2898246bbd14a6b17d8920ac600de" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/jdk/jdk8" path="prebuilts/jdk/jdk8" revision="74e4f1844dfa9b8df9e0fe2ff34a2ecc24d52b07" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/jdk/jdk9" path="prebuilts/jdk/jdk9" revision="3447ef32fa4961229942fa345c8707c7f9e00246" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/ktlint" path="prebuilts/ktlint" revision="fddd5e7beee2d5aba454e8a0fe38700a6aae7d8a" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/manifest-merger" path="prebuilts/manifest-merger" revision="c61778dd7fdef4194cf8592f9d4a7ead9bb16811" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk-cw-fs,pdk-fs" name="platform/prebuilts/maven_repo/android" path="prebuilts/maven_repo/android" revision="ecc2406087855bedf2d8e8e528ab0b2b4e6c7298" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk-cw-fs,pdk-fs" name="platform/prebuilts/maven_repo/bumptech" path="prebuilts/maven_repo/bumptech" revision="a9302911c0f0c2308d0bfa09ef93173a438233bb" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/misc" path="prebuilts/misc" revision="d635463bac1eff2564dfe59319ce25e610288c1c" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/module_sdk/art" path="prebuilts/module_sdk/art" revision="0a68152386e56eab7fce3813aca01301e197b17b" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/ndk" path="prebuilts/ndk" revision="c41613541a7c15d1a676f53503e630913f0ebc76" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="darwin,pdk,pdk-cw-fs,pdk-fs" name="platform/prebuilts/python/darwin-x86/2.7.5" path="prebuilts/python/darwin-x86/2.7.5" revision="0c5958b1636c47ed7c284f859c8e805fd06a0e63" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="linux,pdk,pdk-cw-fs,pdk-fs" name="platform/prebuilts/python/linux-x86/2.7.5" path="prebuilts/python/linux-x86/2.7.5" revision="53add29eb7b4eaa9e128e3ec84eac9e65cf4c986" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/qemu-kernel" path="prebuilts/qemu-kernel" revision="973acaa875014fd42374d7f8bfc9525621c984ae" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/r8" path="prebuilts/r8" revision="758bb406983f1acac24b8581e0ce3edb1bdb5934" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/remoteexecution-client" path="prebuilts/remoteexecution-client" revision="588195b9236632d81e914cb7b40bee1bcc376ed4" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/runtime" path="prebuilts/runtime" revision="204609cdf43ecef9bf3d76ed4820cadd4f42a7dd" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/rust" path="prebuilts/rust" revision="d803dd208b4ecd722b75ef6083d30142a6520832" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/sdk" path="prebuilts/sdk" revision="068d145c4e940e0de15b32c7ba2e99d2e03be542" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk,tools" name="platform/prebuilts/tools" path="prebuilts/tools" revision="53a1b1e054e85d6544d4291604c29d0214541fa0" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/vndk/v27" path="prebuilts/vndk/v27" revision="ff2c01a1b01ef3e2529561293cc5468b09ddea64" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/vndk/v28" path="prebuilts/vndk/v28" revision="d6ed2d7c6d55e3ad3cba372233160b812c250e2e" upstream="refs/tags/android-r-preview-2"/>
-  <project clone-depth="1" groups="pdk" name="platform/prebuilts/vndk/v29" path="prebuilts/vndk/v29" revision="b43d21914ddad9107202fd22b6719505aba9bab1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs" name="platform/sdk" path="sdk" revision="b0dcd4a2c77ad06abaf0870d0d3029432b1756ae" upstream="refs/tags/android-r-preview-2">
+  <project dest-branch="master" groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/display" path="hardware/qcom/sm8150/display" revision="7f2aafbff147ec2a30ca4243385ebb0b7aec1cfc" upstream="master"/>
+  <project dest-branch="master" groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/gps" path="hardware/qcom/sm8150/gps" revision="34ea098fe53b5118c1f294710d20f390a27f43b9" upstream="master"/>
+  <project dest-branch="master" groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/media" path="hardware/qcom/sm8150/media" revision="7de99155938d318c46bedd20fea3a3d736a53b23" upstream="master"/>
+  <project dest-branch="master" groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/thermal" path="hardware/qcom/sm8150/thermal" revision="2f27907a2770b508d3e04c76ddd41e2dd3b4af38" upstream="master"/>
+  <project dest-branch="master" groups="qcom_sm8150" name="platform/hardware/qcom/sm8150/vr" path="hardware/qcom/sm8150/vr" revision="a3b38e2ced79c2098ab6418dac4e8c7c1ebe4b0d" upstream="master"/>
+  <project dest-branch="master" groups="qcom_wlan,pdk-qcom" name="platform/hardware/qcom/wlan" path="hardware/qcom/wlan" revision="64500046a97842203e8a912257657753d24f7fe6" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/hardware/ril" path="hardware/ril" revision="f1575d44a910e31bd2a174acd029f55b11c71845" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/hardware/st/nfc" path="hardware/st/nfc" revision="b33f02fc786dd87025cdd9fe293c618b86b77fdc" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/hardware/st/secure_element" path="hardware/st/secure_element" revision="2fd6e665fbeefccbd060f69c7dd42108e309e8ab" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/hardware/st/secure_element2" path="hardware/st/secure_element2" revision="25e14bbde4732c804be4e6f938fdbc46eaeec8e9" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/hardware/ti/am57x" path="hardware/ti/am57x" revision="09c67206f6cb889e4c661f7f4dd6f847a0d88f47" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/libcore" path="libcore" revision="7ebd28594a04dc45ffd3a4c326c15140058f14c3" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/libnativehelper" path="libnativehelper" revision="84e576a16b5d21b1cfb875623e03bdff5f96924c" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/BasicSmsReceiver" path="packages/apps/BasicSmsReceiver" revision="0805f0c123bd84ca454eb375e90fa2313a69a8c5" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/Bluetooth" path="packages/apps/Bluetooth" revision="812089a30598ffe7f1efa920c76d2ecc67f73eb5" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Browser2" path="packages/apps/Browser2" revision="8a68fdaf045848376f2e31a645fb3970868842ad" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Calendar" path="packages/apps/Calendar" revision="efb2485b9258d237e8c3e93ea69011c2c628fdd2" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Camera2" path="packages/apps/Camera2" revision="e06fd1d76847c652b0cdb0a640491dd9aaf83e57" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/Cluster" path="packages/apps/Car/Cluster" revision="7e1ad61d9e8984f90ca7cb139df4430e9d7fbcf0" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/CompanionDeviceSupport" path="packages/apps/Car/CompanionDeviceSupport" revision="68538c52302c4670060cf68120da97c17f925158" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/Dialer" path="packages/apps/Car/Dialer" revision="96e42e0112a724b3b415f91b940fac1dc5148f3d" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/Hvac" path="packages/apps/Car/Hvac" revision="70ce3f23e9b4c10e5b345e868eb45b5779537a6d" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/LatinIME" path="packages/apps/Car/LatinIME" revision="560d84f535a38f0a0eec74524d2360ef6974e4e7" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/Launcher" path="packages/apps/Car/Launcher" revision="d177d4f69d9d3d7c307c9291f3effb312495a3df" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/LensPicker" path="packages/apps/Car/LensPicker" revision="1de5390cf1d3853c15c99fd4dfff3e2d722ba331" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/LinkViewer" path="packages/apps/Car/LinkViewer" revision="1103d7e381c47b0b6cef39b0e9530fb826c46c62" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/LocalMediaPlayer" path="packages/apps/Car/LocalMediaPlayer" revision="7ec358cab4e626301e2a9366a713f480c9f76bb0" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/Media" path="packages/apps/Car/Media" revision="8cfb3d0f986de31a76804f6e6e04bdcaf0523136" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/Messenger" path="packages/apps/Car/Messenger" revision="c4d4a5d4663e47660797000e1599f8e3b6f31efc" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/Notification" path="packages/apps/Car/Notification" revision="800e2f9334f3a0de20e9528e9cd02c4812c28e33" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/Overview" path="packages/apps/Car/Overview" revision="18069cf7b505946bdf5d1eb3566c7c8f201b1b9d" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/Radio" path="packages/apps/Car/Radio" revision="e301e0126d865e15fc748e773a52746c08f7c8d4" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/Settings" path="packages/apps/Car/Settings" revision="093b18b3a60bda7b709b355454edf70ccd130914" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/Stream" path="packages/apps/Car/Stream" revision="65fcbceb6cadefcd715b7b61c0d08c8279408343" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/SystemUpdater" path="packages/apps/Car/SystemUpdater" revision="ad64abe7c7ada0deca3d861a68d72ca770b333ff" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/libs" path="packages/apps/Car/libs" revision="d62248733f5b4dceba8060dc270917e07398614d" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Car/tests" path="packages/apps/Car/tests" revision="fe3429af80780990e3961c83d5eb5bf16273af1d" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/CarrierConfig" path="packages/apps/CarrierConfig" revision="3c13fc2994f0db7377d63701eff9bd7ad009e75a" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/CellBroadcastReceiver" path="packages/apps/CellBroadcastReceiver" revision="45b27963f9bdff08c877640a3e9bc61dcb7dd937" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/CertInstaller" path="packages/apps/CertInstaller" revision="c3288adee0bb55980e4748632fbaceeec4bc53c3" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Contacts" path="packages/apps/Contacts" revision="e8967e6a83c8fd9103001dcf6526b755cd778df2" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/DeskClock" path="packages/apps/DeskClock" revision="23f6a4c2093ee3b67950f57f94179a71f86bc999" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/packages/apps/DevCamera" path="packages/apps/DevCamera" revision="1b84f1f7fce56aae85e58d435b686d946c1f5f07" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Dialer" path="packages/apps/Dialer" revision="434cfb8a4fd5753c6231734cd9e3da20c26bc00f" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/DocumentsUI" path="packages/apps/DocumentsUI" revision="707f67150657020becaad9d5da87e290d085fb80" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/EmergencyInfo" path="packages/apps/EmergencyInfo" revision="a228eb59f9233c580a55d31f45ede58035d54d50" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Gallery" path="packages/apps/Gallery" revision="c436e2f2a7dd793db46ab8d7fd48259b2a0631e8" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Gallery2" path="packages/apps/Gallery2" revision="7a51e1fa4cbb806abcad95142e58390ca4126903" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/HTMLViewer" path="packages/apps/HTMLViewer" revision="ad709f9d80fc5b84d93b691806651e9b6f2ca194" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/KeyChain" path="packages/apps/KeyChain" revision="7c0c35442fb278c7d63c95718af5224fdc36f5d1" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Launcher3" path="packages/apps/Launcher3" revision="ea991a4be5bc48a079647df2d35f8ca6ef0d896b" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/LegacyCamera" path="packages/apps/LegacyCamera" revision="0d54a1dd6746faf3d679a3c0a2d36e5416834170" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/ManagedProvisioning" path="packages/apps/ManagedProvisioning" revision="6e1d96a6315ba2bbebd4853ce1150d4e6a55d767" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Messaging" path="packages/apps/Messaging" revision="b1aa213ce95b908b1c90356b8fc4445599d55eca" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Music" path="packages/apps/Music" revision="87cbf89f8ad4c62c356b6e87053cfa68422b7011" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/MusicFX" path="packages/apps/MusicFX" revision="d9f1d2d3cbf259e06c71489452aa2bfa22a979ef" upstream="master"/>
+  <project dest-branch="master" groups="apps_nfc,pdk-fs" name="platform/packages/apps/Nfc" path="packages/apps/Nfc" revision="e919a6ff0dab23eec9fb107ddc736711fd9299ae" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/OneTimeInitializer" path="packages/apps/OneTimeInitializer" revision="9dd324bae9cdc1e608680873653c767107a687a3" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/PackageInstaller" path="packages/apps/PermissionController" revision="c343b0516a0ff61500e1fd27a493ef3ca579855c" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/apps/PhoneCommon" path="packages/apps/PhoneCommon" revision="6f9878dc58b9561b0ab2fff040e24cd3ec7d4ae4" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Protips" path="packages/apps/Protips" revision="7f4bc7b7bd60c06e900975908e1b06979888e859" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Provision" path="packages/apps/Provision" revision="b4bc0db4fc6e08a7640c5071525b15e8b15414f0" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/QuickSearchBox" path="packages/apps/QuickSearchBox" revision="dec07b4199f8e5db20b173dcdf1a00d47f8d13bf" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/SafetyRegulatoryInfo" path="packages/apps/SafetyRegulatoryInfo" revision="db3edb6f3531446f9aa234631d6697f148bc0623" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/SampleLocationAttribution" path="packages/apps/SampleLocationAttribution" revision="e2f9e0754772bd122adfd8d06756e22ed9305d1d" upstream="master"/>
+  <project dest-branch="master" groups="apps_se,pdk-fs" name="platform/packages/apps/SecureElement" path="packages/apps/SecureElement" revision="a05bb069e22abd4db7c14650d79d2ead3867c827" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Settings" path="packages/apps/Settings" revision="0f6b2ec233c6bf5eef38f9572712a83d54b8c2c2" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/SettingsIntelligence" path="packages/apps/SettingsIntelligence" revision="9c7a808ea96fd072e1fd68b4bcd1733f8ff4a3b2" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/SpareParts" path="packages/apps/SpareParts" revision="fd4351c6184d37684020481795248fdcb37d8ed8" upstream="master"/>
+  <project dest-branch="master" groups="apps_stk,pdk-fs" name="platform/packages/apps/Stk" path="packages/apps/Stk" revision="7b633568807a03dda2235efbcf21527989ff56b6" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/StorageManager" path="packages/apps/StorageManager" revision="2113ef90eddddb24e7c3c7b3a9e49c791335f2fe" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/packages/apps/TV" path="packages/apps/TV" revision="f6ef153abc8b35796ba50e4eb78ec35c84ad678f" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Tag" path="packages/apps/Tag" revision="2e1a407490ee6c9f43b3521a2639f8755f523eb0" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Terminal" path="packages/apps/Terminal" revision="54bb27fdc57826240561175f827f88700c83b06e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/packages/apps/Test/connectivity" path="packages/apps/Test/connectivity" revision="7399fcc91fbe474f819e3b45df27c8845360925c" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/ThemePicker" path="packages/apps/ThemePicker" revision="a66d3ffcbff158f0eb0482741348b8c3ccc99dd0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/packages/apps/TimeZoneData" path="packages/apps/TimeZoneData" revision="f23cfe134712cef43766dc1e8e79d5f220ba736d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/packages/apps/TimeZoneUpdater" path="packages/apps/TimeZoneUpdater" revision="88da0bd35394bb4ffc5de8167e6a2b9d060c1686" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/Traceur" path="packages/apps/Traceur" revision="489fc4071d29c589ddcbd474d17a801b098d96c7" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/TvSettings" path="packages/apps/TvSettings" revision="9f61e1a476f93b6083b42dcabb5237f1b501a186" upstream="master"/>
+  <project dest-branch="master" name="platform/packages/apps/UniversalMediaPlayer" path="packages/apps/UniversalMediaPlayer" revision="b82ed64e09ef725b0c675f3fc30296c4844befae" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/WallpaperPicker" path="packages/apps/WallpaperPicker" revision="4292a37c4b9d746fff958de315604aa957361314" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/apps/WallpaperPicker2" path="packages/apps/WallpaperPicker2" revision="a84f0b107f606a98adb857e35b1e71efbdee3200" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/inputmethods/LatinIME" path="packages/inputmethods/LatinIME" revision="4eb192212f6605efaa0e5f3c6124e0942cf239c5" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/inputmethods/LeanbackIME" path="packages/inputmethods/LeanbackIME" revision="38afee1136642059a6c3d23a6bc38b0786ad29ff" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/packages/modules/ArtPrebuilt" path="packages/modules/ArtPrebuilt" revision="491a40e7de77dac8666f05aab45e6e71e57ceb49" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/CaptivePortalLogin" path="packages/modules/CaptivePortalLogin" revision="afe9ad2cc33bcc69db06c7131be36348885d65bc" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/packages/modules/CellBroadcastService" path="packages/modules/CellBroadcastService" revision="26848c5022821a557cd36e9a5a567cf76e6f25f7" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/Cronet" path="packages/modules/Cronet" revision="f22adf20638c1b564bfd9766ed5aabf23a1aab9b" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/DnsResolver" path="packages/modules/DnsResolver" revision="fc9aa724a657dd5d05c7fd6cf975fbe002e6daba" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/ExtServices" path="packages/modules/ExtServices" revision="c2bf02c01f3d40f79e35f9bc1002609a7904e726" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/packages/modules/IPsec" path="packages/modules/IPsec" revision="3ca6fa6fcba520556b3ed3eaace8afa946617f47" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/packages/modules/ModuleMetadata" path="packages/modules/ModuleMetadata" revision="bf198f3182e53f3d1dc9d061f558656e59f5d4c8" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/NetworkPermissionConfig" path="packages/modules/NetworkPermissionConfig" revision="8cfa62762bf2eab1194ba8828be46a1fbd7087f9" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/NetworkStack" path="packages/modules/NetworkStack" revision="55da3a991e4059b75648fcc0f3ea59f89af35eee" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/RuntimeI18n" path="packages/modules/RuntimeI18n" revision="8d6fa86372699b438f66a94ec857f46c4139bbdc" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/SdkExtensions" path="packages/modules/SdkExtensions" revision="a6caee837fb07a59121a9fe4ae5c72649daf9e42" upstream="master"/>
+  <project dest-branch="master" name="platform/packages/modules/TestModule" path="packages/modules/TestModule" revision="3523a2f0f9b12d4e60374af63aae14f75a2b4c10" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/modules/vndk" path="packages/modules/vndk" revision="d035b0fdeff269a944b40c29d16a2e3571398c3f" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/providers/BlockedNumberProvider" path="packages/providers/BlockedNumberProvider" revision="508626f60afba73c69fd63fa9ac7aeaceb3323fc" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/providers/BookmarkProvider" path="packages/providers/BookmarkProvider" revision="66d866abdf7184af7a98edce18012fc33c41b623" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/CalendarProvider" path="packages/providers/CalendarProvider" revision="e3d8716228790ebcb8af94bb766bd2d57739d2dc" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/providers/CallLogProvider" path="packages/providers/CallLogProvider" revision="54431b0dc01c67c0d59b39ba278babd47aac30b9" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/ContactsProvider" path="packages/providers/ContactsProvider" revision="cc8d17fefc8516ddbef28093cac248e2e60a0f28" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/DownloadProvider" path="packages/providers/DownloadProvider" revision="0f71dcac864d807b89630a30726cf0396b2859ba" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/MediaProvider" path="packages/providers/MediaProvider" revision="735b89804878af5dae31d6884b0818bdfb271d0c" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/providers/PartnerBookmarksProvider" path="packages/providers/PartnerBookmarksProvider" revision="9c3b541b4357011de2047a2e24f92a63c6d8d8a0" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/TelephonyProvider" path="packages/providers/TelephonyProvider" revision="d4d2391c9c3db958bfe6e380a9662cdc9440fe70" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/providers/TvProvider" path="packages/providers/TvProvider" revision="72c3c50bc143d011bdf1985a127154026b79511c" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/providers/UserDictionaryProvider" path="packages/providers/UserDictionaryProvider" revision="8463287886e3dfc618eb09da758fe571c4bdc953" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/screensavers/Basic" path="packages/screensavers/Basic" revision="c8c79a5cc2d34ffc8f1caaee96f2acf26990f3ff" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/screensavers/PhotoTable" path="packages/screensavers/PhotoTable" revision="d88967f46294b1325da10075ab88cb21b812a2d1" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/AlternativeNetworkAccess" path="packages/services/AlternativeNetworkAccess" revision="d5997fad372e6b9989f816fed1519d45ed32a249" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/BuiltInPrintService" path="packages/services/BuiltInPrintService" revision="c4037b2aa4dedc03622713496a28ef83fbe51655" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Car" path="packages/services/Car" revision="71bbcd26d5f772e747a7d62b92251b4161ef0504" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Mms" path="packages/services/Mms" revision="67bc2e703c45f02b5436117a774c2718901070ca" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Telecomm" path="packages/services/Telecomm" revision="490401c49428989c58747ffa10871b9b059888fb" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/packages/services/Telephony" path="packages/services/Telephony" revision="fb895c39f22d66c4bee236a5d4246b72d9b8bbc1" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs" name="platform/packages/wallpapers/LivePicker" path="packages/wallpapers/LivePicker" revision="2c4affb0eba4131177de2de0650a74d3e6aa4a2b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/pdk" path="pdk" revision="59deedc9c468ce8ae0f10e9c30742fd6f3ac82b7" upstream="master"/>
+  <project dest-branch="master" groups="pdk-fs,pdk-cw-fs,cts" name="platform/platform_testing" path="platform_testing" revision="f15eff8c26b70473e2ac63bcf203c41d9470b02e" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk-fs" name="platform/prebuilts/abi-dumps/ndk" path="prebuilts/abi-dumps/ndk" revision="15137e8613422c16c963a42a3aa230dee9fd4dec" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk-fs" name="platform/prebuilts/abi-dumps/platform" path="prebuilts/abi-dumps/platform" revision="3a423764c3627dc79985b47111de8f77c7ce0aad" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk-fs" name="platform/prebuilts/abi-dumps/vndk" path="prebuilts/abi-dumps/vndk" revision="be13f0398e1ead68e288502d86fb078cf999b688" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk-fs" name="platform/prebuilts/android-emulator" path="prebuilts/android-emulator" revision="fea18b6695bad591306822d6b031f7ffed3fe932" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/asuite" path="prebuilts/asuite" revision="be88322b7fbef612f653c1ea73bbdb90f80c9053" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/build-tools" path="prebuilts/build-tools" revision="d9b7d5e728d3226c44d6fa818efefcac7279b5ea" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/bundletool" path="prebuilts/bundletool" revision="c6cc587801a6c70796809842c1970a374fc22883" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/checkcolor" path="prebuilts/checkcolor" revision="8740e7ad190a24e7692d6aae424e81c85a7292bc" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/checkstyle" path="prebuilts/checkstyle" revision="f3179e75784f9551d648e9035944b36569e017a9" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/clang-tools" path="prebuilts/clang-tools" revision="ec7e496bac97241dc9c26d44ca71df66e2b26f20" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk,darwin" name="platform/prebuilts/clang/host/darwin-x86" path="prebuilts/clang/host/darwin-x86" revision="b40fb300258802b9a6c56ce0d33ca8dfd3e665b1" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/clang/host/linux-x86" path="prebuilts/clang/host/linux-x86" revision="8539e6c8e61390f065090d1a1c04ec95107c8621" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk-fs" name="platform/prebuilts/cmdline-tools" path="prebuilts/cmdline-tools" revision="1b7d724e36df1caab8b6bebbdd0b379eef8d6f69" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk-fs" name="platform/prebuilts/devtools" path="prebuilts/devtools" revision="bc11a72a91685bb0a35e7ecf10ffcba4e07558bd" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk-fs" name="platform/prebuilts/fuchsia_sdk" path="prebuilts/fuchsia_sdk" revision="12c41f24a38aefda3c5dda0dd513945b616cd765" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk,darwin,arm" name="platform/prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9" path="prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9" revision="e3c9192408e0ad4fa1a7b39f111dac93aef4dca8" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk,darwin,arm" name="platform/prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9" path="prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9" revision="9081aab4f83e15d4e097b24b4edd6bac33439351" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk,darwin" name="platform/prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1" path="prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1" revision="b616fc20ee024ace07f39b13a1f5a2bbdb67f8f7" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk,darwin,mips" name="platform/prebuilts/gcc/darwin-x86/mips/mips64el-linux-android-4.9" path="prebuilts/gcc/darwin-x86/mips/mips64el-linux-android-4.9" revision="7394043d1bf1189f0963b9e7f87ca44aaafc860c" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk,darwin,x86" name="platform/prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9" path="prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9" revision="3eb882505ec463db6ebaae9b2db27fea1dfa888e" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk,linux,arm" name="platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" revision="6db7620069bbcac51474f5e4b0691071273f589a" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk,linux,arm" name="platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9" path="prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9" revision="1d67e7fe709e8f81e91e5f85a5d4c04b27c6b319" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk,linux" name="platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" revision="90e45fec56fdeac84c9eb174c63fa6e748c6faa9" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk-fs" name="platform/prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8" path="prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8" revision="c4602d47837e2518310d06c26952d23a45ce4ab9" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk,linux,mips" name="platform/prebuilts/gcc/linux-x86/mips/mips64el-linux-android-4.9" path="prebuilts/gcc/linux-x86/mips/mips64el-linux-android-4.9" revision="2bf8cb6fba61df1d2725364d1751622979b085e3" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk,linux,x86" name="platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" path="prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" revision="6d6c9c7e26cf86eafd41b9e73840c7f8d50d1027" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="darwin,pdk" name="platform/prebuilts/gdb/darwin-x86" path="prebuilts/gdb/darwin-x86" revision="284b55fac5598bcd1f986e69b7556befdd663c53" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="linux,pdk" name="platform/prebuilts/gdb/linux-x86" path="prebuilts/gdb/linux-x86" revision="9453bfa625bc14025e6aa50dc296dd82ebbfb8c6" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="darwin,pdk,tradefed" name="platform/prebuilts/go/darwin-x86" path="prebuilts/go/darwin-x86" revision="748609c914d883228a9381c6be86623984d68a2b" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="linux,pdk,tradefed" name="platform/prebuilts/go/linux-x86" path="prebuilts/go/linux-x86" revision="7f4776e1ddb05395a4025a30de8d7b78d62ac9aa" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk,pdk-cw-fs,pdk-fs" name="platform/prebuilts/gradle-plugin" path="prebuilts/gradle-plugin" revision="68f2332cdaab47ad03b3d57be0e83c6cec3d4463" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/jdk/jdk11" path="prebuilts/jdk/jdk11" revision="e4fb089b45a6633baf0233e2c524d614ed7355f1" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/jdk/jdk8" path="prebuilts/jdk/jdk8" revision="74e4f1844dfa9b8df9e0fe2ff34a2ecc24d52b07" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/jdk/jdk9" path="prebuilts/jdk/jdk9" revision="3447ef32fa4961229942fa345c8707c7f9e00246" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/ktlint" path="prebuilts/ktlint" revision="12e4973a914b120dbc996507cd58b3fe14afcf8e" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/manifest-merger" path="prebuilts/manifest-merger" revision="c61778dd7fdef4194cf8592f9d4a7ead9bb16811" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/prebuilts/maven_repo/android" path="prebuilts/maven_repo/android" revision="ecc2406087855bedf2d8e8e528ab0b2b4e6c7298" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/prebuilts/maven_repo/bumptech" path="prebuilts/maven_repo/bumptech" revision="52359d0baa6af2c033f5ee57c8fbb3f51deb734e" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/misc" path="prebuilts/misc" revision="8430fec9bf77c601284583665d9fae3d514cf0b4" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/module_sdk/art" path="prebuilts/module_sdk/art" revision="0a68152386e56eab7fce3813aca01301e197b17b" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/ndk" path="prebuilts/ndk" revision="f5538578aa305b4764283b729b10b3c31a15a558" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="darwin,pdk,pdk-cw-fs,pdk-fs" name="platform/prebuilts/python/darwin-x86/2.7.5" path="prebuilts/python/darwin-x86/2.7.5" revision="0c5958b1636c47ed7c284f859c8e805fd06a0e63" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="linux,pdk,pdk-cw-fs,pdk-fs" name="platform/prebuilts/python/linux-x86/2.7.5" path="prebuilts/python/linux-x86/2.7.5" revision="53add29eb7b4eaa9e128e3ec84eac9e65cf4c986" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/qemu-kernel" path="prebuilts/qemu-kernel" revision="9b570fb5f707782532655f348fd9bea8de68c7bc" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/r8" path="prebuilts/r8" revision="a9ab006a1c5224313533f95220be4fb16ec72b02" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/remoteexecution-client" path="prebuilts/remoteexecution-client" revision="cbf6a78b7f91229831c684f734a7d053871c0f21" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/rust" path="prebuilts/rust" revision="765d27cdd93fb86280c2c8e5a85fde72073a6c8f" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/sdk" path="prebuilts/sdk" revision="ed87fbd3e94173069244715dfaf8c27b7a42c5e6" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk,tools" name="platform/prebuilts/tools" path="prebuilts/tools" revision="8aec3d9132bf1f0f142c0221496cc76811b7ad4c" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/vndk/v27" path="prebuilts/vndk/v27" revision="0f6002bffc84a181b476f07f1d1491aacffa8924" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/vndk/v28" path="prebuilts/vndk/v28" revision="2569adfe06033d1758f37e33b5b50e57e2aabd44" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/vndk/v29" path="prebuilts/vndk/v29" revision="da70d9a2d97c65571f1fa353c221afdef2da081a" upstream="master"/>
+  <project clone-depth="1" dest-branch="master" groups="pdk" name="platform/prebuilts/vndk/v30" path="prebuilts/vndk/v30" revision="fe7fcee02ad528d1480f3cc112866953bc51f080" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs" name="platform/sdk" path="sdk" revision="7cb6fc634a03afec776a03f2543185908b3563b0" upstream="master">
     <linkfile dest="frameworks/support/README.md" src="current/androidx-README.md"/>
   </project>
-  <project groups="pdk" name="platform/system/apex" path="system/apex" revision="3d773bca8aa756f8028b811474d2832c545da83d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/bpf" path="system/bpf" revision="6161ff246f648c1375e3a7fd2a271ee18dbc8b43" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/bpfprogs" path="system/bpfprogs" revision="97260028c2b7aa60752ddb301f5d909e4f39431d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/bt" path="system/bt" revision="d781b315cd40da012bacc94ca3c18de932236058" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/ca-certificates" path="system/ca-certificates" revision="f5946ce8e7753603ea9cb97e6851de58d453f169" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/chre" path="system/chre" revision="fdbc68dbd37c96f486f7781aabd2aa401d4ffe44" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/connectivity/wificond" path="system/connectivity/wificond" revision="46509c42de6d1f15ba5b59419d4734d3ea7970fb" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/connectivity/wifilogd" path="system/connectivity/wifilogd" revision="4b31b4738442ba355548d36605a169d9d1fc36ee" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/core" path="system/core" revision="b33afa9d8da88cbda0df1a82358915aa7393899b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/extras" path="system/extras" revision="0b9f8de9be1e37c735d7cf58ad93b851e06a3a83" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/gatekeeper" path="system/gatekeeper" revision="e583844fc9c6d6dbb293f8694fd66cd5a4794c02" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/gsid" path="system/gsid" revision="fc817e25fe44f3c62aa273268d9e2c2e9057699c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/hardware/interfaces" path="system/hardware/interfaces" revision="cd7224246968587cbdb1a16e36be64cd7439b329" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/hwservicemanager" path="system/hwservicemanager" revision="088c39801860788256ff2f4da508cb09c45138a4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/incremental_delivery" path="system/incremental_delivery" revision="471a1b767e72d9069b542bbfc9e4978ab0267ab3" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/iorap" path="system/iorap" revision="806a07b868ac808bbd7ef09c37d6bd180e15de36" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/keymaster" path="system/keymaster" revision="ae3b046f5ad442c1738dd0e258b95b90e4c456f5" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/libartpalette" path="system/libartpalette" revision="894b033578235e26acbb45e5fb65e93b3bdae60a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/libfmq" path="system/libfmq" revision="57103f7e0c1e913bc205b0bc2ce1a39db7b59a1d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/libhidl" path="system/libhidl" revision="330ef560a5f99b54bfd84318c0ac8d79d1b48fff" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/libhwbinder" path="system/libhwbinder" revision="889cf78f80f1035c58513fa2459c6920657e095a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/libsysprop" path="system/libsysprop" revision="2d063546b2802b56ba1938dfc2dfdd12404cf7da" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/libufdt" path="system/libufdt" revision="715ca232a5b4b870968eceedc332eb84cf312963" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/libvintf" path="system/libvintf" revision="94931a3cb52f2f9e823069d3e40b14aa81a4c8bd" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/linkerconfig" path="system/linkerconfig" revision="7587c35384ff8af14528285205910645ff3519c5" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/media" path="system/media" revision="360f362006dab2e06dc5d073630d3a39d4d786af" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/memory/libion" path="system/memory/libion" revision="63b80a458bb656bb7020934178b986001ae2aed9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/memory/libmeminfo" path="system/memory/libmeminfo" revision="15a431bd324beef987fe3569c7da4fad763c11dd" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/memory/libmemtrack" path="system/memory/libmemtrack" revision="22a4769b32dce6f1bc8401a3e9bb806dd7d6fbf9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/memory/libmemunreachable" path="system/memory/libmemunreachable" revision="9f479f24d9ffac9a9c3f8412b30aba438ea47674" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/memory/lmkd" path="system/memory/lmkd" revision="fce58e91653f33ac284b8288b3d946df3845a8c7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/netd" path="system/netd" revision="ed1acb63e7796f87c5c0e30c3e4a47bb3287818d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/nfc" path="system/nfc" revision="8d1816cb12ef7768f7a10a7a95238bd2d7f7d127" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/nvram" path="system/nvram" revision="184c1c9a5c39f51f82bdb453afc9cf144f8e4183" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/security" path="system/security" revision="21b6c38fa099855a88483bcc4960b39eb0446707" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/sepolicy" path="system/sepolicy" revision="c58ad4b82c1701c416e069ecb5eb889c471cd78b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/server_configurable_flags" path="system/server_configurable_flags" revision="94c7eb57618f3a32336bf0d5d46ecd74125f9f97" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/teeui" path="system/teeui" revision="4e1c58ce593bf0937f4aac51f265e29f6595177f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/testing/gtest_extras" path="system/testing/gtest_extras" revision="f324d3180147bbae1eb742eabd4e75d109b2882d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/timezone" path="system/timezone" revision="3bd3a573d8aeb55c99ca1b6d8374953bfd656ad1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/tools/aidl" path="system/tools/aidl" revision="b01451df7656b2437c940ba300178d81c6c951ff" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/tools/hidl" path="system/tools/hidl" revision="2a800b1c8946a1f84a6e42e0003626b0baba99de" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/tools/mkbootimg" path="system/tools/mkbootimg" revision="33a31ff81a48e20cb029a62b10e3fc6b614d93b7" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/tools/sysprop" path="system/tools/sysprop" revision="5afe96bb34146fb59d6142b132df33eb06c88f29" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/tools/xsdc" path="system/tools/xsdc" revision="27c0f47dc844be82e9bf1fe85670ab82917e6407" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/update_engine" path="system/update_engine" revision="6a6d0f13d4b4ecb8357e8bdb22be6fec626510df" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/system/vold" path="system/vold" revision="eaa3443ad830b856a4fcb8c8314e176c8ad147eb" upstream="refs/tags/android-r-preview-2"/>
-  <project name="platform/test/app_compat/csuite" path="test/app_compat/csuite" revision="a82698d20c210475ffbb9add00cc8502dc012abc" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/framework" path="test/framework" revision="65cc35a42c3dad36a0fc858035a5aefe29b4d55b" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/test/mlts/benchmark" path="test/mlts/benchmark" revision="67a799ab5bce0160ba6677ec190077d5ba5ad08d" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/test/mlts/models" path="test/mlts/models" revision="a92852efb52754926c69e9cdbe651de935f55349" upstream="refs/tags/android-r-preview-2"/>
-  <project name="platform/test/mts" path="test/mts" revision="23938da40abcebc7d44164f19aad5cf682c5cdad" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="cts,pdk-cw-fs,pdk-fs" name="platform/test/suite_harness" path="test/suite_harness" revision="3b2cb38d4561a7bed1f19ffcd30816f05e2a0b48" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vti/dashboard" path="test/vti/dashboard" revision="a9bd47e4caa21d535fb89c0e6efe23fa08d25847" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vti/fuzz_test_serving" path="test/vti/fuzz_test_serving" revision="6319e3d94c65669050c49c6ca570096d41823b82" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vti/test_serving" path="test/vti/test_serving" revision="a2cebf686dd9437431d8b611f21db744c9650d0c" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/test/vts" path="test/vts" revision="00260fb7bc6303f521498f13a01b010759c8bd74" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vts-testcase/fuzz" path="test/vts-testcase/fuzz" revision="284b33bc3c34abaf2acbe1593538cc747a5f6570" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/test/vts-testcase/hal" path="test/vts-testcase/hal" revision="3299de8fff9370ea2b45f1d7bdcfc322456bd486" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/test/vts-testcase/hal-trace" path="test/vts-testcase/hal-trace" revision="2695892568f8fade958ec0ec172df8f295ae4112" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/test/vts-testcase/kernel" path="test/vts-testcase/kernel" revision="26a8e5900e536b89bd44e6448c58fba3eb382ac4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vts-testcase/nbu" path="test/vts-testcase/nbu" revision="0712e2a442364af77a0b1dda0adf922d1d1447bc" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vts-testcase/performance" path="test/vts-testcase/performance" revision="f0e5dcee43de6f9c44a3872721087d96eaa48273" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,projectarch,pdk" name="platform/test/vts-testcase/security" path="test/vts-testcase/security" revision="668f52c000954da5833ef05310b127b0ec1c659f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="vts,pdk" name="platform/test/vts-testcase/vndk" path="test/vts-testcase/vndk" revision="c97165b3eed351cd322c10a292cd9b202e80dcea" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="tools,vts,projectarch,pdk,tradefed" name="platform/tools/acloud" path="tools/acloud" revision="8cec5007c2230710c071e2aabc8a0b4a6d479061" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,tools" name="platform/tools/apifinder" path="tools/apifinder" revision="05eee3720e682f4ce5ce1153f0236cee12d3883a" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,tradefed" name="platform/tools/apksig" path="tools/apksig" revision="2dd388f2f5595d93199ed322ff55c48233d89e99" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,tradefed" name="platform/tools/apkzlib" path="tools/apkzlib" revision="eba4cc5b98798e46c3f80b9dd0bdbd92757e4dde" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/tools/asuite" path="tools/asuite" revision="80e97555a4214d48ceecbb47050a151113a1f3e1" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/tools/currysrc" path="tools/currysrc" revision="ee58ce6a1931a4410059f2651d7e444bb8df35dc" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="tools,pdk-fs" name="platform/tools/dexter" path="tools/dexter" revision="fb3ac2a5b6efef22c621b973378be559f2d32196" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="tools" name="platform/tools/doc_generation" path="tools/doc_generation" revision="e7c9b74790a10ef58f165b32d0755831a8d93e32" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="tools" name="platform/tools/external/fat32lib" path="tools/external/fat32lib" revision="2aa98e48614927413550d00c755351b3f68542b4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="tools" name="platform/tools/external_updater" path="tools/external_updater" revision="d98145b82d11e300d88d27687193db38e1bbb2a8" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="nopresubmit,pdk,tradefed" name="platform/tools/loganalysis" path="tools/loganalysis" revision="838538ace54b0a1dbc2ae34d0498c8b458f1f17f" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,tools" name="platform/tools/metalava" path="tools/metalava" revision="4d219f6665223fd7cf1f3cddcbe1957bdb90a5f6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="adt-infra,cts,developers,motodev,pdk,tools,tradefed" name="platform/tools/repohooks" path="tools/repohooks" revision="73316598e68edb52962b70014e9057423d0f05e9" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,tools" name="platform/tools/security" path="tools/security" revision="f3ac98aa24ad5d682291c2144ac8b465ef2c6aa4" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/tools/test/connectivity" path="tools/test/connectivity" revision="1d63deeb1634b1bfddf9087d4f6910573dd08060" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="platform/tools/test/graphicsbenchmark" path="tools/test/graphicsbenchmark" revision="98bafdf921e46a577c0c366c85ebcf8ffa6ff9d6" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,tradefed" name="platform/tools/tradefederation" path="tools/tradefederation/core" revision="ae07bea29c08eb4c6bb880bee15469f41b693015" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk,tradefed" name="platform/tools/tradefederation/contrib" path="tools/tradefederation/contrib" revision="193e913d04ccac5cd8701e8d72c2ff58559aca61" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="tools,pdk" name="platform/tools/treble" path="tools/treble" revision="16f4a997c7d240d29535e8ce0f9037ab180da982" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="tools,cts,pdk,pdk-cw-fs,pdk-fs" name="platform/tools/trebuchet" path="tools/trebuchet" revision="d2240446bb55e53591d85fe1b9a795aca10a92be" upstream="refs/tags/android-r-preview-2"/>
-  <project name="toolchain/benchmark" revision="1fba1825631e6e52dff5b3ceb87a5b439e2acf52" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk" name="toolchain/pgo-profiles" revision="7a666994302474ff5891e256a1d2fa79be95aad3" upstream="refs/tags/android-r-preview-2"/>
-  <project groups="pdk-cw-fs,pdk-fs,pdk" name="tools/platform-compat" revision="35d5010d9febb5e5ef91a43413397ce4a5d10677" upstream="refs/tags/android-r-preview-2"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/apex" path="system/apex" revision="51aa2b56b1f557766e62e49c5faed7396e76f9a9" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/bpf" path="system/bpf" revision="2a775a423ab49efcaf92eceec2db32538d03986f" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/bpfprogs" path="system/bpfprogs" revision="beed480907f887e655f4c4ba52f30e688c54eae3" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/bt" path="system/bt" revision="a750dd9106511bff9ef38597452b17d3ad1050a3" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/ca-certificates" path="system/ca-certificates" revision="1bfb2b42158b24a1d30fc2fab0728e74c03aa332" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/chre" path="system/chre" revision="078afe6d04d9afc83d0e9608d28136a0fb69719e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/connectivity/wificond" path="system/connectivity/wificond" revision="0bcc0e4488989dad285c7664b4cdaa6eaad666d4" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/connectivity/wifilogd" path="system/connectivity/wifilogd" revision="6b125d3435b4e931934306a866bb591bb67dce14" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/core" path="system/core" revision="b8bcd11f8b9d40a3cae8bd155a71e9be564e8359" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/extras" path="system/extras" revision="812c8ccdc6bc1bd50ff90e45742fd0cb7ba60c62" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/gatekeeper" path="system/gatekeeper" revision="644ddd6370eb6a943d56c8021ed98cc72599d50e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/gsid" path="system/gsid" revision="60bbc030e129d8e160044bebfd2f8c04abe0ffd9" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/hardware/interfaces" path="system/hardware/interfaces" revision="303520bd3f4f16c3dcc180851622f8cb3b84d2e0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/hwservicemanager" path="system/hwservicemanager" revision="5531f87ad32eaeca3659a8d2624733df0ca119d2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/incremental_delivery" path="system/incremental_delivery" revision="629be47a284536e9b5529be1cf9c51e1f87ec6a5" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/iorap" path="system/iorap" revision="806a07b868ac808bbd7ef09c37d6bd180e15de36" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/keymaster" path="system/keymaster" revision="d84348de3143156d92f1c46a017a82df08207597" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/libartpalette" path="system/libartpalette" revision="2848934f836db8cccc8b1ec3040f5d7248d4f6c5" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/libbase" path="system/libbase" revision="2df7c5626c15e5c8d3d2a38ee3860ded3e9616e8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/libfmq" path="system/libfmq" revision="0b86c494d121cae76ae2336e3ade962d0df7222c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/libhidl" path="system/libhidl" revision="1602b7d606bbeb83411c7d986c5f4ae26d3441aa" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/libhwbinder" path="system/libhwbinder" revision="f050d28c33a226769e55e60072c06c733602049c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/libsysprop" path="system/libsysprop" revision="f16b187916e917988d58d6de6445015c4beced70" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/libufdt" path="system/libufdt" revision="103a2f03d787cd69a897dc5f310494719c8f96c1" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/libvintf" path="system/libvintf" revision="a192fa5637cd255a27524849248ed9d37df96897" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/libziparchive" path="system/libziparchive" revision="27d0eaa4ea9e6cfd7b9cf14ebc3fc5e6162a88f5" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/linkerconfig" path="system/linkerconfig" revision="28d91b58e4f7cb4838dbde8f722cc23637d1bb90" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/media" path="system/media" revision="5f007863c3ef45ae323daf8de3cc89fd0ad7fb3c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/memory/libdmabufheap" path="system/memory/libdmabufheap" revision="970f482c38050174bbd04a6edb3c46d0d165d615" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/memory/libion" path="system/memory/libion" revision="fff944ed86fd8ab67cd3e961368522b1132d43a3" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/memory/libmeminfo" path="system/memory/libmeminfo" revision="8bee3d91dc26ab34a17269b8ad7f11769d2e935f" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/memory/libmemtrack" path="system/memory/libmemtrack" revision="800d172aabf2be6b83939a41f996c070b22cc05d" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/memory/libmemunreachable" path="system/memory/libmemunreachable" revision="fe4c42218a61f3d54bb47810fb66f23e54e64cec" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/memory/lmkd" path="system/memory/lmkd" revision="7d1f4f0047df41f84a1d88ac2f58c6e63645fdf0" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/netd" path="system/netd" revision="16a23705a18ee4839442598bb6f075b1bfacfbe8" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/nfc" path="system/nfc" revision="5d6cf5d30f58fcad9ad9413afb3046f64a045386" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/nvram" path="system/nvram" revision="184c1c9a5c39f51f82bdb453afc9cf144f8e4183" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/security" path="system/security" revision="9cc2e8305985d17622c76d99258c38876b2e3873" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/sepolicy" path="system/sepolicy" revision="bd397a14b4b9202aee7446c4603f293e9072442b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/server_configurable_flags" path="system/server_configurable_flags" revision="dc7438f938a08470f961ba04bb8767b4d44199cd" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/teeui" path="system/teeui" revision="aa62b6cb40f57cf9548099db1c91c8a452c100a6" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/testing/gtest_extras" path="system/testing/gtest_extras" revision="8b01e5b60bb320cc0f81da43f31bd6a73ecc7860" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/timezone" path="system/timezone" revision="67a0c64481e4af1d2076cf0dd082fb9f58e454d3" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/tools/aidl" path="system/tools/aidl" revision="187bcc9039642fd7acb5d0c4dc2a7fae28b8b84c" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/tools/hidl" path="system/tools/hidl" revision="1c444f8db372cebb76f46b34bad3058b31f56900" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/tools/mkbootimg" path="system/tools/mkbootimg" revision="5cc6456425d98d8fce685dcb13d3ad8baffccccf" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/tools/sysprop" path="system/tools/sysprop" revision="1d166c2f4d45a1c2eb6064b6c2f5bd5559a7d889" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/tools/xsdc" path="system/tools/xsdc" revision="695b9a4d5e1482c350185f1bfbd180333f180427" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/update_engine" path="system/update_engine" revision="ebd5e25c24c787f33a1377d7b5c6d8f6a3bbbd01" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/system/vold" path="system/vold" revision="5de675c93be181256ecc0361e885fa922693cfb8" upstream="master"/>
+  <project dest-branch="master" name="platform/test/app_compat/csuite" path="test/app_compat/csuite" revision="a82698d20c210475ffbb9add00cc8502dc012abc" upstream="master"/>
+  <project dest-branch="master" groups="vts,projectarch,pdk" name="platform/test/framework" path="test/framework" revision="0690d5b557c21763d28905a74dda85a41a3f65d7" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/test/mlts/benchmark" path="test/mlts/benchmark" revision="c192a20f81d085674cf8d69d8c4a560b51b81af3" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/test/mlts/models" path="test/mlts/models" revision="73313692ee90e6d768cd086fbb7c94298ecaf1ac" upstream="master"/>
+  <project dest-branch="master" name="platform/test/mts" path="test/mts" revision="c6ba595da2de2eb1ec577842cbf33df1e83c4c11" upstream="master"/>
+  <project dest-branch="master" groups="cts,pdk-cw-fs,pdk-fs" name="platform/test/suite_harness" path="test/suite_harness" revision="72091179f2255a3a595c47cf5c638032edb9ed78" upstream="master"/>
+  <project dest-branch="master" groups="vts,projectarch,pdk" name="platform/test/vti/dashboard" path="test/vti/dashboard" revision="a9bd47e4caa21d535fb89c0e6efe23fa08d25847" upstream="master"/>
+  <project dest-branch="master" groups="vts,projectarch,pdk" name="platform/test/vti/fuzz_test_serving" path="test/vti/fuzz_test_serving" revision="6319e3d94c65669050c49c6ca570096d41823b82" upstream="master"/>
+  <project dest-branch="master" groups="vts,projectarch,pdk" name="platform/test/vti/test_serving" path="test/vti/test_serving" revision="3da55c2868ace67e4841506c3f20caf5b9dd27cb" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/test/vts" path="test/vts" revision="314bae8b91ca727f816475e626a1e41d5a9a0eef" upstream="master"/>
+  <project dest-branch="master" groups="vts,projectarch,pdk" name="platform/test/vts-testcase/fuzz" path="test/vts-testcase/fuzz" revision="b740c5e12e313e90f5d6754d04c72f19503aea57" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/test/vts-testcase/hal" path="test/vts-testcase/hal" revision="51c06ae8f4d844cda5b961d808764eb8e9db3ff7" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/test/vts-testcase/hal-trace" path="test/vts-testcase/hal-trace" revision="2695892568f8fade958ec0ec172df8f295ae4112" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/test/vts-testcase/kernel" path="test/vts-testcase/kernel" revision="c57f93de798733b2d511b015873dacb916d9a348" upstream="master"/>
+  <project dest-branch="master" groups="vts,projectarch,pdk" name="platform/test/vts-testcase/nbu" path="test/vts-testcase/nbu" revision="0712e2a442364af77a0b1dda0adf922d1d1447bc" upstream="master"/>
+  <project dest-branch="master" groups="vts,projectarch,pdk" name="platform/test/vts-testcase/performance" path="test/vts-testcase/performance" revision="f0e5dcee43de6f9c44a3872721087d96eaa48273" upstream="master"/>
+  <project dest-branch="master" groups="vts,projectarch,pdk" name="platform/test/vts-testcase/security" path="test/vts-testcase/security" revision="50d45dc890d2ce5ad35527c0e3f3d82e7edbbe1f" upstream="master"/>
+  <project dest-branch="master" groups="vts,pdk" name="platform/test/vts-testcase/vndk" path="test/vts-testcase/vndk" revision="97e65cac9fab46b50fb3d1ff6c5e8aacd942a61e" upstream="master"/>
+  <project dest-branch="master" groups="tools,vts,projectarch,pdk,tradefed" name="platform/tools/acloud" path="tools/acloud" revision="273c7dd9aaba6d4db15b90aafb3e62f1a42058d1" upstream="master"/>
+  <project dest-branch="master" groups="pdk,tools" name="platform/tools/apifinder" path="tools/apifinder" revision="84052f24c4260257c01e298a454cb044a5c01242" upstream="master"/>
+  <project dest-branch="master" groups="pdk,tradefed" name="platform/tools/apksig" path="tools/apksig" revision="2dd388f2f5595d93199ed322ff55c48233d89e99" upstream="master"/>
+  <project dest-branch="master" groups="pdk,tradefed" name="platform/tools/apkzlib" path="tools/apkzlib" revision="eba4cc5b98798e46c3f80b9dd0bdbd92757e4dde" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/tools/asuite" path="tools/asuite" revision="5397c316b5acba10250a077a2a0010ae9bed5700" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/tools/currysrc" path="tools/currysrc" revision="7074dfcc06d5e89a0980885c6955124edbb946fc" upstream="master"/>
+  <project dest-branch="master" groups="tools,pdk-fs" name="platform/tools/dexter" path="tools/dexter" revision="29183339b36620dae3cca0d6c5632f00ad75dee3" upstream="master"/>
+  <project dest-branch="master" groups="tools" name="platform/tools/doc_generation" path="tools/doc_generation" revision="e7c9b74790a10ef58f165b32d0755831a8d93e32" upstream="master"/>
+  <project dest-branch="master" groups="tools" name="platform/tools/external/fat32lib" path="tools/external/fat32lib" revision="68194a031e8f0a8f4ab68184aeb7ee9d9b86ceca" upstream="master"/>
+  <project dest-branch="master" groups="tools" name="platform/tools/external_updater" path="tools/external_updater" revision="e8c98de52551020ad857b106d45f026ee607d6f4" upstream="master"/>
+  <project dest-branch="master" groups="nopresubmit,pdk,tradefed" name="platform/tools/loganalysis" path="tools/loganalysis" revision="77e029a6d9f4c32190d04c9f95b5fe0abe1908ba" upstream="master"/>
+  <project dest-branch="master" groups="pdk,tools" name="platform/tools/metalava" path="tools/metalava" revision="5c44209c290f571d0f9e70114dd61b23aed28279" upstream="master"/>
+  <project dest-branch="master" groups="adt-infra,cts,developers,motodev,pdk,tools,tradefed" name="platform/tools/repohooks" path="tools/repohooks" revision="07107e6bd338844643aa173683f0826366dd9664" upstream="master"/>
+  <project dest-branch="master" groups="pdk,tools" name="platform/tools/security" path="tools/security" revision="5de12c62271730443c0762a13c0b6d229435261e" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/tools/test/connectivity" path="tools/test/connectivity" revision="4abe9950da54f255f706ed37c47ea90f40c007d2" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="platform/tools/test/graphicsbenchmark" path="tools/test/graphicsbenchmark" revision="9eb54ab3f7f35d1696ca650d02a0657620d25f09" upstream="master"/>
+  <project dest-branch="master" groups="pdk,tradefed" name="platform/tools/tradefederation" path="tools/tradefederation/core" revision="07ec6549a9c1cedf7d72c7b671733801f4c7b8b6" upstream="master"/>
+  <project dest-branch="master" groups="pdk,tradefed" name="platform/tools/tradefederation/contrib" path="tools/tradefederation/contrib" revision="7eaeb6b981685b77df5bf7b22a05ce7a11d17b0d" upstream="master"/>
+  <project dest-branch="master" groups="tools,pdk" name="platform/tools/treble" path="tools/treble" revision="513316f3ddf23ca6c28cea37d0ca00d00ea84f4b" upstream="master"/>
+  <project dest-branch="master" groups="tools,cts,pdk,pdk-cw-fs,pdk-fs" name="platform/tools/trebuchet" path="tools/trebuchet" revision="d2240446bb55e53591d85fe1b9a795aca10a92be" upstream="master"/>
+  <project dest-branch="master" name="toolchain/benchmark" revision="f0080c2949dd06f1c565738e06b3bbd2c100de3b" upstream="master"/>
+  <project dest-branch="master" groups="pdk" name="toolchain/pgo-profiles" revision="c4966d71bbf434c71c9b1552ed421a54b66dcfa4" upstream="master"/>
+  <project dest-branch="master" groups="pdk-cw-fs,pdk-fs,pdk" name="tools/platform-compat" revision="2fbdb23e180f36de523066beaf3a20a1efc5389b" upstream="master"/>
 
   <repo-hooks enabled-list="pre-upload" in-project="platform/tools/repohooks"/>
 </manifest>

--- a/master.xml
+++ b/master.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch="https://android.googlesource.com/"
            review="https://android-review.googlesource.com/" />
-  <default revision="refs/tags/android-r-preview-2"
+  <default revision="master"
            remote="aosp"
            sync-j="4" />
 
@@ -88,7 +88,7 @@
   <project path="device/ti/beagle_x15" name="device/ti/beagle-x15" groups="device,beagle_x15,pdk" />
   <project path="device/ti/beagle_x15-kernel" name="device/ti/beagle-x15-kernel" groups="device,beagle_x15,pdk" clone-depth="1" />
   <project path="external/aac" name="platform/external/aac" groups="pdk" />
-  <project path="external/adeb" name="platform/external/adeb" groups="pdk" />
+  <project path="external/abseil-cpp" name="platform/external/abseil-cpp" groups="pdk" />
   <project path="external/adhd" name="platform/external/adhd" groups="pdk" />
   <project path="external/adt-infra" name="platform/external/adt-infra" groups="adt-infra,notdefault,pdk-fs" />
   <project path="external/android-clat" name="platform/external/android-clat" groups="pdk" />
@@ -105,6 +105,7 @@
   <project path="external/arm-neon-tests" name="platform/external/arm-neon-tests" groups="vendor" />
   <project path="external/arm-optimized-routines" name="platform/external/arm-optimized-routines" groups="pdk" />
   <project path="external/arm-trusted-firmware" name="platform/external/arm-trusted-firmware" groups="pdk" />
+  <project path="external/auto" name="platform/external/auto" groups="pdk" />
   <project path="external/autotest" name="platform/external/autotest" groups="pdk-fs" />
   <project path="external/avb" name="platform/external/avb" groups="pdk" />
   <project path="external/bc" name="platform/external/bc" groups="pdk" />
@@ -156,6 +157,7 @@
   <project path="external/elfutils" name="platform/external/elfutils" groups="pdk" />
   <project path="external/emma" name="platform/external/emma" groups="pdk" />
   <project path="external/error_prone" name="platform/external/error_prone" groups="pdk" />
+  <project path="external/escapevelocity" name="platform/external/escapevelocity" groups="pdk" />
   <project path="external/ethtool" name="platform/external/ethtool" groups="pdk" />
   <project path="external/expat" name="platform/external/expat" groups="pdk" />
   <project path="external/f2fs-tools" name="platform/external/f2fs-tools" groups="pdk" />
@@ -189,6 +191,7 @@
   <project path="external/google-fonts/rubik" name="platform/external/google-fonts/rubik" groups="pdk" />
   <project path="external/google-fonts/zilla-slab" name="platform/external/google-fonts/zilla-slab" groups="pdk" />
   <project path="external/google-fruit" name="platform/external/google-fruit" groups="pdk" />
+  <project path="external/google-java-format" name="platform/external/google-java-format" groups="pdk" />
   <project path="external/google-styleguide" name="platform/external/google-styleguide" groups="pdk" />
   <project path="external/googletest" name="platform/external/googletest" groups="pdk" />
   <project path="external/gptfdisk" name="platform/external/gptfdisk" groups="pdk" />
@@ -233,7 +236,9 @@
   <project path="external/kernel-headers" name="platform/external/kernel-headers" groups="pdk" />
   <project path="external/kmod" name="platform/external/kmod" groups="pdk" />
   <project path="external/kotlinc" name="platform/external/kotlinc" groups="pdk" />
+  <project path="external/kotlinx.atomicfu" name="platform/external/kotlinx.atomicfu" groups="pdk" />
   <project path="external/kotlinx.coroutines" name="platform/external/kotlinx.coroutines" groups="pdk" />
+  <project path="external/kotlinx.metadata" name="platform/external/kotlinx.metadata" groups="pdk" />
   <project path="external/ksoap2" name="platform/external/ksoap2" groups="pdk" />
   <project path="external/libaom" name="platform/external/libaom" groups="pdk" />
   <project path="external/libavc" name="platform/external/libavc" groups="pdk" />
@@ -242,10 +247,10 @@
   <project path="external/libcap" name="platform/external/libcap" groups="pdk" />
   <project path="external/libcap-ng" name="platform/external/libcap-ng" groups="pdk" />
   <project path="external/libchrome" name="platform/external/libchrome" groups="pdk" />
+  <project path="external/libcppbor" name="platform/external/libcppbor" groups="pdk" />
   <project path="external/libcups" name="platform/external/libcups" groups="pdk-cw-fs,pdk-fs" />
   <project path="external/libcxx" name="platform/external/libcxx" groups="pdk" />
   <project path="external/libcxxabi" name="platform/external/libcxxabi" groups="pdk" />
-  <project path="external/libdaemon" name="platform/external/libdaemon" groups="pdk" />
   <project path="external/libdivsufsort" name="platform/external/libdivsufsort" groups="pdk" />
   <project path="external/libdrm" name="platform/external/libdrm" groups="pdk" />
   <project path="external/libepoxy" name="platform/external/libepoxy" groups="pdk" />
@@ -278,17 +283,19 @@
   <project path="external/libutf" name="platform/external/libutf" groups="pdk" />
   <project path="external/libvpx" name="platform/external/libvpx" groups="pdk" />
   <project path="external/libvterm" name="platform/external/libvterm" groups="pdk" />
+  <project path="external/libwebsockets" name="platform/external/libwebsockets" groups="pdk" />
   <project path="external/libxaac" name="platform/external/libxaac" groups="pdk" />
   <project path="external/libxkbcommon" name="platform/external/libxkbcommon" groups="pdk" />
   <project path="external/libxml2" name="platform/external/libxml2" groups="pdk,libxml2" />
   <project path="external/libyuv" name="platform/external/libyuv" groups="pdk,libyuv" />
-  <project path="external/linux-kselftest" name="platform/external/linux-kselftest" groups="vts,pdk" />
+  <project path="external/linux-kselftest" name="platform/external/linux-kselftest" groups="vts,pdk" clone-depth="1" />
   <project path="external/llvm" name="platform/external/llvm" groups="pdk" />
   <project path="external/lmfit" name="platform/external/lmfit" groups="pdk" />
   <project path="external/lua" name="platform/external/lua" groups="pdk" />
   <project path="external/ltp" name="platform/external/ltp" groups="vts,pdk" />
   <project path="external/lz4" name="platform/external/lz4" groups="pdk" />
   <project path="external/lzma" name="platform/external/lzma" groups="pdk" />
+  <project path="external/marisa-trie" name="platform/external/marisa-trie" groups="pdk" />
   <project path="external/markdown" name="platform/external/markdown" groups="pdk" />
   <project path="external/mdnsresponder" name="platform/external/mdnsresponder" groups="pdk" />
   <project path="external/mesa3d" name="platform/external/mesa3d" groups="pdk-cw-fs,pdk-fs" />
@@ -309,10 +316,9 @@
   <project path="external/neon_2_sse" name="platform/external/neon_2_sse" groups="pdk" />
   <project path="external/neven" name="platform/external/neven" groups="pdk" />
   <project path="external/newfs_msdos" name="platform/external/newfs_msdos" groups="pdk" />
-  <project path="external/nfacct" name="platform/external/nfacct" groups="pdk" />
   <project path="external/nist-pkits" name="platform/external/nist-pkits" groups="pdk" />
   <project path="external/nist-sip" name="platform/external/nist-sip" groups="pdk" />
-  <project path="external/nos/host/generic" name="platform/external/nos/host/generic" groups="pixel" />
+  <project path="external/nos/host/generic" name="platform/external/nos/host/generic" groups="pdk" />
   <project path="external/noto-fonts" name="platform/external/noto-fonts" groups="pdk" />
   <project path="external/oauth" name="platform/external/oauth" groups="pdk" />
   <project path="external/objenesis" name="platform/external/objenesis" groups="pdk" />
@@ -323,6 +329,7 @@
   <project path="external/OpenCSD" name="platform/external/OpenCSD" groups="pdk" />
   <project path="external/oss-fuzz" name="platform/external/oss-fuzz" groups="pdk" />
   <project path="external/owasp/sanitizer" name="platform/external/owasp/sanitizer" groups="pdk" />
+  <project path="external/pffft" name="platform/external/pffft" groups="pdk" />
   <project path="external/parameter-framework" name="platform/external/parameter-framework" groups="pdk" />
   <project path="external/pcre" name="platform/external/pcre" groups="pdk" />
   <project path="external/pdfium" name="platform/external/pdfium" groups="pdk" />
@@ -350,6 +357,7 @@
   <project path="external/python/ipaddress" name="platform/external/python/ipaddress" groups="pdk" />
   <project path="external/python/mock" name="platform/external/python/mock" groups="pdk" />
   <project path="external/python/oauth2client" name="platform/external/python/oauth2client" groups="vts,pdk" />
+  <project path="external/python/parse_type" name="platform/external/python/parse_type" groups="vts,pdk" />
   <project path="external/python/pyasn1" name="platform/external/python/pyasn1" groups="vts,pdk" />
   <project path="external/python/pyasn1-modules" name="platform/external/python/pyasn1-modules" groups="vts,pdk" />
   <project path="external/python/pybind11" name="platform/external/python/pybind11" groups="pdk" />
@@ -367,14 +375,78 @@
   <project path="external/roboto-fonts" name="platform/external/roboto-fonts" groups="pdk" />
   <project path="external/rootdev" name="platform/external/rootdev" groups="pdk" />
   <project path="external/Reactive-Extensions/RxCpp" name="platform/external/Reactive-Extensions/RxCpp" groups="pdk" />
+  <project path="external/rnnoise" name="platform/external/rnnoise" groups="pdk" />
+  <project path="external/rust/crates/aho-corasick" name="platform/external/rust/crates/aho-corasick" groups="pdk" />
+  <project path="external/rust/crates/android_logger" name="platform/external/rust/crates/android_logger" groups="pdk" />
+  <project path="external/rust/crates/android_log-sys" name="platform/external/rust/crates/android_log-sys" groups="pdk" />
+  <project path="external/rust/crates/anyhow" name="platform/external/rust/crates/anyhow" groups="pdk" />
+  <project path="external/rust/crates/bindgen" name="platform/external/rust/crates/bindgen" groups="pdk" />
   <project path="external/rust/crates/bitflags" name="platform/external/rust/crates/bitflags" groups="pdk" />
-  <project path="external/rust/crates/byteorder" name="platform/external/rust/crates/byteorder" groups="pdk" />
+  <project path="external/rust/crates/bytes" name="platform/external/rust/crates/bytes" groups="pdk" />
+  <project path="external/rust/crates/cexpr" name="platform/external/rust/crates/cexpr" groups="pdk" />
+  <project path="external/rust/crates/cfg-if" name="platform/external/rust/crates/cfg-if" groups="pdk" />
+  <project path="external/rust/crates/clang-sys" name="platform/external/rust/crates/clang-sys" groups="pdk" />
+  <project path="external/rust/crates/clap" name="platform/external/rust/crates/clap" groups="pdk" />
+  <project path="external/rust/crates/codespan-reporting" name="platform/external/rust/crates/codespan-reporting" groups="pdk" />
+  <project path="external/rust/crates/env_logger" name="platform/external/rust/crates/env_logger" groups="pdk" />
+  <project path="external/rust/crates/futures" name="platform/external/rust/crates/futures" groups="pdk" />
+  <project path="external/rust/crates/futures-channel" name="platform/external/rust/crates/futures-channel" groups="pdk" />
+  <project path="external/rust/crates/futures-core" name="platform/external/rust/crates/futures-core" groups="pdk" />
+  <project path="external/rust/crates/futures-executor" name="platform/external/rust/crates/futures-executor" groups="pdk" />
+  <project path="external/rust/crates/futures-io" name="platform/external/rust/crates/futures-io" groups="pdk" />
+  <project path="external/rust/crates/futures-macro" name="platform/external/rust/crates/futures-macro" groups="pdk" />
+  <project path="external/rust/crates/futures-sink" name="platform/external/rust/crates/futures-sink" groups="pdk" />
+  <project path="external/rust/crates/futures-task" name="platform/external/rust/crates/futures-task" groups="pdk" />
+  <project path="external/rust/crates/futures-util" name="platform/external/rust/crates/futures-util" groups="pdk" />
+  <project path="external/rust/crates/getrandom" name="platform/external/rust/crates/getrandom" groups="pdk" />
+  <project path="external/rust/crates/glob" name="platform/external/rust/crates/glob" groups="pdk" />
+  <project path="external/rust/crates/heck" name="platform/external/rust/crates/heck" groups="pdk" />
+  <project path="external/rust/crates/lazy_static" name="platform/external/rust/crates/lazy_static" groups="pdk" />
+  <project path="external/rust/crates/lazycell" name="platform/external/rust/crates/lazycell" groups="pdk" />
   <project path="external/rust/crates/libc" name="platform/external/rust/crates/libc" groups="pdk" />
+  <project path="external/rust/crates/libloading" name="platform/external/rust/crates/libloading" groups="pdk" />
+  <project path="external/rust/crates/log" name="platform/external/rust/crates/log" groups="pdk" />
+  <project path="external/rust/crates/memchr" name="platform/external/rust/crates/memchr" groups="pdk" />
+  <project path="external/rust/crates/nom" name="platform/external/rust/crates/nom" groups="pdk" />
+  <project path="external/rust/crates/once_cell" name="platform/external/rust/crates/once_cell" groups="pdk" />
+  <project path="external/rust/crates/pin-project" name="platform/external/rust/crates/pin-project" groups="pdk" />
+  <project path="external/rust/crates/pin-project-internal" name="platform/external/rust/crates/pin-project-internal" groups="pdk" />
+  <project path="external/rust/crates/pin-utils" name="platform/external/rust/crates/pin-utils" groups="pdk" />
+  <project path="external/rust/crates/paste" name="platform/external/rust/crates/paste" groups="pdk" />
+  <project path="external/rust/crates/paste-impl" name="platform/external/rust/crates/paste-impl" groups="pdk" />
+  <project path="external/rust/crates/peeking_take_while" name="platform/external/rust/crates/peeking_take_while" groups="pdk" />
+  <project path="external/rust/crates/ppv-lite86" name="platform/external/rust/crates/ppv-lite86" groups="pdk" />
+  <project path="external/rust/crates/proc-macro-error" name="platform/external/rust/crates/proc-macro-error" groups="pdk" />
+  <project path="external/rust/crates/proc-macro-error-attr" name="platform/external/rust/crates/proc-macro-error-attr" groups="pdk" />
+  <project path="external/rust/crates/proc-macro-hack" name="platform/external/rust/crates/proc-macro-hack" groups="pdk" />
+  <project path="external/rust/crates/proc-macro-nested" name="platform/external/rust/crates/proc-macro-nested" groups="pdk" />
   <project path="external/rust/crates/proc-macro2" name="platform/external/rust/crates/proc-macro2" groups="pdk" />
+  <project path="external/rust/crates/protobuf" name="platform/external/rust/crates/protobuf" groups="pdk" />
+  <project path="external/rust/crates/protobuf-codegen" name="platform/external/rust/crates/protobuf-codegen" groups="pdk" />
   <project path="external/rust/crates/quote" name="platform/external/rust/crates/quote" groups="pdk" />
+  <project path="external/rust/crates/rand" name="platform/external/rust/crates/rand" groups="pdk" />
+  <project path="external/rust/crates/rand_chacha" name="platform/external/rust/crates/rand_chacha" groups="pdk" />
+  <project path="external/rust/crates/rand_core" name="platform/external/rust/crates/rand_core" groups="pdk" />
+  <project path="external/rust/crates/regex" name="platform/external/rust/crates/regex" groups="pdk" />
+  <project path="external/rust/crates/regex-syntax" name="platform/external/rust/crates/regex-syntax" groups="pdk" />
   <project path="external/rust/crates/remain" name="platform/external/rust/crates/remain" groups="pdk" />
+  <project path="external/rust/crates/rustc-hash" name="platform/external/rust/crates/rustc-hash" groups="pdk" />
+  <project path="external/rust/crates/shlex" name="platform/external/rust/crates/shlex" groups="pdk" />
+  <project path="external/rust/crates/slab" name="platform/external/rust/crates/slab" groups="pdk" />
+  <project path="external/rust/crates/structopt" name="platform/external/rust/crates/structopt" groups="pdk" />
+  <project path="external/rust/crates/structopt-derive" name="platform/external/rust/crates/structopt-derive" groups="pdk" />
   <project path="external/rust/crates/syn" name="platform/external/rust/crates/syn" groups="pdk" />
+  <project path="external/rust/crates/syn-mid" name="platform/external/rust/crates/syn-mid" groups="pdk" />
+  <project path="external/rust/crates/termcolor" name="platform/external/rust/crates/termcolor" groups="pdk" />
+  <project path="external/rust/crates/textwrap" name="platform/external/rust/crates/textwrap" groups="pdk" />
+  <project path="external/rust/crates/thiserror" name="platform/external/rust/crates/thiserror" groups="pdk" />
+  <project path="external/rust/crates/thiserror-impl" name="platform/external/rust/crates/thiserror-impl" groups="pdk" />
+  <project path="external/rust/crates/thread_local" name="platform/external/rust/crates/thread_local" groups="pdk" />
+  <project path="external/rust/crates/unicode-width" name="platform/external/rust/crates/unicode-width" groups="pdk" />
+  <project path="external/rust/crates/unicode-segmentation" name="platform/external/rust/crates/unicode-segmentation" groups="pdk" />
   <project path="external/rust/crates/unicode-xid" name="platform/external/rust/crates/unicode-xid" groups="pdk" />
+  <project path="external/rust/crates/which" name="platform/external/rust/crates/which" groups="pdk" />
+  <project path="external/rust/cxx" name="platform/external/rust/cxx" groups="pdk" />
   <project path="external/scapy" name="platform/external/scapy" groups="pdk-fs" />
   <project path="external/scrypt" name="platform/external/scrypt" groups="pdk" />
   <project path="external/scudo" name="platform/external/scudo" groups="pdk" />
@@ -417,6 +489,7 @@
   <project path="external/unicode" name="platform/external/unicode" groups="pdk" />
   <project path="external/universal-tween-engine" name="platform/external/universal-tween-engine" />
   <project path="external/ukey2" name="platform/external/ukey2" groups="pdk" />
+  <project path="external/usrsctp" name="platform/external/usrsctp" groups="pdk" />
   <project path="external/v4l2_codec2" name="platform/external/v4l2_codec2" groups="pdk" />
   <project path="external/v8" name="platform/external/v8" groups="pdk" />
   <project path="external/vboot_reference" name="platform/external/vboot_reference" groups="vboot,pdk-fs" />
@@ -440,6 +513,7 @@
   <project path="external/yapf" name="platform/external/yapf" groups="vts,projectarch,pdk" />
   <project path="external/zlib" name="platform/external/zlib" groups="pdk" />
   <project path="external/zopfli" name="platform/external/zopfli" groups="pdk" />
+  <project path="external/zstd" name="platform/external/zstd" groups="pdk" />
   <project path="external/zxing" name="platform/external/zxing" groups="pdk" />
   <project path="frameworks/av" name="platform/frameworks/av" groups="pdk" />
   <project path="frameworks/base" name="platform/frameworks/base" groups="pdk-cw-fs,pdk-fs" />
@@ -450,6 +524,7 @@
   <project path="frameworks/hardware/interfaces" name="platform/frameworks/hardware/interfaces" groups="pdk" />
   <project path="frameworks/layoutlib" name="platform/frameworks/layoutlib" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/libs/net" name="platform/frameworks/libs/net" groups="pdk-cw-fs,pdk-fs" />
+  <project path="frameworks/libs/native_bridge_support" name="platform/frameworks/libs/native_bridge_support" groups="pdk" />
   <project path="frameworks/minikin" name="platform/frameworks/minikin" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/ml" name="platform/frameworks/ml" groups="pdk" />
   <project path="frameworks/multidex" name="platform/frameworks/multidex" groups="pdk-cw-fs,pdk-fs" />
@@ -461,7 +536,6 @@
   <project path="frameworks/opt/chips" name="platform/frameworks/opt/chips" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/opt/colorpicker" name="platform/frameworks/opt/colorpicker" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/opt/net/ethernet" name="platform/frameworks/opt/net/ethernet" groups="pdk-fs" />
-  <project path="frameworks/opt/net/ike" name="platform/frameworks/opt/net/ike" groups="pdk" />
   <project path="frameworks/opt/net/ims" name="platform/frameworks/opt/net/ims" groups="frameworks_ims,pdk-cw-fs,pdk-fs" />
   <project path="frameworks/opt/net/voip" name="platform/frameworks/opt/net/voip" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/opt/net/wifi" name="platform/frameworks/opt/net/wifi" groups="pdk" />
@@ -529,8 +603,8 @@
   <project path="hardware/ril" name="platform/hardware/ril" groups="pdk" />
   <project path="hardware/st/nfc" name="platform/hardware/st/nfc" groups="pdk" />
   <project path="hardware/st/secure_element" name="platform/hardware/st/secure_element" groups="pdk" />
+  <project path="hardware/st/secure_element2" name="platform/hardware/st/secure_element2" groups="pdk" />
   <project path="hardware/ti/am57x" name="platform/hardware/ti/am57x" groups="pdk" />
-  <project path="kernel/build" name="kernel/build" />
   <project path="kernel/configs" name="kernel/configs" groups="vts,pdk" />
   <project path="kernel/tests" name="kernel/tests" groups="vts,pdk" />
   <project path="libcore" name="platform/libcore" groups="pdk" />
@@ -541,6 +615,7 @@
   <project path="packages/apps/Calendar" name="platform/packages/apps/Calendar" groups="pdk-fs" />
   <project path="packages/apps/Camera2" name="platform/packages/apps/Camera2" groups="pdk-fs" />
   <project path="packages/apps/Car/Cluster" name="platform/packages/apps/Car/Cluster" groups="pdk-fs" />
+  <project path="packages/apps/Car/CompanionDeviceSupport" name="platform/packages/apps/Car/CompanionDeviceSupport" groups="pdk-fs" />
   <project path="packages/apps/Car/Dialer" name="platform/packages/apps/Car/Dialer" groups="pdk-fs" />
   <project path="packages/apps/Car/Hvac" name="platform/packages/apps/Car/Hvac" groups="pdk-fs" />
   <project path="packages/apps/Car/LatinIME" name="platform/packages/apps/Car/LatinIME" groups="pdk-fs" />
@@ -589,7 +664,6 @@
   <project path="packages/apps/SecureElement" name="platform/packages/apps/SecureElement" groups="apps_se,pdk-fs" />
   <project path="packages/apps/Settings" name="platform/packages/apps/Settings" groups="pdk-fs" />
   <project path="packages/apps/SettingsIntelligence" name="platform/packages/apps/SettingsIntelligence" groups="pdk-fs" />
-  <project path="packages/apps/SoundRecorder" name="platform/packages/apps/SoundRecorder" groups="pdk-fs" />
   <project path="packages/apps/SpareParts" name="platform/packages/apps/SpareParts" groups="pdk-fs" />
   <project path="packages/apps/Stk" name="platform/packages/apps/Stk" groups="apps_stk,pdk-fs" />
   <project path="packages/apps/StorageManager" name="platform/packages/apps/StorageManager" groups="pdk-fs" />
@@ -612,10 +686,13 @@
   <project path="packages/modules/CellBroadcastService" name="platform/packages/modules/CellBroadcastService" groups="pdk" />
   <project path="packages/modules/Cronet" name="platform/packages/modules/Cronet" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/modules/ExtServices" name="platform/packages/modules/ExtServices" groups="pdk-cw-fs,pdk-fs" />
+  <project path="packages/modules/IPsec" name="platform/packages/modules/IPsec" groups="pdk" />
   <project path="packages/modules/DnsResolver" name="platform/packages/modules/DnsResolver" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/modules/ModuleMetadata" name="platform/packages/modules/ModuleMetadata" groups="pdk" />
   <project path="packages/modules/NetworkPermissionConfig" name="platform/packages/modules/NetworkPermissionConfig" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/modules/NetworkStack" name="platform/packages/modules/NetworkStack" groups="pdk-cw-fs,pdk-fs" />
+  <project path="packages/modules/RuntimeI18n" name="platform/packages/modules/RuntimeI18n" groups="pdk-cw-fs,pdk-fs" />
+  <project path="packages/modules/SdkExtensions" name="platform/packages/modules/SdkExtensions" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/modules/TestModule" name="platform/packages/modules/TestModule" />
   <project path="packages/modules/vndk" name="platform/packages/modules/vndk" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/providers/BlockedNumberProvider" name="platform/packages/providers/BlockedNumberProvider" groups="pdk-fs" />
@@ -652,6 +729,7 @@
   <project path="prebuilts/clang-tools" name="platform/prebuilts/clang-tools" groups="pdk" clone-depth="1" />
   <project path="prebuilts/clang/host/darwin-x86" name="platform/prebuilts/clang/host/darwin-x86" groups="pdk,darwin" clone-depth="1" />
   <project path="prebuilts/clang/host/linux-x86" name="platform/prebuilts/clang/host/linux-x86" groups="pdk" clone-depth="1" />
+  <project path="prebuilts/cmdline-tools" name="platform/prebuilts/cmdline-tools" groups="pdk-fs" clone-depth="1" />
   <project path="prebuilts/devtools" name="platform/prebuilts/devtools" groups="pdk-fs" clone-depth="1" />
   <project path="prebuilts/fuchsia_sdk" name="platform/prebuilts/fuchsia_sdk" groups="pdk-fs" clone-depth="1" />
   <project path="prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9" name="platform/prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9" groups="pdk,darwin,arm" clone-depth="1" />
@@ -684,7 +762,6 @@
   <project path="prebuilts/python/linux-x86/2.7.5" name="platform/prebuilts/python/linux-x86/2.7.5" groups="linux,pdk,pdk-cw-fs,pdk-fs" clone-depth="1" />
   <project path="prebuilts/qemu-kernel" name="platform/prebuilts/qemu-kernel" groups="pdk" clone-depth="1" />
   <project path="prebuilts/remoteexecution-client" name="platform/prebuilts/remoteexecution-client" groups="pdk" clone-depth="1" />
-  <project path="prebuilts/runtime" name="platform/prebuilts/runtime" groups="pdk" clone-depth="1" />
   <project path="prebuilts/rust" name="platform/prebuilts/rust" groups="pdk" clone-depth="1" />
   <project path="prebuilts/r8" name="platform/prebuilts/r8" groups="pdk" clone-depth="1" />
   <project path="prebuilts/sdk" name="platform/prebuilts/sdk" groups="pdk" clone-depth="1" />
@@ -692,6 +769,7 @@
   <project path="prebuilts/vndk/v27" name="platform/prebuilts/vndk/v27" groups="pdk" clone-depth="1" />
   <project path="prebuilts/vndk/v28" name="platform/prebuilts/vndk/v28" groups="pdk" clone-depth="1" />
   <project path="prebuilts/vndk/v29" name="platform/prebuilts/vndk/v29" groups="pdk" clone-depth="1" />
+  <project path="prebuilts/vndk/v30" name="platform/prebuilts/vndk/v30" groups="pdk" clone-depth="1" />
   <project path="sdk" name="platform/sdk" groups="pdk-cw-fs,pdk-fs">
     <linkfile src="current/androidx-README.md" dest="frameworks/support/README.md" />
   </project>
@@ -713,15 +791,18 @@
   <project path="system/iorap" name="platform/system/iorap" groups="pdk" />
   <project path="system/keymaster" name="platform/system/keymaster" groups="pdk" />
   <project path="system/libartpalette" name="platform/system/libartpalette" groups="pdk" />
+  <project path="system/libbase" name="platform/system/libbase" groups="pdk" />
   <project path="system/libfmq" name="platform/system/libfmq" groups="pdk" />
   <project path="system/libhidl" name="platform/system/libhidl" groups="pdk" />
   <project path="system/libhwbinder" name="platform/system/libhwbinder" groups="pdk" />
   <project path="system/libsysprop" name="platform/system/libsysprop" groups="pdk" />
   <project path="system/libufdt" name="platform/system/libufdt" groups="pdk" />
   <project path="system/libvintf" name="platform/system/libvintf" groups="pdk" />
+  <project path="system/libziparchive" name="platform/system/libziparchive" groups="pdk" />
   <project path="system/linkerconfig" name="platform/system/linkerconfig" groups="pdk" />
   <project path="system/media" name="platform/system/media" groups="pdk" />
   <project path="system/memory/libion" name="platform/system/memory/libion" groups="pdk" />
+  <project path="system/memory/libdmabufheap" name="platform/system/memory/libdmabufheap" groups="pdk" />
   <project path="system/memory/libmeminfo" name="platform/system/memory/libmeminfo" groups="pdk" />
   <project path="system/memory/libmemtrack" name="platform/system/memory/libmemtrack" groups="pdk" />
   <project path="system/memory/libmemunreachable" name="platform/system/memory/libmemunreachable" groups="pdk" />

--- a/plugins/Android.bp.in
+++ b/plugins/Android.bp.in
@@ -29,6 +29,7 @@ bootstrap_go_package {
     pluginFor: ["soong_build"],
     deps: [
         "soong-android",
+        "soong-etc",
     ],
     srcs: [
         "@@BOB_DIR@@/plugins/prebuilt/prebuilt_data.go",

--- a/plugins/prebuilt/prebuilt_data.go
+++ b/plugins/prebuilt/prebuilt_data.go
@@ -20,6 +20,7 @@ package prebuilt
 
 import (
 	"android/soong/android"
+	"android/soong/etc"
 )
 
 func init() {
@@ -30,7 +31,7 @@ func init() {
 // Prebuilts going to data partition
 type PrebuiltData struct {
 	// pretend to be soong prebuilt module
-	android.PrebuiltEtc
+	etc.PrebuiltEtc
 }
 
 // implemented interfaces check
@@ -41,7 +42,7 @@ func PrebuiltDataFactory() android.Module {
 	m := &PrebuiltData{}
 	// register PrebuiltEtc properties,
 	// install path will be relative to data partition root
-	android.InitPrebuiltEtcModule(&m.PrebuiltEtc, "")
+	etc.InitPrebuiltEtcModule(&m.PrebuiltEtc, "")
 
 	// init module (including name and common properties) with target-specific variants info
 	android.InitAndroidArchModule(m, android.DeviceSupported, android.MultilibFirst)
@@ -71,7 +72,7 @@ func (m *PrebuiltData) InstallInData() bool {
 // Prebuilts going to data partition
 type PrebuiltTestcase struct {
 	// pretend to be soong prebuilt module
-	android.PrebuiltEtc
+	etc.PrebuiltEtc
 }
 
 // implemented interfaces check
@@ -82,7 +83,7 @@ func PrebuiltTestcaseFactory() android.Module {
 	m := &PrebuiltTestcase{}
 	// register PrebuiltEtc properties,
 	// install path will be relative to the `testcases` directory
-	android.InitPrebuiltEtcModule(&m.PrebuiltEtc, "")
+	etc.InitPrebuiltEtcModule(&m.PrebuiltEtc, "")
 
 	// init module (including name and common properties) with target-specific variants info
 	android.InitAndroidArchModule(m, android.DeviceSupported, android.MultilibFirst)


### PR DESCRIPTION
Revert the manifest to the master branch, taken on 2020-07-23. This is
the manifests.git repo SHA 9cd4aa7a5745.

Soong's prebuilt_etc module has moved into a separate package, so
update our prebuilt modules appropriately.

Change-Id: I214c4d82d3d983642340aa8dd6775edaa0508f0d
Signed-off-by: David Kilroy <david.kilroy@arm.com>