### PR TITLE
Fix bob_resource tests on Soong

### DIFF
--- a/tests/resources/build.bp
+++ b/tests/resources/build.bp
@@ -21,7 +21,7 @@ bob_install_group {
         install_path: "$(TARGET_OUT_TESTCASES)",
     },
     builder_android_bp: {
-        install_path: "testcases",
+        install_path: "tests",
     },
     builder_ninja: {
         install_path: "install/testcases",


### PR DESCRIPTION
This commit fixes the install path for the `IG_testcases` install group
on Soong.

Change-Id: Ib97cc18436d2427945cd9148cd9089346c277332
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>