### PR TITLE
Optimize ResolveDependencySortMutator

### DIFF
--- a/core/library.go
+++ b/core/library.go
@@ -976,7 +976,7 @@ func (handler *graphMutatorHandler) ResolveDependencySortMutator(mctx blueprint.
 	// dependencies and the (shared) graph will be complete (for the
 	// current module).
 	for _, nodeID := range sub.GetNodes() {
-		cost := graph.GetSubgraph(sub, nodeID).GetNodeCount()
+		cost := graph.GetSubgraphNodeCount(sub, nodeID)
 		sources, _ := sub.GetSources(nodeID)
 		priority := len(sources)
 		sub.SetNodePriority(nodeID, (10*priority)-cost)

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -326,3 +326,47 @@ func Test_SubnodeOrderAfterDeleteProxyEdges(t *testing.T) {
 			strings.Join(target, ", "))
 	}
 }
+
+func Test_GetSubgraphNodeCount(t *testing.T) {
+	testGraph := NewGraph("Test")
+	testGraph.AddEdge("top", "a")
+	testGraph.AddEdge("top", "b")
+
+	testGraph.AddEdge("a", "a0")
+	testGraph.AddEdge("a", "a1")
+	testGraph.AddEdge("b", "b0")
+	testGraph.AddEdge("b", "b1")
+
+	nodes := []string{"top", "a", "a0", "a1", "b", "b0", "b1"}
+
+	for _, node := range nodes {
+		count1 := GetSubgraph(testGraph, node).GetNodeCount()
+		count2 := GetSubgraphNodeCount(testGraph, node)
+		if count1 != count2 {
+			t.Errorf("Mismatch!\n%d <------- result\n%d <------- correct", count1, count2)
+		}
+	}
+}
+
+func Test_GetSubgraphHasNode(t *testing.T) {
+	testGraph := NewGraph("Test")
+	testGraph.AddEdge("top", "a")
+	testGraph.AddEdge("top", "b")
+
+	testGraph.AddEdge("a", "a0")
+	testGraph.AddEdge("a", "a1")
+	testGraph.AddEdge("b", "b0")
+	testGraph.AddEdge("b", "b1")
+
+	nodes := []string{"top", "a", "a0", "a1", "b", "b0", "b1"}
+
+	for _, node1 := range nodes {
+		for _, node2 := range nodes {
+			res1 := GetSubgraphHasNode(testGraph, node1, node2)
+			res2 := GetSubgraph(testGraph, node1).HasNode(node2)
+			if res1 != res2 {
+				t.Errorf("Mismatch!\n%v <------- result\n%v <------- correct", res1, res2)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Remove redundant calls to GetSubgraph in `internal/graph` to avoid
unnecessary copying. This commit brings the execution time of
`ResolveDependencySortMutator` from around 6.75s (27.58% of the overall
execution time) to around 0.73s (3.86%).

Change-Id: I092cfb0d3b01f4db81fc78cc7f0ce4bc64b190a8
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>