### PR TITLE
Fix signoff checker

### DIFF
--- a/.travis/checks/check-signoff.py
+++ b/.travis/checks/check-signoff.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import os
+import re
 import subprocess
 import sys
 
@@ -15,11 +16,17 @@ ENDC = '\033[0m'
 def isAutomaticMerge(sha):
     """
     Check whether a commit is a non-conflicting merge. Such merge
-    doesn't have any changes in it
+    either doesn't have any changes in it or has a commit message
+    matching a certain regular expression
     """
     cmd = ['git', 'show', '--format=', '--raw', sha]
     commit = subprocess.check_output(cmd).decode("utf-8")
-    return len(commit) == 0
+    if len(commit) == 0:
+        return True
+
+    cmd = ['git', 'log', '-n1', '--format=%B', sha]
+    commit_message = subprocess.check_output(cmd).decode("utf-8")
+    return re.match('Merge [0-9a-f]+ into [0-9a-f]+\n\n$', commit_message)
 
 
 def isSignedOff(message):


### PR DESCRIPTION
This commit fixes the signoff checker script that is run on Travis by
enabling `isAutomaticMerge` to recognize non-empty merge commits.

Change-Id: Ib19aa3148fd675e783802345a12c0dcba480df4f
Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>