### PR TITLE
Independent default

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -460,17 +460,6 @@ func pathMutator(mctx blueprint.BottomUpMutatorContext) {
 	}
 }
 
-type buildWrapperProcessor interface {
-	processBuildWrapper(blueprint.BaseModuleContext)
-}
-
-// Prefixes build_wrapper with source path if necessary
-func buildWrapperMutator(mctx blueprint.BottomUpMutatorContext) {
-	if p, ok := mctx.Module().(buildWrapperProcessor); ok {
-		p.processBuildWrapper(mctx)
-	}
-}
-
 func collectReexportLibsDependenciesMutator(mctx blueprint.TopDownMutatorContext) {
 	mainModule := mctx.Module()
 	if e, ok := mainModule.(enableable); ok {

--- a/core/library.go
+++ b/core/library.go
@@ -286,6 +286,10 @@ func (l *Build) processPaths(ctx blueprint.BaseModuleContext, g generatorBackend
 	if l.Target.Kernel_dir != "" && !filepath.IsAbs(l.Target.Kernel_dir) {
 		l.Target.Kernel_dir = filepath.Join(prefix, l.Target.Kernel_dir)
 	}
+
+	l.BuildProps.processBuildWrapper(ctx)
+	l.Host.processBuildWrapper(ctx)
+	l.Target.processBuildWrapper(ctx)
 }
 
 // library is a base class for modules which are generated from sets of object files
@@ -556,12 +560,6 @@ func (l *library) GetExportedVariables(ctx blueprint.ModuleContext) (expLocalInc
 
 func (l *library) processPaths(ctx blueprint.BaseModuleContext, g generatorBackend) {
 	l.Properties.Build.processPaths(ctx, g)
-}
-
-func (l *library) processBuildWrapper(ctx blueprint.BaseModuleContext) {
-	l.Properties.Build.BuildProps.processBuildWrapper(ctx)
-	l.Properties.Build.Host.processBuildWrapper(ctx)
-	l.Properties.Build.Target.processBuildWrapper(ctx)
 }
 
 func (m *library) filesToInstall(ctx blueprint.BaseModuleContext) []string {

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -136,7 +136,6 @@ func Main() {
 	ctx.RegisterBottomUpMutator("check_lib_fields", checkLibraryFieldsMutator).Parallel()
 	ctx.RegisterBottomUpMutator("strip_empty_components", stripEmptyComponentsMutator).Parallel()
 	ctx.RegisterBottomUpMutator("process_paths", pathMutator).Parallel()
-	ctx.RegisterBottomUpMutator("process_build_wrapper", buildWrapperMutator).Parallel()
 	ctx.RegisterTopDownMutator("supported_variants", supportedVariantsMutator).Parallel()
 	ctx.RegisterBottomUpMutator(splitterMutatorName, splitterMutator).Parallel()
 	ctx.RegisterTopDownMutator("target", targetMutator).Parallel()


### PR DESCRIPTION
Start the process of making `bob_defaults` independent from `library`. Eventually they will have separate property sets, allowing the use of defaults on more module types.