### PR TITLE
Reconfigure and print configuration for build directory

### DIFF
--- a/bootstrap/utils.bash
+++ b/bootstrap/utils.bash
@@ -43,7 +43,9 @@ function create_config_symlinks() {
     local BOB_DIR="${1}" BUILDDIR="${2}"
 
     ln -sf "${BOB_DIR}/config.bash" "${BUILDDIR}/config"
+    ln -sf "${BOB_DIR}/reconfig.bash" "${BUILDDIR}/reconfig"
     ln -sf "${BOB_DIR}/menuconfig.bash" "${BUILDDIR}/menuconfig"
+    ln -sf "${BOB_DIR}/print_user_config.bash" "${BUILDDIR}/print_user_config"
     ln -sf "${BOB_DIR}/config_system/mconfigfmt.py" "${BUILDDIR}/mconfigfmt"
 }
 

--- a/config_system/print_user_config.py
+++ b/config_system/print_user_config.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# Copyright 2020 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+import logging
+import re
+import sys
+
+from config_system import log_handlers
+from config_system.general import read_config, get_user_set_options
+
+root_logger = logging.getLogger()
+root_logger.setLevel(logging.WARNING)
+
+# Add StreamHandler with color Formatter
+stream = logging.StreamHandler()
+formatter = log_handlers.ColorFormatter("%(levelname)s: %(message)s", stream.stream.isatty())
+stream.setFormatter(formatter)
+root_logger.addHandler(stream)
+
+
+def print_user_config():
+    """
+    Prints configuration which has been set by the user
+
+    Particular options are grouped based on provided source.
+    For those options with empty source group name is 'no source'
+    """
+    configs = {}
+    for config in get_user_set_options():
+        (key, value, source) = config
+        if not source in configs:
+            configs[source] = [(key, value)]
+        else:
+            configs[source].append((key, value))
+
+    for key in configs:
+        print("#\n# %s\n#" % (key if key else "no source"))
+        for (name, value) in configs[key]:
+            print("%s=%s" % (name, value))
+        print("")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", "--config", required=True,
+                        help="Path to the configuration file (*.config)")
+    parser.add_argument("-d", "--database", default="Mconfig",
+                        help="Path to the configuration database (Mconfig)")
+    parser.add_argument("--ignore-missing", action="store_true", default=False,
+                        help="Ignore missing database files included with 'source'")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    read_config(args.database, args.config, args.ignore_missing)
+    print_user_config()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/print_user_config.bash
+++ b/print_user_config.bash
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright 2020 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+trap 'echo "*** Unexpected error ***"' ERR
+
+ORIG_PWD="$(pwd)"
+
+# Move to the build directory
+cd $(dirname "${BASH_SOURCE[0]}")
+
+source ".bob.bootstrap"
+
+# Move to the working directory
+cd -P "${WORKDIR}"
+
+ignore_missing="--ignore-missing"
+
+if [[ ! ${BOB_CONFIG_OPTS} =~ ${ignore_missing} ]]; then
+    ignore_missing=""
+fi
+
+"${BOB_DIR}/config_system/print_user_config.py" \
+    -c "${CONFIG_FILE}" \
+    -d "${SRCDIR}/Mconfig" \
+    ${ignore_missing}
+

--- a/reconfig.bash
+++ b/reconfig.bash
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright 2020 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+trap 'echo "*** Unexpected error ***"' ERR
+
+ORIG_PWD="$(pwd)"
+
+# Move to the build directory
+cd $(dirname "${BASH_SOURCE[0]}")
+
+source ".bob.bootstrap"
+
+# Move to the working directory
+cd -P "${WORKDIR}"
+
+"${BOB_DIR}/config_system/update_config.py" -d "${SRCDIR}/Mconfig" \
+    ${BOB_CONFIG_OPTS} ${BOB_CONFIG_PLUGIN_OPTS} \
+    -j "${CONFIG_JSON}" \
+    -c "${CONFIG_FILE}" \
+    --depfile "${CONFIG_FILE}.d"


### PR DESCRIPTION
Switching between build directories does not allow easily
to verify what user configuration has been previously set.

Add script which allows reconfiguration based on previous
configuration set.
Add script which prints all options which has been set by the user.

Change-Id: I7f856af80453e1b6304aae262ecdd51f35256a43
Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>