### PR TITLE
Fix exclude_srcs on Android.bp

### DIFF
--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -210,7 +210,7 @@ func addCcLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContex
 	if l.shortName() != l.outputName() {
 		m.AddString("stem", l.outputName())
 	}
-	m.AddStringList("srcs", utils.Filter(utils.IsCompilableSource, l.Properties.Srcs))
+	m.AddStringList("srcs", utils.Filter(utils.IsCompilableSource, l.Properties.getSources(mctx)))
 	m.AddStringList("generated_sources", l.getGeneratedSourceModules(mctx))
 	genHeaderModules, exportGenHeaderModules := l.getGeneratedHeaderModules(mctx)
 	m.AddStringList("generated_headers", append(genHeaderModules, exportGenHeaderModules...))


### PR DESCRIPTION
When generating a library in Android.bp, use the `getSources` method
rather than accessing the `Srcs` property directly. This will take into
account `exclude_srcs`, which otherwise would be ignored.

Change-Id: I2a7dcccb60f339e2325c1075598787e0938dff29
Signed-off-by: Chris Diamand <chris.diamand@arm.com>