### PR TITLE
Limit environment hashing just to relevant options

### DIFF
--- a/.travis/run_all_tests.sh
+++ b/.travis/run_all_tests.sh
@@ -49,6 +49,12 @@ if [ ${DO_PYTHON_TESTS} -eq 1 ] ; then
         pytest config_system
     fold_end $?
     ####################
+
+    ####################
+    fold_start 'scripts pytest'
+        pytest scripts/env_hash.py
+    fold_end $?
+    ####################
 fi
 
 ####################

--- a/scripts/env_hash.py
+++ b/scripts/env_hash.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,13 +30,70 @@ import config_system.utils as utils  # nopep8: E402 module level import not at t
 
 
 def hash_env():
+    """Hash only relevant environment options"""
+
+    # List of relevant options which might influence the generation of
+    # build.ninja and should be only taken into account while hashing
+    #
+    # For detailed information please check:
+    #      gcc - https://gcc.gnu.org/onlinedocs/gcc/Environment-Variables.html
+    #    clang - https://clang.llvm.org/docs/CommandGuide/clang.html#environment
+    # armclang - https://developer.arm.com/documentation/100748/0606/Supporting-reference-information/Toolchain-environment-variables # nopep8: E501 line to long
+    #
+    relevant_env = [
+        "LD_LIBRARY_PATH",
+        "PATH",
+
+        # bob-build
+        "BOB_CPUPROFILE",
+        "BOB_LINK_PARALLELISM",
+        "BOB_VERSION",
+
+        # go
+        "GO386",
+        "GOARCH",
+        "GOARM",
+        "GOOS",
+        "GOMIPS",
+        "GOPATH",
+        "GOROOT",
+
+        # gcc
+        "C_INCLUDE_PATH",
+        "COMPILER_PATH",
+        "CPATH",
+        "CPLUS_INCLUDE_PATH",
+        "DEPENDENCIES_OUTPUT",
+        "GCC_COMPARE_DEBUG",
+        "GCC_EXEC_PREFIX",
+        "LIBRARY_PATH",
+        "OBJC_INCLUDE_PATH",
+        "SOURCE_DATE_EPOCH",
+        "SUNPRO_DEPENDENCIES",
+
+        # clang
+        "MACOSX_DEPLOYMENT_TARGET",
+        "OBJCPLUS_INCLUDE_PATH",
+
+        # armclang
+        "ARM_PRODUCT_PATH",
+        "ARM_TOOL_VARIANT",
+        "ARMCOMPILER6_ASMOPT",
+        "ARMCOMPILER6_CLANGOPT",
+        "ARMCOMPILER6_FROMELFOPT",
+        "ARMCOMPILER6_LINKOPT",
+        "ARMROOT"
+    ]
+
     m = hashlib.sha256()
     for k in sorted(os.environ.keys()):
-        val = os.environ[k]
-        # When Python 2 is used make sure that utf-8 encoding is used to prevent non-ASCII errors
-        if hasattr(os.environ[k], 'decode'):
-            val = val.decode('utf-8')
-        m.update(u"{}={}\n".format(k, val).encode('utf-8'))
+        if k in relevant_env:
+            val = os.environ[k]
+            # When Python 2 is used make sure that utf-8 encoding
+            # is used to prevent non-ASCII errors
+            if hasattr(os.environ[k], 'decode'):
+                val = val.decode('utf-8')
+            m.update(u"{}={}\n".format(k, val).encode('utf-8'))
     return m.hexdigest()
 
 
@@ -44,6 +101,45 @@ def write_env_hash(filename):
     """Write a hash of the current environment to the named file."""
     with utils.open_and_write_if_changed(filename) as fp:
         fp.write(hash_env())
+
+
+def test_hash_env_relevant():
+    """Test if relevant environment option will change the hash"""
+    no_path_env = False
+    old_path_env = ""
+    org_hash = hash_env()
+
+    # PATH is one of the option that bob cares about
+    if "PATH" in os.environ.keys():
+        old_path_env = os.environ['PATH']
+    else:
+        no_path_env = True
+
+    # change PATH
+    os.environ['PATH'] = "/new/fake/bob/directory"
+
+    # hash should change
+    assert org_hash != hash_env()
+
+    # restore previous state and check hash
+    if no_path_env:
+        del os.environ['PATH']
+    else:
+        os.environ['PATH'] = old_path_env
+
+    # hash should be the same again
+    assert org_hash == hash_env()
+
+
+def test_hash_env_irrelevant():
+    """Test if irrelevant environment option will not change the hash"""
+    org_hash = hash_env()
+
+    # set FAKE_ENV environment option which should not change the hash
+    os.environ['FAKE_ENV'] = "/fake/environment/set"
+
+    # hash should not change
+    assert org_hash == hash_env()
 
 
 def main():


### PR DESCRIPTION
There are many environment options which should not cause
redundant regeneration of build.ninja.

Perform environment hashing just with options which bob cares about.
Add test to check if hash changes due to (ir)relevant option.

Change-Id: I0c1a9168f2de4e390d67d65d28211333dde31c7e
Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>