### PR TITLE
Improved encapsulation tests

### DIFF
--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -302,3 +302,11 @@ config KERNEL_CC
 config KERNEL_CLANG_TRIPLE
 	string "Kernel Clang triple"
 	default "x86_64-linux-gnu" if ANDROID
+
+## Testing of unimplemented features
+config TEST_ENCAPSULATED_OUTPUTS
+	bool "Test `encapsulates` property"
+	default n
+	help
+	  When enabled, include tests which clarify the meaning of the
+	  `encapsulates` property. These currently do not pass.

--- a/tests/bplist
+++ b/tests/bplist
@@ -5,6 +5,7 @@
 ./build.bp
 ./command_vars/build.bp
 ./cxx11_simple/build.bp
+./encapsulates/build.bp
 ./escaping/build.bp
 ./export_cflags/liba/build.bp
 ./export_cflags/libb/build.bp

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -63,6 +63,7 @@ bob_alias {
         "bob_test_aliases_all_variants",
         "bob_test_command_vars",
         "bob_test_cxx11simple",
+        "bob_test_encapsulates",
         "bob_test_export_cflags",
         "bob_test_export_include_dirs",
         "bob_test_external_libs",

--- a/tests/encapsulates/build.bp
+++ b/tests/encapsulates/build.bp
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2020 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+*                 encapsulates_1_2_3
+ *               /        |         \
+ *              /   encapsulated2    encapsulated3
+ * encapsulated1          |                 \ (module_deps)
+ *              encapsulated2_actual     not_encapsulated
+ */
+
+bob_generate_source {
+    name: "encapsulated1",
+    out: ["subdir/1.h"],
+    export_gen_include_dirs: ["subdir"],
+    cmd: "echo '#define D1 1' > ${out}",
+}
+
+bob_generate_source {
+    name: "encapsulated2_actual",
+    out: ["2.h"],
+    export_gen_include_dirs: ["."],
+    cmd: "echo '#define D2 2' > ${out}",
+}
+
+bob_generate_source {
+    name: "encapsulated2",
+    out: ["unused2.txt"],
+    cmd: "echo > ${out}",
+    encapsulates: ["encapsulated2_actual"],
+}
+
+/* This module should *not* be transitively encapsulated. Generate headers
+ * which conflict with as much as possible, and another which will be tested
+ * with __has_include, so that we can detect if this include directory is
+ * passed incorrectly.
+ */
+bob_generate_source {
+    name: "not_encapsulated",
+    out: [
+        "subdir/1.h",
+        "2.h",
+        "3.h",
+        "must_not_have.h",
+    ],
+    export_gen_include_dirs: [
+        "subdir",
+        ".",
+    ],
+    // Tee will copy its input to each file in ${out} as well as stdout (which
+    // is redirected to avoid cluttering the build output).
+    cmd: "echo '#error' | tee ${out} >/dev/null",
+}
+
+bob_generate_source {
+    name: "encapsulated3",
+    out: ["3.h"],
+    export_gen_include_dirs: ["."],
+    module_srcs: ["not_encapsulated"],
+    module_deps: ["not_encapsulated"],
+    cmd: "echo '#define D3 3' > ${out}",
+}
+
+// Encapsulate modules 1, 2, and 3, to allow testing that encapsulated outputs
+// and include directories are propagated to the next level correctly.
+bob_generate_source {
+    name: "encapsulates_1_2_3",
+    out: ["unused.txt"],
+    encapsulates: [
+        "encapsulated1",
+        "encapsulated2",
+        "encapsulated3",
+    ],
+    // While we're here, ensure that ${outs} *doesn't* include the encapsulated
+    // outputs - only downstream modules should include those. Also - we can't
+    // test this, but this command should *not* have access to e.g.
+    // ${encapsulated1_out} - that should only be provided by module_deps.
+    tool: "check_basenames.py",
+    cmd: "${tool} -o ${out} --expected unused.txt --actual ${out}",
+}
+
+bob_binary {
+    name: "check_includes",
+    generated_headers: ["encapsulates_1_2_3"],
+    srcs: ["check_includes.c"],
+    enabled: false,
+    test_encapsulated_outputs: {
+        enabled: true,
+    },
+}
+
+// Check that ${modname_out} includes ${modname}'s encapsulated oututs
+bob_generate_source {
+    name: "check_outputs_via_module_deps",
+    out: ["unused.txt"],
+    module_deps: ["encapsulates_1_2_3"],
+    tool: "check_basenames.py",
+    cmd: "${tool} -o ${out} --expected encapsulates_1_2_3/unused.txt encapsulated2/unused2.txt subdir/1.h 2.h 3.h --actual ${encapsulates_1_2_3_out}",
+    build_by_default: true,
+    enabled: false,
+    test_encapsulated_outputs: {
+        enabled: true,
+    },
+}
+
+// Check that module_srcs: [${modname}] includes ${modname}'s encapsulated oututs
+bob_generate_source {
+    name: "check_outputs_via_module_srcs",
+    out: ["unused.txt"],
+    module_srcs: ["encapsulates_1_2_3"],
+    tool: "check_basenames.py",
+    cmd: "${tool} -o ${out} --expected encapsulates_1_2_3/unused.txt encapsulated2/unused2.txt subdir/1.h 2.h 3.h --actual ${in}",
+    build_by_default: true,
+    enabled: false,
+    test_encapsulated_outputs: {
+        enabled: true,
+    },
+}
+
+bob_alias {
+    name: "bob_test_encapsulates",
+    srcs: [
+        "check_includes",
+        "check_outputs_via_module_deps",
+        "check_outputs_via_module_srcs",
+    ],
+}

--- a/tests/encapsulates/check_basenames.py
+++ b/tests/encapsulates/check_basenames.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+# Copyright 2020 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+
+
+def parse_args():
+    ap = argparse.ArgumentParser()
+
+    ap.add_argument("--out", "-o", type=str, help="File to write on success")
+    ap.add_argument("--expected", default=[], nargs="+", action="append", help="Expected basenames")
+    ap.add_argument("--actual", default=[], nargs="+", action="append", help="Actual filenames")
+
+    args = ap.parse_args()
+
+    if len(args.expected) != len(args.actual):
+        ap.error("Mismatch of expected ({}) vs actual ({}) lists".format(len(args.expected),
+                                                                         len(args.actual)))
+
+    return args
+
+
+def check_basenames(expected, actual):
+    """Check that each path suffix in `expected` has a corresponding path in `actual`"""
+    if len(expected) != len(actual):
+        print("Mismatching list lengths: expected {} ({}), got {} ({})".format(
+              len(expected), str(expected), len(actual), str(actual)))
+        return False
+
+    passed = True
+
+    for expected_basename in sorted(expected, key=len, reverse=True):
+        expected_basename = os.sep + expected_basename  # Ensure we match complete path components
+        found = False
+        for i in range(0, len(actual)):
+            actual_path = os.sep + actual[i]
+            if actual_path.endswith(expected_basename):
+                found = True
+                del actual[i]
+                break
+        if not found:
+            print("Could not find path containing expected basename '{}' in {}".format(
+                  expected_basename[1:], str(actual)))
+            passed = False
+
+    return passed
+
+
+def main():
+    args = parse_args()
+
+    passed = True
+
+    for i in range(0, len(args.expected)):
+        passed &= check_basenames(args.expected[i], args.actual[i])
+
+    if not passed:
+        if os.path.isfile(args.out):
+            os.unlink(args.out)
+        sys.exit(1)
+
+    with open(args.out, "wt"):
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/encapsulates/check_includes.c
+++ b/tests/encapsulates/check_includes.c
@@ -1,0 +1,15 @@
+#include "1.h"
+#include "2.h"
+#include "3.h"
+
+#if __has_include("must_not_have.h")
+    #error "must_not_have.h should not be available!"
+#endif
+
+#if D1 != 1 || D2 != 2 || D3 != 3
+    #error "Incorrect values of D1, D2 or D3"
+#endif
+
+int main(void) {
+    return 0;
+}


### PR DESCRIPTION
Add new encapsulation tests which check the contents of `module_srcs`
and `${modname_out}`, as well as incorrect inclusion of include
directories generated by transitive *non*-encapsulated dependencies.

*** These currently fail ***

The `${modname_out}` property should include ${modnames}'s encapsulated
dependencies' outputs, but currently does not. This will be fixed in a
subsequent commit.

Change-Id: I5eb02ce0f7450651fe1f282020f3a9a5a4aff2dc
Signed-off-by: Chris Diamand <chris.diamand@arm.com>