### PR TITLE
New `bob_config_json` variable for Bob JSON configuration file

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -357,6 +357,7 @@ func androidLibraryBuildAction(sb *strings.Builder, mod blueprint.Module, ctx bl
 			// Setup args like we do for bob_generated_*
 			args := map[string]string{}
 			args["bob_config"] = configFile
+			args["bob_config_json"] = filepath.Join(getBuildDir(), configJSONFile)
 			if m.Properties.Post_install_tool != nil {
 				args["tool"] = *m.Properties.Post_install_tool
 			}

--- a/core/androidbp_generated.go
+++ b/core/androidbp_generated.go
@@ -65,6 +65,8 @@ func expandCmd(s string, moduleDir string) string {
 			return filepath.Join("${module_dir}", moduleDir)
 		case "bob_config":
 			return configFile
+		case "bob_config_json":
+			return filepath.Join(getBuildDir(), configJSONFile)
 		case "bob_config_opts":
 			return configOpts
 		default:

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -234,7 +234,8 @@ func (s *SourceProps) getSources(ctx blueprint.BaseModuleContext) []string {
 func (s *SourceProps) processPaths(ctx blueprint.BaseModuleContext, g generatorBackend) {
 	prefix := projectModuleDir(ctx)
 	var special = map[string]string{
-		"${bob_config}": configFile,
+		"${bob_config}":      configFile,
+		"${bob_config_json}": filepath.Join(getBuildDir(), configJSONFile),
 	}
 
 	// Look for special items. Remove from Srcs and add to Specials

--- a/core/generated.go
+++ b/core/generated.go
@@ -424,6 +424,7 @@ func (m *generateCommon) getArgs(ctx blueprint.ModuleContext) (string, map[strin
 		"as":                asBinary,
 		"asflags":           utils.Join(astargetflags, props.Asflags),
 		"bob_config":        configFile,
+		"bob_config_json":   filepath.Join(getBuildDir(), configJSONFile),
 		"bob_config_opts":   configOpts,
 		"cc":                cc,
 		"cflags":            strings.Join(props.Cflags, " "),

--- a/core/linux.go
+++ b/core/linux.go
@@ -884,6 +884,7 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 		cmd = strings.Replace(cmd, "${args}", strings.Join(props.Post_install_args, " "), -1)
 
 		args["bob_config"] = configFile
+		args["bob_config_json"] = filepath.Join(getBuildDir(), configJSONFile)
 		if props.Post_install_tool != nil {
 			args["tool"] = *props.Post_install_tool
 			deps = append(deps, *props.Post_install_tool)

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -37,6 +37,8 @@ var (
 	configFile = os.Getenv("CONFIG_FILE")
 	configOpts = os.Getenv("BOB_CONFIG_OPTS")
 	srcdir     = os.Getenv("SRCDIR")
+
+	configJSONFile = "config.json"
 )
 
 type moduleBase struct {
@@ -79,7 +81,7 @@ func Main() {
 	// Load the config first. This is needed because some of the module
 	// types' definitions contain a struct-per-feature, and features are
 	// specified in the config.
-	jsonPath := getPathInBuildDir("config.json")
+	jsonPath := getPathInBuildDir(configJSONFile)
 	config := &bobConfig{}
 	err := config.Properties.LoadConfig(jsonPath)
 	if err != nil {

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -335,6 +335,9 @@ are substituted into the command:
 - `${tool}` - the tool specified in `bob_module.post_install_tool`.
 - `${out}` - the output file(s) of the current module.
 - `${bob_config}` - the Bob configuration file.
+- `${bob_config_json}` - the Bob configuration JSON file, intended for use
+  by tools that just need to read configuration values without having to
+  know about the config system.
 - `${args}` - arguments from `post_install_args`
 
 Not supported on Android.bp.


### PR DESCRIPTION
Bob JSON configuration file `config.json` does not have corresponding
variable which allows to reference it in *.bp file.
This makes difficulties to use it and forces dangerous workarounds.

Provide new Bob variable for JSON configuration file.

Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>
Change-Id: I8b7f4cd1c15eff5a1aad02b5beec38c4d8fe734d