### PR TITLE
Fixed encapsulation output propagation for androidmk backend.

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -740,6 +740,7 @@ func (g *androidMkGenerator) generateCommonActions(sb *strings.Builder, m *gener
 	m.recordOutputsFromInout(inouts)
 	m.includeDirs = utils.PrefixDirs(m.Properties.Export_gen_include_dirs, m.outputDir())
 	m.encapsulatedMods = getGeneratedEncapsulatedModules(ctx)
+	m.encapsulatedOuts = getGeneratedEncapsulatedFiles(ctx)
 
 	sb.WriteString("##########################\ninclude $(CLEAR_VARS)\n\n")
 

--- a/tests/source_encapsulation/build.bp
+++ b/tests/source_encapsulation/build.bp
@@ -186,7 +186,7 @@ bob_generate_source {
     out: ["message.h"],
     implicit_outs: ["impl/implicit.h"],
     export_gen_include_dirs: ["."],
-    cmd: "echo '#error \"Error!\"' > ${out} && echo '#define IMPL 1' > ${gen_dir}/impl/implicit.h",
+    cmd: "echo '#error \"Error!\"' > ${out} && mkdir -p ${gen_dir}/impl && echo '#define IMPL 1' > ${gen_dir}/impl/implicit.h",
 }
 
 bob_generate_source {


### PR DESCRIPTION
The outputs of a android_make module include the outputs of
encapsulated modules where `getArgs()` must return encapsulated
outputs as dependencies.

Correct propagated outputs based on `encapsulates` property.

Generating outputs within subdirectories forces creating proper
directories at first.

Add creating desired directory to the `cmd` property.

Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>
Change-Id: Idb97ab9b74996bbffeee84949fdd56f0fe4e0c41