### PR TITLE
  Allow installation of generated sources

### DIFF
--- a/core/androidbp_backend.go
+++ b/core/androidbp_backend.go
@@ -95,6 +95,15 @@ func (g *androidBpGenerator) escapeFlag(s string) string {
 	return s
 }
 
+func addProvenanceProps(m bpwriter.Module, props AndroidProps) {
+	if props.isProprietary() {
+		m.AddString("owner", props.Owner)
+		m.AddBool("vendor", true)
+		m.AddBool("proprietary", true)
+		m.AddBool("soc_specific", true)
+	}
+}
+
 func addInstallProps(m bpwriter.Module, props *InstallableProps, proprietary bool) {
 	installBase, installRel, ok := getSoongInstallPath(props)
 	if ok {

--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -110,15 +110,6 @@ func (l *library) getGeneratedHeaderModules(mctx blueprint.BaseModuleContext) (h
 	return
 }
 
-func addProvenanceProps(m bpwriter.Module, props AndroidProps) {
-	if props.isProprietary() {
-		m.AddString("owner", props.Owner)
-		m.AddBool("vendor", true)
-		m.AddBool("proprietary", true)
-		m.AddBool("soc_specific", true)
-	}
-}
-
 func addPGOProps(m bpwriter.Module, props AndroidPGOProps) {
 	if props.Pgo.Profile_file == nil {
 		return

--- a/core/androidbp_generated.go
+++ b/core/androidbp_generated.go
@@ -121,6 +121,9 @@ func (g *androidBpGenerator) generateSourceActions(gs *generateSource, mctx blue
 	m.AddStringList("implicit_outs", gs.Properties.Implicit_outs)
 
 	populateCommonProps(&gs.generateCommon, mctx, m)
+
+	// No AndroidProps in gen sources, so always in vendor for now
+	addInstallProps(m, gs.getInstallableProps(), true)
 }
 
 func (g *androidBpGenerator) transformSourceActions(ts *transformSource, mctx blueprint.ModuleContext) {
@@ -142,4 +145,7 @@ func (g *androidBpGenerator) transformSourceActions(ts *transformSource, mctx bl
 	gr.AddStringList("implicit_outs", ts.Properties.TransformSourceProps.Out.Implicit_outs)
 
 	populateCommonProps(&ts.generateCommon, mctx, m)
+
+	// No AndroidProps in gen sources, so always in vendor for now
+	addInstallProps(m, ts.getInstallableProps(), true)
 }

--- a/core/androidbp_kernel_module.go
+++ b/core/androidbp_kernel_module.go
@@ -105,34 +105,5 @@ func (g *androidBpGenerator) kernelModuleActions(l *kernelModule, mctx blueprint
 		l.Properties.Make_args,
 	)
 
-	installBase, installRel, ok := getSoongInstallPath(l.getInstallableProps())
-	if ok {
-		switch installBase {
-		case "data":
-			bpmod.AddBool("install_in_data", true)
-		case "tests":
-			/* Eventually we want to install in testcases,
-			 * but we can't put binaries there yet:
-			 * bpmod.AddBool("install_in_testcases", true)
-			 * So place resources in /data/nativetest to align with cc_test.
-			 *
-			 * `nativetest` has no corresponding `InstallIn...` method,
-			 * so request the `/data` partition and add the `nativetest`
-			 * part in as another relative component. */
-			bpmod.AddBool("install_in_data", true)
-			if l.Properties.isProprietary() {
-				// Vendor modules need an additional path element to match cc_test
-				installRel = filepath.Join("nativetest", "vendor", installRel)
-			} else {
-				installRel = filepath.Join("nativetest", installRel)
-			}
-		default:
-			/* Paths like `lib/modules` are implicitly in /system, or /vendor, but
-			 * unlike e.g. a library, which would add the `lib` for us, we need to add
-			 * it ourselves here - so the whole path is used as the relative part. */
-			installRel = filepath.Join(installBase, installRel)
-		}
-		bpmod.AddString("install_path", installRel)
-	}
-
+	addInstallProps(bpmod, l.getInstallableProps(), l.Properties.isProprietary())
 }


### PR DESCRIPTION
Add install_path properties to the genrulebob and gensrcsbob
definitions.

Move the logic to determine the values of the properties from
androidbp_kernel_modules.go into androidbp_backend.go.
