### PR TITLE
Remove SplittableProps from target-specific props

### DIFF
--- a/core/defaults.go
+++ b/core/defaults.go
@@ -59,7 +59,7 @@ func (m *defaults) build() *Build {
 }
 
 func (m *defaults) topLevelProperties() []interface{} {
-	return []interface{}{&m.Properties.Build.BuildProps}
+	return []interface{}{&m.Properties.Build.BuildProps, &m.Properties.Build.SplittableProps}
 }
 
 func (m *defaults) features() *Features {
@@ -80,7 +80,7 @@ func (m *defaults) GenerateBuildActions(ctx blueprint.ModuleContext) {
 func defaultsFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &defaults{}
 
-	module.Properties.Features.Init(&config.Properties, BuildProps{})
+	module.Properties.Features.Init(&config.Properties, BuildProps{}, SplittableProps{})
 	module.Properties.Build.Target.Init(&config.Properties, BuildProps{})
 	module.Properties.Build.Host.Init(&config.Properties, BuildProps{})
 

--- a/core/library.go
+++ b/core/library.go
@@ -150,7 +150,6 @@ type BuildProps struct {
 
 	InstallableProps
 	EnableableProps
-	SplittableProps
 	StripProps
 	AndroidProps
 	AndroidPGOProps
@@ -205,6 +204,7 @@ type Build struct {
 	BuildProps
 	Target TargetSpecific
 	Host   TargetSpecific
+	SplittableProps
 }
 
 // These function check the boolean pointers - which are only filled if someone sets them
@@ -316,7 +316,7 @@ func (l *library) build() *Build {
 }
 
 func (l *library) topLevelProperties() []interface{} {
-	return []interface{}{&l.Properties.Build.BuildProps}
+	return []interface{}{&l.Properties.Build.BuildProps, &l.Properties.Build.SplittableProps}
 }
 
 func (l *library) features() *Features {
@@ -679,7 +679,7 @@ func (m *binary) outputFileName() string {
 }
 
 func (l *library) LibraryFactory(config *bobConfig, module blueprint.Module) (blueprint.Module, []interface{}) {
-	l.Properties.Features.Init(&config.Properties, BuildProps{})
+	l.Properties.Features.Init(&config.Properties, BuildProps{}, SplittableProps{})
 	l.Properties.Build.Host.Features.Init(&config.Properties, BuildProps{})
 	l.Properties.Build.Target.Features.Init(&config.Properties, BuildProps{})
 

--- a/core/splitter.go
+++ b/core/splitter.go
@@ -55,19 +55,6 @@ func supportedVariantsMutator(mctx blueprint.TopDownMutatorContext) {
 		return
 	}
 
-	// It's not valid to specify host_supported or target_supported in a
-	// target: {} or host: {} section
-	if moduleWithBuildProps, ok := mctx.Module().(moduleWithBuildProps); ok {
-		b := moduleWithBuildProps.build()
-		if b.Host.SplittableProps.Host_supported != nil ||
-			b.Host.SplittableProps.Target_supported != nil ||
-			b.Target.SplittableProps.Host_supported != nil ||
-			b.Target.SplittableProps.Target_supported != nil {
-			panic(fmt.Errorf("target-specific [host|target]_supported in module %s",
-				mctx.ModuleName()))
-		}
-	}
-
 	// Defaults are always split into both variants
 	if _, isDefaults := mctx.Module().(*defaults); isDefaults {
 		return


### PR DESCRIPTION
Now that modules can use multiple combined types as their features and
top-level properties, remove `host_supported` and `target_supported`
from the structs used inside `host: {}` and `target: {}` blocks.

As a result, we no longer need to check that they aren't accidentally
set, because the properties simply do not exist.

Change-Id: I22e383a6c0f18820e8e037e61d4ffab8abf0ee12
Signed-off-by: Chris Diamand <chris.diamand@arm.com>