### PR TITLE
Type-independent target-specific properties

### DIFF
--- a/core/defaults.go
+++ b/core/defaults.go
@@ -70,6 +70,10 @@ func (m *defaults) getTarget() tgtType {
 	return m.Properties.TargetType
 }
 
+func (m *defaults) getTargetSpecific(variant tgtType) *TargetSpecific {
+	return m.Properties.getTargetSpecific(variant)
+}
+
 func (m *defaults) processPaths(ctx blueprint.BaseModuleContext, g generatorBackend) {
 	m.Properties.Build.processPaths(ctx, g)
 }
@@ -80,9 +84,8 @@ func (m *defaults) GenerateBuildActions(ctx blueprint.ModuleContext) {
 func defaultsFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &defaults{}
 
+	module.Properties.Build.init(&config.Properties)
 	module.Properties.Features.Init(&config.Properties, BuildProps{}, SplittableProps{})
-	module.Properties.Build.Target.Init(&config.Properties, BuildProps{})
-	module.Properties.Build.Host.Init(&config.Properties, BuildProps{})
 
 	return module, []interface{}{&module.Properties, &module.SimpleName.Properties}
 }

--- a/core/gen_binary.go
+++ b/core/gen_binary.go
@@ -59,7 +59,8 @@ func (m *generateBinary) GenerateBuildActions(ctx blueprint.ModuleContext) {
 
 func genBinaryFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &generateBinary{}
-	module.generateCommon.Properties.Features.Init(&config.Properties, GenerateProps{})
+	module.generateCommon.init(&config.Properties, GenerateProps{})
+
 	return module, []interface{}{
 		&module.SimpleName.Properties,
 		&module.generateCommon.Properties,

--- a/core/gen_shared.go
+++ b/core/gen_shared.go
@@ -60,8 +60,9 @@ func (m *generateSharedLibrary) outputFileName() string {
 
 func genSharedLibFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &generateSharedLibrary{}
-	module.generateCommon.Properties.Features.Init(&config.Properties, GenerateProps{},
+	module.generateCommon.init(&config.Properties, GenerateProps{},
 		GenerateLibraryProps{})
+
 	if config.Properties.GetBool("osx") {
 		module.fileNameExtension = ".dylib"
 	} else {

--- a/core/gen_static.go
+++ b/core/gen_static.go
@@ -59,8 +59,9 @@ func (m *generateStaticLibrary) outputFileName() string {
 
 func genStaticLibFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &generateStaticLibrary{}
-	module.generateCommon.Properties.Features.Init(&config.Properties, GenerateProps{},
+	module.generateCommon.init(&config.Properties, GenerateProps{},
 		GenerateLibraryProps{})
+
 	return module, []interface{}{
 		&module.SimpleName.Properties,
 		&module.generateCommon.Properties,

--- a/core/generated.go
+++ b/core/generated.go
@@ -171,6 +171,12 @@ func splitGeneratedComponent(comp string) (module string, lib string) {
 	return split[0], strings.Join(split[1:], "/")
 }
 
+func (m *generateCommon) init(properties *configProperties, list ...interface{}) {
+	m.Properties.Features.Init(properties, list...)
+	m.Properties.FlagArgsBuild.Host.TargetProps.init(BuildProps{})
+	m.Properties.FlagArgsBuild.Target.TargetProps.init(BuildProps{})
+}
+
 func (m *generateCommon) shortName() string {
 	return m.Name()
 }
@@ -647,16 +653,18 @@ type transformSource struct {
 
 func generateSourceFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &generateSource{}
-	module.generateCommon.Properties.Features.Init(&config.Properties,
+	module.generateCommon.init(&config.Properties,
 		GenerateProps{}, GenerateSourceProps{})
+
 	return module, []interface{}{&module.generateCommon.Properties, &module.Properties,
 		&module.SimpleName.Properties}
 }
 
 func transformSourceFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &transformSource{}
-	module.generateCommon.Properties.Features.Init(&config.Properties,
+	module.generateCommon.init(&config.Properties,
 		GenerateProps{}, TransformSourceProps{})
+
 	return module, []interface{}{&module.generateCommon.Properties,
 		&module.Properties,
 		&module.SimpleName.Properties}

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -43,6 +43,10 @@ func (m *kernelModule) build() *Build {
 	return &m.Properties.Build
 }
 
+func (m *kernelModule) getTargetSpecific(tgt tgtType) *TargetSpecific {
+	return m.Properties.getTargetSpecific(tgt)
+}
+
 func (m *kernelModule) topLevelProperties() []interface{} {
 	return []interface{}{&m.Properties.Build.BuildProps}
 }
@@ -218,9 +222,8 @@ func (m *kernelModule) GenerateBuildActions(ctx blueprint.ModuleContext) {
 
 func kernelModuleFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &kernelModule{}
+	module.Properties.Build.init(&config.Properties)
 	module.Properties.Features.Init(&config.Properties, BuildProps{})
-	module.Properties.Build.Target.Init(&config.Properties, BuildProps{})
-	module.Properties.Build.Host.Init(&config.Properties, BuildProps{})
 
 	return module, []interface{}{&module.Properties, &module.SimpleName.Properties}
 }

--- a/core/splitter.go
+++ b/core/splitter.go
@@ -47,6 +47,14 @@ type splittable interface {
 	getSplittableProps() *SplittableProps
 }
 
+// targetSpecificLibrary extends splittable to allow retrieving specific data
+// for host and target.
+type targetSpecificLibrary interface {
+	// Get the target specific properties
+	getTargetSpecific(tgtType) *TargetSpecific
+	splittable
+}
+
 // Traverse the core properties of defaults to find out which variations are
 // supported.
 func supportedVariantsMutator(mctx blueprint.TopDownMutatorContext) {


### PR DESCRIPTION
Target specific data (for host and target) is hardcoded to BuildProps
structure which makes module always to have the same property sets.

Change target type to be type-independent which uses reflection
to put the right type inside.

Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>
Change-Id: If3bd60099ffb1a9a27520043b283b199952f0b56