### PR TITLE
Allow tests to run with old gcc

### DIFF
--- a/tests/encapsulates/check_includes.c
+++ b/tests/encapsulates/check_includes.c
@@ -2,9 +2,13 @@
 #include "2.h"
 #include "3.h"
 
+#ifdef __has_include
 #if __has_include("must_not_have.h")
     #error "must_not_have.h should not be available!"
 #endif
+#else
+    #warning "Compiler does not support __has_include, unable to check header visibility"
+#endif /* __has_include */
 
 #if D1 != 1 || D2 != 2 || D3 != 3
     #error "Incorrect values of D1, D2 or D3"

--- a/tests/generated_headers/check_no_h1_h2.c
+++ b/tests/generated_headers/check_no_h1_h2.c
@@ -1,6 +1,10 @@
+#ifdef __has_include
 #if __has_include("h1.h") || __has_include("h2.h")
     #error "h1.1 and h2.h incorrectly exported via generated_headers"
 #endif
+#else
+    #warning "Compiler does not support __has_include, unable to check header visibility"
+#endif /* __has_include */
 
 int main(void)
 {

--- a/tests/source_encapsulation/build.bp
+++ b/tests/source_encapsulation/build.bp
@@ -186,7 +186,7 @@ bob_generate_source {
     out: ["message.h"],
     implicit_outs: ["impl/implicit.h"],
     export_gen_include_dirs: ["."],
-    cmd: "echo '#error \"Error!\"' > ${out} && mkdir -p ${gen_dir}/impl && echo '#define IMPL 1' > ${gen_dir}/impl/implicit.h",
+    cmd: "echo '#define HAS_MSG 1' > ${out} && mkdir -p ${gen_dir}/impl && echo '#define IMPL 1' > ${gen_dir}/impl/implicit.h",
 }
 
 bob_generate_source {

--- a/tests/source_encapsulation/test_deps.c
+++ b/tests/source_encapsulation/test_deps.c
@@ -1,6 +1,10 @@
+#ifdef __has_include
 #if __has_include("must_not_have.h")
     #error "must_not_have.h should not be available!"
 #endif
+#else
+    #warning "Compiler does not support __has_include, unable to check header visibility"
+#endif /* __has_include */
 
 #include "must_have.h"
 #include "types.h"

--- a/tests/source_encapsulation/test_implicit.c
+++ b/tests/source_encapsulation/test_implicit.c
@@ -1,8 +1,5 @@
-#if __has_include("message.h")
-    #define HAS_MSG 1
-#endif
-
 #include "types.h"
+#include "message.h"
 #include "impl/implicit.h"
 
 int main(void) {


### PR DESCRIPTION
__has_include is only supported from GCC 5.0. Where we use it, check
whether __has_include is defined before we use it. If it is not
available output a warning that we're not able to check whether a
header is available.

Change the command for gen_srcs_five to output a useful macro
definition to message.h, and actually use the header instead of using
__has_include.

Change-Id: I788b120e1eb8f8d34fa3f56058e5a0223846ba56
Signed-off-by: David Kilroy <david.kilroy@arm.com>