### PR TITLE
Reduce 'moduleWithBuildProps' interface.

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -507,19 +507,15 @@ func collectReexportLibsDependenciesMutator(mctx blueprint.TopDownMutatorContext
 	mctx.WalkDeps(func(child blueprint.Module, parent blueprint.Module) bool {
 		depTag := mctx.OtherModuleDependencyTag(child)
 		if depTag == wholeStaticDepTag || depTag == staticDepTag || depTag == sharedDepTag {
-			var parentBuild *Build
-			if moduleWithBuildProps, ok := parent.(moduleWithBuildProps); ok {
-				parentBuild = moduleWithBuildProps.build()
-			} else {
+			parentModule, ok1 := parent.(moduleWithBuildProps)
+			childModule, ok2 := child.(moduleWithBuildProps)
+
+			if !ok1 || !ok2 {
 				return false
 			}
 
-			var childBuild *Build
-			if moduleWithBuildProps, ok := child.(moduleWithBuildProps); ok {
-				childBuild = moduleWithBuildProps.build()
-			} else {
-				return false
-			}
+			parentBuild := parentModule.build()
+			childBuild := childModule.build()
 
 			if len(childBuild.Reexport_libs) > 0 &&
 				(parent.Name() == mainModule.Name() || utils.Contains(parentBuild.Reexport_libs, child.Name())) {

--- a/core/defaults.go
+++ b/core/defaults.go
@@ -81,6 +81,26 @@ func (m *defaults) processPaths(ctx blueprint.BaseModuleContext, g generatorBack
 func (m *defaults) GenerateBuildActions(ctx blueprint.ModuleContext) {
 }
 
+func (m *defaults) getEscapeProperties() []*[]string {
+	return []*[]string{
+		&m.Properties.Asflags,
+		&m.Properties.Cflags,
+		&m.Properties.Conlyflags,
+		&m.Properties.Cxxflags,
+		&m.Properties.Ldflags}
+}
+
+func (m *defaults) getSourceProperties() *SourceProps {
+	return &m.Properties.SourceProps
+}
+
+// {{match_srcs}} template is only applied in specific properties where we've
+// seen sensible use-cases and for `BuildProps` this is:
+//  - Ldflags
+func (m *defaults) getMatchSourcePropNames() []string {
+	return []string{"Ldflags"}
+}
+
 func defaultsFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &defaults{}
 
@@ -114,6 +134,12 @@ var _ featurable = (*defaults)(nil)
 
 // Defaults contain path fragments which need to be prefixes
 var _ pathProcessor = (*defaults)(nil)
+
+// Defaults support {{match_srcs}} on some properties
+var _ matchSourceInterface = (*defaults)(nil)
+
+// Defaults have properties that require escaping
+var _ propertyEscapeInterface = (*defaults)(nil)
 
 func defaultDepsMutator(mctx blueprint.BottomUpMutatorContext) {
 	if l, ok := mctx.Module().(defaultable); ok {

--- a/core/generated.go
+++ b/core/generated.go
@@ -154,6 +154,12 @@ type generateCommon struct {
 	}
 }
 
+// generateCommon support {{match_srcs}} on some properties
+var _ matchSourceInterface = (*generateCommon)(nil)
+
+// generateCommon have properties that require escaping
+var _ propertyEscapeInterface = (*generateCommon)(nil)
+
 // Modules implementing hostBin are able to supply a host binary that can be executed
 type hostBin interface {
 	hostBin() string
@@ -231,6 +237,27 @@ func (m *generateCommon) setVariant(variant tgtType) {
 
 func (m *generateCommon) getSplittableProps() *SplittableProps {
 	return &m.Properties.FlagArgsBuild.SplittableProps
+}
+
+func (m *generateCommon) getEscapeProperties() []*[]string {
+	return []*[]string{
+		&m.Properties.FlagArgsBuild.Asflags,
+		&m.Properties.FlagArgsBuild.Cflags,
+		&m.Properties.FlagArgsBuild.Conlyflags,
+		&m.Properties.FlagArgsBuild.Cxxflags,
+		&m.Properties.FlagArgsBuild.Ldflags}
+}
+
+func (m *generateCommon) getSourceProperties() *SourceProps {
+	return &m.Properties.GenerateProps.SourceProps
+}
+
+// {{match_srcs}} template is only applied in specific properties where we've
+// seen sensible use-cases and for `generateCommon` these are:
+//  - Args
+//  - Cmd
+func (m *generateCommon) getMatchSourcePropNames() []string {
+	return []string{"Cmd", "Args"}
 }
 
 // Populate the output from inout structures that have already been

--- a/core/library.go
+++ b/core/library.go
@@ -318,6 +318,12 @@ type library struct {
 
 var _ propertyExporter = (*library)(nil)
 
+// library support {{match_srcs}} on some properties
+var _ matchSourceInterface = (*library)(nil)
+
+// library have properties that require escaping
+var _ propertyEscapeInterface = (*library)(nil)
+
 func (l *library) defaults() []string {
 	return l.Properties.Defaults
 }
@@ -428,6 +434,26 @@ func (l *library) altShortName() string {
 		return l.altName() + "__" + string(l.Properties.TargetType)
 	}
 	return l.altName()
+}
+
+func (l *library) getEscapeProperties() []*[]string {
+	return []*[]string{
+		&l.Properties.Asflags,
+		&l.Properties.Cflags,
+		&l.Properties.Conlyflags,
+		&l.Properties.Cxxflags,
+		&l.Properties.Ldflags}
+}
+
+func (l *library) getSourceProperties() *SourceProps {
+	return &l.Properties.SourceProps
+}
+
+// {{match_srcs}} template is only applied in specific properties where we've
+// seen sensible use-cases and for `BuildProps` this is:
+//  - Ldflags
+func (l *library) getMatchSourcePropNames() []string {
+	return []string{"Ldflags"}
 }
 
 // Returns the shortname for the output, which is used as a phony target. If it


### PR DESCRIPTION
The moduleWithBuildProps interface is very tied to the idea
of having a single BuildProps type and mostly it is being used
as a proxy for detection 'library' modules.
This way some of the modules overuse moduleWithBuildProps while handling
its data.

Introduce two new interfaces for better data processing:
- `propertyEscapeInterface` which allows escaping properties
- `matchSourceInterface` to be used by arbitrary modules that support
  {{match_srcs}} on some properties

Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>
Change-Id: Id5d716d0aed2f184c12388a2c1af6d3f8fed060b