### PR TITLE
Remove `targetable` interface.

### DIFF
--- a/core/defaults.go
+++ b/core/defaults.go
@@ -127,7 +127,7 @@ var _ defaultable = (*defaults)(nil)
 var _ moduleWithBuildProps = (*defaults)(nil)
 
 // Defaults have host and target variants
-var _ targetable = (*defaults)(nil)
+var _ targetSpecificLibrary = (*defaults)(nil)
 
 // Defaults support conditional properties via "features"
 var _ featurable = (*defaults)(nil)

--- a/core/splitter.go
+++ b/core/splitter.go
@@ -52,6 +52,7 @@ type splittable interface {
 type targetSpecificLibrary interface {
 	// Get the target specific properties
 	getTargetSpecific(tgtType) *TargetSpecific
+	getTarget() tgtType
 	splittable
 }
 


### PR DESCRIPTION
Current usage of `targettable` introduces confusion with
`targetSpecificLibrary` and it mostly uses `build()` method
as another version of `moduleWithBuildProps` thus it should
be removed.

Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>
Change-Id: I72d7eb2a6c09a8b2795eb3c7faad03d703fe620d