### PR TITLE
Generic target-specific init

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -45,38 +45,31 @@ type moduleWithBuildProps interface {
 	build() *Build
 }
 
-// TargetProps Type for generic target properties
-type TargetProps struct {
+// A TargetSpecific module is one that supports building on host and target,
+// with a set of properties in `host: {}` or `target: {}` blocks.
+type TargetSpecific struct {
+	Features
+
 	// 'BlueprintEmbed' is a special case in Blueprint which makes it interpret
 	// a runtime-generated type as being embedded in its parent struct.
 	BlueprintEmbed interface{}
 }
 
-// init Initilization of target specific properties
-func (t *TargetProps) init(list ...interface{}) {
+// init initializes properties and features
+func (t *TargetSpecific) init(properties *configProperties, list ...interface{}) {
 	if len(list) == 0 {
 		panic("List can't be empty")
 	}
 
 	propsType := coalesceTypes(typesOf(list...)...)
 	t.BlueprintEmbed = reflect.New(propsType).Interface()
-}
 
-// A TargetSpecific module is one that supports building on host and target.
-type TargetSpecific struct {
-	Features
-	TargetProps
-}
-
-// init initializes properties and features
-func (t *TargetSpecific) init(properties *configProperties) {
-	t.TargetProps.init(BuildProps{})
-	t.Features.Init(properties, BuildProps{})
+	t.Features.Init(properties, list...)
 }
 
 // getTargetSpecificProps returns target specific property data as an empty interface
 func (t *TargetSpecific) getTargetSpecificProps() interface{} {
-	return t.TargetProps.BlueprintEmbed
+	return t.BlueprintEmbed
 }
 
 // A type implementing dependentInterface can be depended upon by other modules.

--- a/core/defaults.go
+++ b/core/defaults.go
@@ -104,8 +104,9 @@ func (m *defaults) getMatchSourcePropNames() []string {
 func defaultsFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &defaults{}
 
-	module.Properties.Build.init(&config.Properties)
 	module.Properties.Features.Init(&config.Properties, BuildProps{}, SplittableProps{})
+	module.Properties.Host.init(&config.Properties, BuildProps{})
+	module.Properties.Target.init(&config.Properties, BuildProps{})
 
 	return module, []interface{}{&module.Properties, &module.SimpleName.Properties}
 }

--- a/core/generated.go
+++ b/core/generated.go
@@ -179,8 +179,8 @@ func splitGeneratedComponent(comp string) (module string, lib string) {
 
 func (m *generateCommon) init(properties *configProperties, list ...interface{}) {
 	m.Properties.Features.Init(properties, list...)
-	m.Properties.FlagArgsBuild.Host.TargetProps.init(BuildProps{})
-	m.Properties.FlagArgsBuild.Target.TargetProps.init(BuildProps{})
+	m.Properties.FlagArgsBuild.Host.init(properties, BuildProps{})
+	m.Properties.FlagArgsBuild.Target.init(properties, BuildProps{})
 }
 
 func (m *generateCommon) shortName() string {

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -222,8 +222,9 @@ func (m *kernelModule) GenerateBuildActions(ctx blueprint.ModuleContext) {
 
 func kernelModuleFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &kernelModule{}
-	module.Properties.Build.init(&config.Properties)
 	module.Properties.Features.Init(&config.Properties, BuildProps{})
+	module.Properties.Host.init(&config.Properties, BuildProps{})
+	module.Properties.Target.init(&config.Properties, BuildProps{})
 
 	return module, []interface{}{&module.Properties, &module.SimpleName.Properties}
 }

--- a/core/library.go
+++ b/core/library.go
@@ -207,12 +207,6 @@ type Build struct {
 	SplittableProps
 }
 
-// Init initializes host and target specific data
-func (l *Build) init(properties *configProperties) {
-	l.getTargetSpecific(tgtTypeHost).init(properties)
-	l.getTargetSpecific(tgtTypeTarget).init(properties)
-}
-
 func (l *Build) getTargetSpecific(tgt tgtType) *TargetSpecific {
 	if tgt == tgtTypeHost {
 		return &l.Host
@@ -720,8 +714,9 @@ func (m *binary) outputFileName() string {
 }
 
 func (l *library) LibraryFactory(config *bobConfig, module blueprint.Module) (blueprint.Module, []interface{}) {
-	l.Properties.Build.init(&config.Properties)
 	l.Properties.Features.Init(&config.Properties, BuildProps{}, SplittableProps{})
+	l.Properties.Host.init(&config.Properties, BuildProps{})
+	l.Properties.Target.init(&config.Properties, BuildProps{})
 
 	return module, []interface{}{&l.Properties, &l.SimpleName.Properties}
 }


### PR DESCRIPTION
Don't hard-code `BuildProps{}` in any stage of the target-specific
property init; instead force this to be specified in the factory
function, where we call `init()` explicitly for host and target props
with the appropriate property type.

Remove `Build.init()`; libraries, defaults, and kernel modules will all
have different properties so this doesn't save any code duplication in
the long run.

Further simplify the number of `init()` functions by removing the
`TargetProps` type, as it only contained one field anyway.

Change-Id: I194948870d69b103e4792344e6e3edc27bbd9d99
Signed-off-by: Chris Diamand <chris.diamand@arm.com>