### PR TITLE
Rename bob configuration file.

### DIFF
--- a/bob.bootstrap.version
+++ b/bob.bootstrap.version
@@ -1,2 +1,2 @@
 # Version number used to identify whether the user needs to re-boostrap their build directory.
-BOB_VERSION="6"
+BOB_VERSION="7"

--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -81,7 +81,7 @@ fi
 # Calculate Bob directory relative to the working directory.
 BOB_DIR="$(relative_path $(pwd) "${SCRIPT_DIR}")"
 CONFIG_FILE="${BUILDDIR}/${CONFIGNAME}"
-CONFIG_JSON="${BUILDDIR}/config.json"
+CONFIG_JSON="${BUILDDIR}/.bob.config.json"
 
 export TOPNAME="build.bp"
 export BOOTSTRAP="${BOB_DIR}/bootstrap.bash"

--- a/core/config_props.go
+++ b/core/config_props.go
@@ -149,15 +149,6 @@ func (properties *configProperties) LoadConfig(filename string) error {
 		return fmt.Errorf("Unable to decode json configuration: %s", err.Error())
 	}
 
-	// Check for old format of config.json
-	if len(properties.properties) == 2 {
-		_, hasFeatures := properties.properties["Features"]
-		_, hasProperties := properties.properties["Properties"]
-		if hasFeatures && hasProperties {
-			utils.Exit(1, "Old style config.json detected. Please re-configure your build tree.")
-		}
-	}
-
 	properties.stringMap = make(map[string]string)
 	properties.features = make(map[string]bool)
 	for key, val := range properties.properties {

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -38,7 +38,7 @@ var (
 	configOpts = os.Getenv("BOB_CONFIG_OPTS")
 	srcdir     = os.Getenv("SRCDIR")
 
-	configJSONFile = "config.json"
+	configJSONFile = ".bob.config.json"
 )
 
 type moduleBase struct {
@@ -75,7 +75,7 @@ func getBobDir() string {
 
 // Main is the entry point for the bob primary builder.
 //
-// It loads the configuration from config.json, registers the module type
+// It loads the configuration from .bob.config.json, registers the module type
 // and mutators, initializes the backend, and finally calls into Blueprint.
 func Main() {
 	// Load the config first. This is needed because some of the module


### PR DESCRIPTION
Currently bob configuration file `config.json` can be wrongly decoded
and make a collision with main configuration file `bob.config`.
Such file is only used internally by bob and should not affect
anything else that wants a configuration file in JSON format.
Rename file form `config.json' to `.bob-config.json` thus only
bob should deal with it.

Additionally update bootstrap number that will impose re-bootstrap.

Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>
Change-Id: I6af5746d2d62ef1f718f2e0985c5f0666dc80fd2