### PR TITLE
Add support for `version_script`

### DIFF
--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -166,6 +166,14 @@ func addCFlags(m bpwriter.Module, cflags []string, conlyFlags []string, cxxFlags
 	return nil
 }
 
+func (g *androidBpGenerator) getVersionScript(l *library, ctx blueprint.ModuleContext) *string {
+	if l.Properties.VersionScriptModule != nil {
+		value := ":" + *l.Properties.VersionScriptModule
+		return &value
+	}
+	return l.Properties.Build.Version_script
+}
+
 func addCcLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContext) {
 	if len(l.Properties.Export_include_dirs) > 0 {
 		panic(fmt.Errorf("Module %s exports non-local include dirs %v - this is not supported",
@@ -332,6 +340,11 @@ func (g *androidBpGenerator) binaryActions(l *binary, mctx blueprint.ModuleConte
 		m.AddBool("auto_gen_config", false)
 		m.AddBool("gtest", false)
 	}
+
+	versionScript := g.getVersionScript(&l.library, mctx)
+	if versionScript != nil {
+		m.AddString("version_script", *versionScript)
+	}
 }
 
 func (g *androidBpGenerator) sharedActions(l *sharedLibrary, mctx blueprint.ModuleContext) {
@@ -365,6 +378,11 @@ func (g *androidBpGenerator) sharedActions(l *sharedLibrary, mctx blueprint.Modu
 	addStaticOrSharedLibraryProps(m, l.library, mctx)
 	if l.strip() {
 		addStripProp(m)
+	}
+
+	versionScript := g.getVersionScript(&l.library, mctx)
+	if versionScript != nil {
+		m.AddString("version_script", *versionScript)
 	}
 }
 

--- a/core/generated.go
+++ b/core/generated.go
@@ -407,8 +407,9 @@ func (m *generateCommon) getHostBin(ctx blueprint.ModuleContext) (string, tgtTyp
 	return toolBin, toolTarget
 }
 
-// Returns the dependents of a generateSource module. This is used for more complex dependencies, where
-// the dependencies are not just a binary or a headers, but where the paths are used directly in a script
+// Returns the outputs of the generated dependencies of a module. This is used for more complex
+// dependencies, where the dependencies are not just binaries or headers, but where the paths are
+// used directly in a script
 func getDependentArgsAndFiles(ctx blueprint.ModuleContext, args map[string]string) (depfiles []string) {
 	ctx.VisitDirectDepsIf(
 		func(m blueprint.Module) bool {

--- a/core/linux.go
+++ b/core/linux.go
@@ -479,6 +479,11 @@ func (l *library) getCommonLibArgs(ctx blueprint.ModuleContext) map[string]strin
 		ldflags = append(ldflags, tc.getLinker().dropUnusedDependencies())
 	}
 
+	versionScript := l.getVersionScript(ctx)
+	if versionScript != nil {
+		ldflags = append(ldflags, tc.getLinker().setVersionScript(*versionScript))
+	}
+
 	sharedLibLdlibs, sharedLibLdflags := l.getSharedLibFlags(ctx)
 
 	linker := tc.getLinker().getTool()
@@ -530,7 +535,10 @@ func (b *binary) getLibArgs(ctx blueprint.ModuleContext) map[string]string {
 func (l *library) Implicits(ctx blueprint.ModuleContext) []string {
 	implicits := utils.NewStringSlice(l.GetWholeStaticLibs(ctx), l.GetStaticLibs(ctx))
 	implicits = append(implicits, l.getSharedLibLinkPaths(ctx)...)
-
+	versionScript := l.getVersionScript(ctx)
+	if versionScript != nil {
+		implicits = append(implicits, *versionScript)
+	}
 	return implicits
 }
 

--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -36,6 +36,7 @@ type linker interface {
 	keepUnusedDependencies() string
 	dropUnusedDependencies() string
 	setRpathLink(string) string
+	setVersionScript(string) string
 	setRpath([]string) string
 	linkWholeArchives([]string) string
 	keepSharedLibraryTransitivity() string
@@ -83,6 +84,10 @@ func (l defaultLinker) getForwardingLibFlags() string {
 
 func (l defaultLinker) setRpathLink(path string) string {
 	return "-Wl,-rpath-link," + path
+}
+
+func (l defaultLinker) setVersionScript(path string) string {
+	return "-Wl,--version-script," + path
 }
 
 func (l defaultLinker) setRpath(paths []string) string {
@@ -789,6 +794,10 @@ func (l xcodeLinker) dropUnusedDependencies() string {
 }
 
 func (l xcodeLinker) setRpathLink(path string) string {
+	return ""
+}
+
+func (l xcodeLinker) setVersionScript(path string) string {
 	return ""
 }
 

--- a/docs/module_types/bob_binary.md
+++ b/docs/module_types/bob_binary.md
@@ -65,6 +65,8 @@ bob_binary {
     post_install_cmd: "${tool} ${args} ${out}",
     post_install_args: ["arg1", "arg2"],
 
+    version_script: "exports.map",
+
     // features available
 }
 ```

--- a/docs/module_types/bob_shared_library.md
+++ b/docs/module_types/bob_shared_library.md
@@ -73,6 +73,8 @@ bob_shared_library {
     post_install_tool: "post_install.py",
     post_install_cmd: "${tool} ${args} ${out}",
     post_install_args: ["arg1", "arg2"],
+
+    version_script: "exports.map",
 }
 ```
 

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -359,6 +359,11 @@ Arguments to insert into `post_install_cmd`. This allows arguments to
 added based on features and defaults. Not supported on Android.bp.
 
 ----
+### **bob_module.version_script** (optional)
+Linker script used for [symbol versioning](../user_guide/libraries_2.md#markdown-header-symbol-versioning).
+Only supported on binaries and shared libraries.
+
+----
 ### **bob_module.target_supported** (optional)
 If true, the module will be built using the target toolchain. `host_supported`
 and `target_supported` can both be enabled. In this case, the module will be

--- a/docs/user_guide/libraries_2.md
+++ b/docs/user_guide/libraries_2.md
@@ -400,3 +400,24 @@ one of a few layouts, see [GDB documentation](https://sourceware.org/gdb/onlined
 The helper script `scripts/move_debug_files.py` can be used to move
 the debug files into a layout based on build IDs. This may need
 `-Wl,--build-id` to be passed to the linker.
+
+## Symbol versioning
+
+As software is developed, the interfaces exposed by a library may
+change. It is good practice to be backwards compatible with the
+previous release of the library. This allows code compiled against
+the old library to continue to run, and simplifies upgrading the
+library in the field.
+
+When an interface changes, it may be desirable to reuse the name of
+an existing interface rather than implementing a new interface with a
+slightly different name. This can be achieved by versioning the
+symbols that make up the library's interface. See [GNU Binutils
+documentation](https://sourceware.org/binutils/docs/ld/VERSION.html)
+for more information on symbol versioning. Also see [documentation on
+library versioning](versioning.md).
+
+Linkers support symbol versioning with version scripts. You can
+specify a version script to use by setting `version_script`. To refer
+to `bob_generate_source` module outputs use `${MODULE_out}` where
+MODULE is the module name.

--- a/plugins/genrulebob/genrule.go
+++ b/plugins/genrulebob/genrule.go
@@ -121,6 +121,7 @@ var _ android.AndroidMkEntriesProvider = (*genrulebobCommon)(nil)
 var _ genruleInterface = (*genrulebobCommon)(nil)
 var _ android.Module = (*genrulebob)(nil)
 var _ android.Module = (*gensrcsbob)(nil)
+var _ android.SourceFileProducer = (*genrulebob)(nil)
 
 type generatedSourceTagType struct {
 	blueprint.BaseDependencyTag
@@ -260,6 +261,12 @@ func (m *genrulebobCommon) GeneratedHeaderDirs() android.Paths {
 
 func (m *genrulebobCommon) GeneratedDeps() (srcs android.Paths) {
 	return m.filterAllOutputs(utils.IsNotCompilableSource)
+}
+
+// Srcs implements the android.SourceFileProducer interface, which allows
+// the outputs of these modules to be referenced using the `:module` syntax.
+func (m *genrulebobCommon) Srcs() android.Paths {
+	return m.outputs().Paths()
 }
 
 func (m *genrulebobCommon) DepsMutator(mctx android.BottomUpMutatorContext) {

--- a/tests/bplist
+++ b/tests/bplist
@@ -38,3 +38,4 @@
 ./static_libs/build.bp
 ./templates/build.bp
 ./transform_source/build.bp
+./version_script/build.bp

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -90,5 +90,6 @@ bob_alias {
         "bob_test_static_libs",
         "bob_test_templates",
         "bob_test_transform_source",
+        "bob_test_version_script",
     ],
 }

--- a/tests/build_tests.sh
+++ b/tests/build_tests.sh
@@ -260,6 +260,17 @@ UPDATE=(${build_dir}/target/executable/build_implicit_out
 check_dep_updated "implicit output" "${build_dir}" "${SRC}" "${UPDATE[@]}"
 
 if [ "$OS" != "OSX" ] ; then
+    # simple version script
+    SRC=tests/version_script/exports0.map
+    UPDATE=(${build_dir}/target/shared/libshared_vs_simple.so)
+    check_dep_updated "simple version script" "${build_dir}" "${SRC}" "${UPDATE[@]}"
+
+    # generated version script
+    SRC=tests/version_script/exports1.map
+    UPDATE=(${build_dir}/gen/vs_version_map/exports2.map
+            ${build_dir}/target/shared/libshared_vs_gen.so)
+    check_dep_updated "generated version script" "${build_dir}" "${SRC}" "${UPDATE[@]}"
+
     # kernel module dependencies on sources
     SRC=tests/kernel_module/module1/test_module1.c
     UPDATE=(${build_dir}/target/kernel_modules/test_module1/test_module1.ko)

--- a/tests/version_script/build.bp
+++ b/tests/version_script/build.bp
@@ -1,0 +1,49 @@
+bob_shared_library {
+    name: "libshared_vs_simple",
+    srcs: ["lib.c"],
+    version_script: "exports0.map",
+}
+
+bob_binary {
+    name: "vs_binary_simple",
+    srcs: ["main.c"],
+    shared_libs: ["libshared_vs_simple"],
+    install_group: "IG_binaries",
+    build_by_default: true, // Required on Android.mk
+    osx: {
+        enabled: false,
+    },
+}
+
+bob_generate_source {
+    name: "vs_version_map",
+    srcs: ["exports1.map"],
+    out: ["exports2.map"],
+    cmd: "sed s/_func/func/ ${in} > ${out}",
+}
+
+bob_shared_library {
+    name: "libshared_vs_gen",
+    srcs: ["lib.c"],
+    generated_deps: ["vs_version_map"],
+    version_script: "${vs_version_map_out}",
+}
+
+bob_binary {
+    name: "vs_binary_gen",
+    srcs: ["main.c"],
+    shared_libs: ["libshared_vs_gen"],
+    install_group: "IG_binaries",
+    build_by_default: true, // Required on Android.mk
+    osx: {
+        enabled: false,
+    },
+}
+
+bob_alias {
+    name: "bob_test_version_script",
+    srcs: [
+        "vs_binary_simple",
+        "vs_binary_gen",
+    ],
+}

--- a/tests/version_script/exports0.map
+++ b/tests/version_script/exports0.map
@@ -1,0 +1,10 @@
+VERS_1 {
+  global:
+    func1;
+  local:
+    *;
+};
+
+VERS_2 {
+  func2;
+} VERS_1;

--- a/tests/version_script/exports1.map
+++ b/tests/version_script/exports1.map
@@ -1,0 +1,10 @@
+VERS_1 {
+  global:
+    _func1;
+  local:
+    *;
+};
+
+VERS_2 {
+  _func2;
+} VERS_1;

--- a/tests/version_script/lib.c
+++ b/tests/version_script/lib.c
@@ -1,0 +1,11 @@
+int func1(void) {
+    return 12345;
+}
+
+int func2(void) {
+    return -12345;
+}
+
+int func3(void) {
+    return 67890;
+}

--- a/tests/version_script/lib.h
+++ b/tests/version_script/lib.h
@@ -1,0 +1,5 @@
+int func1(void);
+int func2(void);
+
+// `func3` is here so that we have a symbol that is not being exported by `exports*.map`.
+int func3(void);

--- a/tests/version_script/main.c
+++ b/tests/version_script/main.c
@@ -1,0 +1,6 @@
+#include "lib.h"
+
+int main()
+{
+	return func1() + func2() == 0 ? 0 : 1;
+}


### PR DESCRIPTION
This commit adds support for the `version_script` property that
controls the linker's `--version-script` option.

`version_script` string can contain variables of the form
`${MODULE_out}` where `MODULE` is the name of a `bob_generate_source`
module.

Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>
Change-Id: I5251581d4df939f3c33189e4d73300bed0cb486d