### PR TITLE
Rework strip.py arguments

### DIFF
--- a/core/linux.go
+++ b/core/linux.go
@@ -682,10 +682,10 @@ func (*linuxGenerator) aliasActions(m *alias, ctx blueprint.ModuleContext) {
 var _ = pctx.StaticVariable("strip", "${BobScriptsDir}/strip.py")
 var stripRule = pctx.StaticRule("strip",
 	blueprint.RuleParams{
-		Command:     "$strip $args --tool $tool -o $out $in",
+		Command:     "$strip $args -o $out $in",
 		CommandDeps: []string{"$strip"},
 		Description: "strip $out",
-	}, "args", "tool")
+	}, "args")
 
 var installRule = pctx.StaticRule("install",
 	blueprint.RuleParams{
@@ -758,9 +758,10 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 			}
 
 			if lib.strip() || separateDebugInfo {
+				tc := g.getToolchain(lib.getTarget())
 				basename := filepath.Base(src)
 				strippedSrc := filepath.Join(lib.stripOutputDir(g), basename)
-				stArgs := []string{}
+				stArgs := tc.getStripFlags()
 				if lib.strip() {
 					stArgs = append(stArgs, "--strip")
 				}
@@ -771,7 +772,6 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 				}
 				stripArgs := map[string]string{
 					"args": strings.Join(stArgs, " "),
-					"tool": g.getToolchain(lib.getTarget()).getStripBinary(),
 				}
 				ctx.Build(pctx,
 					blueprint.BuildParams{

--- a/mconfig/host_toolchain.Mconfig
+++ b/mconfig/host_toolchain.Mconfig
@@ -160,8 +160,8 @@ config HOST_OBJCOPY_BINARY
 	string "Host objcopy"
 	default HOST_GNU_PREFIX + "objcopy" if HOST_TOOLCHAIN_GNU || (HOST_TOOLCHAIN_CLANG && HOST_CLANG_USE_GNU_BINUTILS)
 	default "llvm-objcopy" if HOST_TOOLCHAIN_CLANG
-	default "dsymutil" if HOST_TOOLCHAIN_XCODE
 	default "objcopy"
+	depends on !HOST_TOOLCHAIN_XCODE
 	help
 	  The objcopy executable that we can use in post install scripts
 	  to manipulate host libraries and executables.
@@ -171,3 +171,19 @@ config HOST_AR_BINARY
 	default "ar"
 	help
 	  The name of the archiver used to create host static libraries.
+
+config HOST_DSYMUTIL_BINARY
+	string "Host dsymutil"
+	default "dsymutil"
+	depends on HOST_TOOLCHAIN_XCODE
+	help
+	  The dsymutil executable that we can use in post install scripts
+	  to manipulate debug information in host libraries and executables.
+
+config HOST_STRIP_BINARY
+	string "Host strip"
+	default "strip"
+	depends on HOST_TOOLCHAIN_XCODE
+	help
+	  The strip executable that we can use in post install scripts
+	  to strip symbols from host libraries and executables.

--- a/mconfig/target_toolchain.Mconfig
+++ b/mconfig/target_toolchain.Mconfig
@@ -157,8 +157,8 @@ config TARGET_OBJCOPY_BINARY
 	string "Target objcopy"
 	default TARGET_GNU_PREFIX + "objcopy" if TARGET_TOOLCHAIN_GNU || (TARGET_TOOLCHAIN_CLANG && TARGET_CLANG_USE_GNU_BINUTILS)
 	default "llvm-objcopy" if TARGET_TOOLCHAIN_CLANG
-	default "dsymutil" if TARGET_TOOLCHAIN_XCODE
 	default "objcopy"
+	depends on !TARGET_TOOLCHAIN_XCODE
 	help
 	  The objcopy executable that we can use in post install scripts
 	  to manipulate target libraries and executables.
@@ -168,3 +168,19 @@ config TARGET_AR_BINARY
 	default "ar"
 	help
 	  The name of the archiver used to create target static libraries.
+
+config TARGET_DSYMUTIL_BINARY
+	string "Target dsymutil"
+	default "dsymutil"
+	depends on TARGET_TOOLCHAIN_XCODE
+	help
+	  The dsymutil executable that we can use in post install scripts
+	  to manipulate debug information in target libraries and executables.
+
+config TARGET_STRIP_BINARY
+	string "Target strip"
+	default "strip"
+	depends on TARGET_TOOLCHAIN_XCODE
+	help
+	  The strip executable that we can use in post install scripts
+	  to strip symbols from target libraries and executables.


### PR DESCRIPTION
In preparation for a similar script working with shared libraries,
standardize the options we want scripts to accept.

Primarily we want an option that identifies whether the library is
Unix-like Elf format, or OSX Mach-O. Use this format argument to
control the script behaviour instead of detecting a particular tool.

Add functions to get strip command flags in toolchain.go, and hook it
up to build.ninja code controlling library stripping.

Add definitions of dlsymutil and strip tools for use with the Xcode
toolchain.

Change-Id: I26400bea21b03d063f30f572fd02dded0fa0701b
Signed-off-by: David Kilroy <david.kilroy@arm.com>