### PR TITLE
Fix spelling mistakes in comments and docs

### DIFF
--- a/config_system/config_system/general.py
+++ b/config_system/config_system/general.py
@@ -468,7 +468,7 @@ def set_config_if_prompt(key, value, is_user_set=True, source="cmd_line"):
 def set_config_internal(key, value):
     # Internally most calls to set_config are not (directly) the result of the
     # user specifying the value, so this helper function avoids the need to
-    # explictly set is_user_set=False on every call
+    # explicitly set is_user_set=False on every call
     set_config(key, value, is_user_set=False)
 
 

--- a/core/filepath.go
+++ b/core/filepath.go
@@ -102,7 +102,7 @@ func newGeneratedFilePath(path string) filePath {
 	// $(HOST_OUT_GEN)/STATIC_LIBRARIES/m.Name()/file.ext
 	//
 	// Local path is anything from m.Name() (included)
-	// Module dir is everything upto and including m.Name().
+	// Module dir is everything up to and including m.Name().
 	pathElems := strings.Split(path, string(os.PathSeparator))
 	if len(pathElems) < 4 {
 		panic(fmt.Errorf("Path doesn't have as many elements as expected. %s", path))

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -257,7 +257,7 @@ relative to `$ANDROID_TOP`.
 ### **bob_module.local_include_dirs** (optional)
 A list of include directories to use. These are relative to the
 `build.bp` containing the module definition, and expected to be within
-the source heirarchy.
+the source hierarchy.
 
 ----
 ### **bob_module.export_include_dirs** (optional)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -41,7 +41,7 @@ When the code base contains lots of optional behaviour, it's important that:
   Bob's menuconfig is expected to solve this part of the problem,
   negating the need to document all the options somewhere else.
 
-* maintainance of the options is 'simple'
+* maintenance of the options is 'simple'
 
   Features and templates in the build definitions make clear where the
   configurability exists.
@@ -61,7 +61,7 @@ Bob builds happen in 3 phases:
 * Bootstrap
 
   The user sets up a build output directory, and Bob records some
-  information that it needs to retreive in subsequent phases.
+  information that it needs to retrieve in subsequent phases.
 
 * Configure
 

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -44,7 +44,7 @@ Return the value of `.param`, with all characters lower cased.
 
     {{split .param sep}}
 
-Separate the value of `.param` into an array on each occurence of the
+Separate the value of `.param` into an array on each occurrence of the
 string `sep`.
 
 ### reg_match

--- a/docs/user_guide/code_generation.md
+++ b/docs/user_guide/code_generation.md
@@ -4,7 +4,7 @@ Code Generation
 Occasionally it's preferable to use a tool to generate source code,
 rather than manually write it. Bob has a few module types that support
 generating code at compile time (the collection of module types that
-do this are refered to as generators). In all cases generator output
+do this are referred to as generators). In all cases generator output
 is placed in an intermediate directory specific to the module.
 
 ```

--- a/example/Mconfig
+++ b/example/Mconfig
@@ -15,7 +15,7 @@ choice
 	help
 	  A few different compilers are supported. They are classed by
 	  toolchain which allows a limited amount of flexibility to
-	  accomodate similar compilers.
+	  accommodate similar compilers.
 
 	  Select the compiler toolchain to be used when compiling for the target.
 

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -370,7 +370,7 @@ func (g *graph) DeleteProxyEdges(color string) {
 
 	attrVal := "\"" + color + "\""
 
-	// Re-evaluate the lists if we've removed edges to ensure we propogate multiple links
+	// Re-evaluate the lists if we've removed edges to ensure we propagate multiple links
 	removed := 1
 	for removed > 0 {
 		removed = 0

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -265,7 +265,7 @@ func IsExecutable(fname string) bool {
 // This means that using append has side-effect on the first list.
 // The purpose of this function is to avoid those side-effects.
 func NewStringSlice(lists ...[]string) []string {
-	// Checkout utils test for exmaple why this is different to append()
+	// Checkout utils test for example why this is different to append()
 	sumSize := 0
 	for _, list := range lists {
 		sumSize += len(list)

--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -34,7 +34,7 @@ choice
 	help
 	  A few different compilers are supported. They are classed by
 	  toolchain which allows a limited amount of flexibility to
-	  accomodate similar compilers.
+	  accommodate similar compilers.
 
 	  Select the compiler toolchain to be used when compiling for the target.
 


### PR DESCRIPTION
This PR fixes some spelling mistakes found by [codespell](https://github.com/codespell-project/codespell).

Signed-off-by: Francois Berder <francois.berder@arm.com>
Change-Id: I001d54cf9ff252a3a6e8587b78d77fe0ef264154