### PR TITLE
Rename `featurable` interface method.

### DIFF
--- a/core/alias.go
+++ b/core/alias.go
@@ -59,7 +59,7 @@ func (m *alias) features() *Features {
 	return &m.Properties.Features
 }
 
-func (m *alias) topLevelProperties() []interface{} {
+func (m *alias) featurableProperties() []interface{} {
 	return []interface{}{&m.Properties.AliasProps}
 }
 

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -317,7 +317,7 @@ func stripEmptyComponentsMutator(mctx blueprint.BottomUpMutatorContext) {
 		return
 	}
 
-	strippableProps := f.topLevelProperties()
+	strippableProps := f.featurableProperties()
 
 	if t, ok := mctx.Module().(targetSpecificLibrary); ok {
 		for _, tgt := range []tgtType{tgtTypeHost, tgtTypeTarget} {

--- a/core/defaults.go
+++ b/core/defaults.go
@@ -58,7 +58,7 @@ func (m *defaults) build() *Build {
 	return &m.Properties.Build
 }
 
-func (m *defaults) topLevelProperties() []interface{} {
+func (m *defaults) featurableProperties() []interface{} {
 	return []interface{}{&m.Properties.Build.BuildProps, &m.Properties.Build.SplittableProps}
 }
 

--- a/core/external_library.go
+++ b/core/external_library.go
@@ -35,7 +35,7 @@ type externalLib struct {
 	}
 }
 
-func (m *externalLib) topLevelProperties() []interface{} {
+func (m *externalLib) featurableProperties() []interface{} {
 	return []interface{}{&m.Properties.ExternalLibProps}
 }
 

--- a/core/gen_library.go
+++ b/core/gen_library.go
@@ -123,8 +123,8 @@ func (m *generateLibrary) getSplittableProps() *SplittableProps {
 	return &m.generateCommon.Properties.FlagArgsBuild.SplittableProps
 }
 
-func (m *generateLibrary) topLevelProperties() []interface{} {
-	return append(m.generateCommon.topLevelProperties(), &m.Properties.GenerateLibraryProps)
+func (m *generateLibrary) featurableProperties() []interface{} {
+	return append(m.generateCommon.featurableProperties(), &m.Properties.GenerateLibraryProps)
 }
 
 //// Support singleOutputModule interface

--- a/core/generated.go
+++ b/core/generated.go
@@ -201,7 +201,7 @@ func (m *generateCommon) getGenerateCommon() *generateCommon {
 	return m
 }
 
-func (m *generateCommon) topLevelProperties() []interface{} {
+func (m *generateCommon) featurableProperties() []interface{} {
 	return []interface{}{&m.Properties.GenerateProps}
 }
 
@@ -352,8 +352,8 @@ func (m *generateSource) GenerateBuildActions(ctx blueprint.ModuleContext) {
 	}
 }
 
-func (m *generateSource) topLevelProperties() []interface{} {
-	return append(m.generateCommon.topLevelProperties(), &m.Properties.GenerateSourceProps)
+func (m *generateSource) featurableProperties() []interface{} {
+	return append(m.generateCommon.featurableProperties(), &m.Properties.GenerateSourceProps)
 }
 
 func (gc *generateCommon) getHostBinModule(mctx blueprint.ModuleContext) (hostBinModule blueprint.Module) {
@@ -619,8 +619,8 @@ func (m *transformSource) GenerateBuildActions(ctx blueprint.ModuleContext) {
 	}
 }
 
-func (m *transformSource) topLevelProperties() []interface{} {
-	return append(m.generateCommon.topLevelProperties(), &m.Properties.TransformSourceProps)
+func (m *transformSource) featurableProperties() []interface{} {
+	return append(m.generateCommon.featurableProperties(), &m.Properties.TransformSourceProps)
 }
 
 func (m *transformSource) sourceInfo(ctx blueprint.ModuleContext, g generatorBackend) []filePath {

--- a/core/install.go
+++ b/core/install.go
@@ -165,7 +165,7 @@ func (m *installGroup) GenerateBuildActions(ctx blueprint.ModuleContext) {
 	// No build actions for a bob_install_group
 }
 
-func (m *installGroup) topLevelProperties() []interface{} {
+func (m *installGroup) featurableProperties() []interface{} {
 	return []interface{}{&m.Properties.InstallGroupProps}
 }
 
@@ -208,7 +208,7 @@ func (m *resource) GenerateBuildActions(ctx blueprint.ModuleContext) {
 	}
 }
 
-func (m *resource) topLevelProperties() []interface{} {
+func (m *resource) featurableProperties() []interface{} {
 	return []interface{}{&m.Properties.ResourceProps}
 }
 

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -47,7 +47,7 @@ func (m *kernelModule) getTargetSpecific(tgt tgtType) *TargetSpecific {
 	return m.Properties.getTargetSpecific(tgt)
 }
 
-func (m *kernelModule) topLevelProperties() []interface{} {
+func (m *kernelModule) featurableProperties() []interface{} {
 	return []interface{}{&m.Properties.Build.BuildProps}
 }
 

--- a/core/late_template.go
+++ b/core/late_template.go
@@ -243,7 +243,7 @@ func applyLateTemplates(mctx blueprint.BaseModuleContext) {
 	}
 
 	// Generic template expansion
-	for _, p := range m.topLevelProperties() {
+	for _, p := range m.featurableProperties() {
 		propsVal := reflect.Indirect(reflect.ValueOf(p))
 
 		// Properties have already been expanded, so set stringvalues to nil

--- a/core/library.go
+++ b/core/library.go
@@ -326,7 +326,7 @@ func (l *library) build() *Build {
 	return &l.Properties.Build
 }
 
-func (l *library) topLevelProperties() []interface{} {
+func (l *library) featurableProperties() []interface{} {
 	return []interface{}{&l.Properties.Build.BuildProps, &l.Properties.Build.SplittableProps}
 }
 

--- a/core/properties.go
+++ b/core/properties.go
@@ -86,7 +86,7 @@ func defaultApplierMutator(mctx blueprint.TopDownMutatorContext) {
 
 // Modules implementing featurable support the use of features and templates.
 type featurable interface {
-	topLevelProperties() []interface{}
+	featurableProperties() []interface{}
 	features() *Features
 }
 
@@ -100,7 +100,7 @@ func templateApplierMutator(mctx blueprint.TopDownMutatorContext) {
 		// TemplateApplier mutator is run before TargetApplier, so we
 		// need to apply templates with the core set, as well as
 		// host-specific and target-specific sets (where applicable).
-		props := append([]interface{}{}, m.topLevelProperties()...)
+		props := append([]interface{}{}, m.featurableProperties()...)
 
 		if ts, ok := module.(targetSpecificLibrary); ok {
 			host := ts.getTargetSpecific(tgtTypeHost)
@@ -133,7 +133,7 @@ func featureApplierMutator(mctx blueprint.TopDownMutatorContext) {
 		// FeatureApplier mutator is run first. We need to flatten the
 		// feature specific properties in the core set, and where
 		// supported, the host-specific and target-specific set.
-		var props = []propmap{propmap{m.topLevelProperties(), m.features()}}
+		var props = []propmap{propmap{m.featurableProperties(), m.features()}}
 
 		if ts, ok := module.(targetSpecificLibrary); ok {
 			host := ts.getTargetSpecific(tgtTypeHost)


### PR DESCRIPTION
`featurable` interface contains `topLevelProperties` methods which
provides some confusion about its purpose within the interface
taking into account that it should return all featurable properties.

Change `topLevelProperties` method name to `featurableProperties`.

Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>
Change-Id: Ib3186cca716875977a6e7de00d52c9f4eb175bb3