### PR TITLE
Rework applying default properties to more generic way.

### DIFF
--- a/core/generated.go
+++ b/core/generated.go
@@ -160,6 +160,9 @@ var _ matchSourceInterface = (*generateCommon)(nil)
 // generateCommon have properties that require escaping
 var _ propertyEscapeInterface = (*generateCommon)(nil)
 
+// generateCommon uses other defaults by `flag_defaults` property
+var _ defaultable = (*generateCommon)(nil)
+
 // Modules implementing hostBin are able to supply a host binary that can be executed
 type hostBin interface {
 	hostBin() string
@@ -314,6 +317,14 @@ func (m *generateCommon) getRspfile() (name string, rspfile bool) {
 		return
 	}
 	return "", rspfile
+}
+
+func (m *generateCommon) defaultableProperties() []interface{} {
+	return []interface{}{&m.Properties.FlagArgsBuild.BuildProps}
+}
+
+func (m *generateCommon) defaults() []string {
+	return m.Properties.Flag_defaults
 }
 
 // GenerateSourceProps are properties of 'bob_generate_source', i.e. a module

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -39,6 +39,10 @@ func (m *kernelModule) defaults() []string {
 	return m.Properties.Defaults
 }
 
+func (m *kernelModule) defaultableProperties() []interface{} {
+	return []interface{}{&m.Properties.Build.BuildProps}
+}
+
 func (m *kernelModule) build() *Build {
 	return &m.Properties.Build
 }

--- a/core/library.go
+++ b/core/library.go
@@ -330,6 +330,10 @@ func (l *library) defaults() []string {
 	return l.Properties.Defaults
 }
 
+func (l *library) defaultableProperties() []interface{} {
+	return []interface{}{&l.Properties.Build.BuildProps, &l.Properties.Build.SplittableProps}
+}
+
 func (l *library) build() *Build {
 	return &l.Properties.Build
 }


### PR DESCRIPTION
Currently every module which references `bob_defaults` has to be
equipped with the same set of properties no matter if it uses them
or not. This forces e.g. all library modules to contain kernel
properties.

Change the way of applying default properties to be more generic
and which allows multiple modules to have different set of
defaultable properties.

Remove unrelated `features()` method of `defaultable` interface.

Make `generateCommon` to be `defaultable` as it uses other defaults
by `flag_defaults` property.

Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>
Change-Id: Iab922fab7eb72d0cf676aa6103e26d2e8a6a30e3