### PR TITLE
Reduce build() function usage.

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -326,7 +326,7 @@ func androidLibraryBuildAction(sb *strings.Builder, mod blueprint.Module, ctx bl
 		func(p blueprint.Module) bool { return ctx.OtherModuleDependencyTag(p) == sharedDepTag },
 		func(p blueprint.Module) {
 			if sl, ok := p.(*sharedLibrary); ok {
-				b := sl.build()
+				b := &sl.library.Properties.Build
 				if b.isForwardingSharedLibrary() {
 					hasForwardingLib = true
 				}

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -398,7 +398,7 @@ func dependerMutator(mctx blueprint.BottomUpMutatorContext) {
 	}
 
 	if l, ok := getLibrary(mctx.Module()); ok {
-		build := l.build()
+		build := &l.Properties.Build
 
 		mctx.AddVariationDependencies(nil, wholeStaticDepTag, build.Whole_static_libs...)
 		mctx.AddVariationDependencies(nil, staticDepTag, build.Static_libs...)

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -43,10 +43,6 @@ func (m *kernelModule) defaultableProperties() []interface{} {
 	return []interface{}{&m.Properties.Build.BuildProps}
 }
 
-func (m *kernelModule) build() *Build {
-	return &m.Properties.Build
-}
-
 func (m *kernelModule) getTargetSpecific(tgt tgtType) *TargetSpecific {
 	return m.Properties.getTargetSpecific(tgt)
 }
@@ -157,14 +153,14 @@ func (m *kernelModule) generateKbuildArgs(ctx blueprint.BaseModuleContext) kbuil
 
 	g := getBackend(ctx)
 
-	extraCflags := m.build().BuildProps.Cflags
+	extraCflags := m.Properties.BuildProps.Cflags
 
-	for _, includeDir := range m.build().BuildProps.Local_include_dirs {
+	for _, includeDir := range m.Properties.Build.BuildProps.Local_include_dirs {
 		includeDir = "-I" + getBackendPathInSourceDir(g, includeDir)
 		extraIncludePaths = append(extraIncludePaths, includeDir)
 	}
 
-	for _, includeDir := range m.build().BuildProps.Include_dirs {
+	for _, includeDir := range m.Properties.Build.BuildProps.Include_dirs {
 		includeDir = "-I" + includeDir
 		extraIncludePaths = append(extraIncludePaths, includeDir)
 	}
@@ -176,8 +172,8 @@ func (m *kernelModule) generateKbuildArgs(ctx blueprint.BaseModuleContext) kbuil
 	}
 
 	kbuildOptions := ""
-	if len(m.build().Kbuild_options) > 0 {
-		kbuildOptions = "--kbuild-options " + strings.Join(m.build().Kbuild_options, " ")
+	if len(m.Properties.Build.Kbuild_options) > 0 {
+		kbuildOptions = "--kbuild-options " + strings.Join(m.Properties.Build.Kbuild_options, " ")
 	}
 
 	hostToolchain := m.Properties.Build.Kernel_hostcc

--- a/core/library.go
+++ b/core/library.go
@@ -874,7 +874,7 @@ func checkForMultipleLinking(topLevelModuleName string, staticLibs map[string]bo
 
 // While traversing the static library dependency tree, propagate extra properties.
 func propagateOtherExportedProperties(l *library, depLib propertyExporter) {
-	props := l.build()
+	props := &l.Properties.Build
 	for _, shLib := range depLib.exportSharedLibs() {
 		if !utils.Contains(props.Shared_libs, shLib) {
 			props.Shared_libs = append(props.Shared_libs, shLib)

--- a/core/linux.go
+++ b/core/linux.go
@@ -398,7 +398,7 @@ func (l *library) getSharedLibLinkPaths(ctx blueprint.ModuleContext) (libs []str
 func (l *library) getSharedLibFlags(ctx blueprint.ModuleContext) (ldlibs []string, ldflags []string) {
 	// With forwarding shared library we do not have to use
 	// --no-as-needed for dependencies because it is already set
-	useNoAsNeeded := !l.build().isForwardingSharedLibrary()
+	useNoAsNeeded := !l.Properties.Build.isForwardingSharedLibrary()
 	hasForwardingLib := false
 	libPaths := []string{}
 	tc := getBackend(ctx).getToolchain(l.Properties.TargetType)
@@ -407,7 +407,7 @@ func (l *library) getSharedLibFlags(ctx blueprint.ModuleContext) (ldlibs []strin
 		func(m blueprint.Module) bool { return ctx.OtherModuleDependencyTag(m) == sharedDepTag },
 		func(m blueprint.Module) {
 			if sl, ok := m.(*sharedLibrary); ok {
-				b := sl.build()
+				b := &sl.library.Properties.Build
 				if b.isForwardingSharedLibrary() {
 					hasForwardingLib = true
 					ldlibs = append(ldlibs, tc.getLinker().keepSharedLibraryTransitivity())
@@ -473,7 +473,7 @@ func (l *library) getCommonLibArgs(ctx blueprint.ModuleContext) map[string]strin
 	ldflags := l.Properties.Ldflags
 	tc := getBackend(ctx).getToolchain(l.Properties.TargetType)
 
-	if l.build().isForwardingSharedLibrary() {
+	if l.Properties.Build.isForwardingSharedLibrary() {
 		ldflags = append(ldflags, tc.getLinker().keepUnusedDependencies())
 	} else {
 		ldflags = append(ldflags, tc.getLinker().dropUnusedDependencies())


### PR DESCRIPTION
There are many places where build() function is used redundantly
or unnecessarily.
Get rid of unnecessary build() function call.

Handling kernel modules does not require build() method anymore.
Remove build() function for `kernelModule`.

Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>
Change-Id: Ia72b0b79d714a9bdbcca8ce87e622aba150fbf05