### PR TITLE
Check error while globbing

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -216,7 +216,12 @@ func glob(ctx blueprint.BaseModuleContext, globs []string, excludes []string) []
 			// directory (not the working directory), so add it
 			// here, and remove it afterwards.
 			file = getPathInSourceDir(file)
-			matches, _ := ctx.GlobWithDeps(file, excludesFromSrcDir)
+			matches, err := ctx.GlobWithDeps(file, excludesFromSrcDir)
+
+			if err != nil {
+				ctx.ModuleErrorf("glob failed with: %s", err)
+			}
+
 			for _, match := range matches {
 				rel, err := filepath.Rel(getSourceDir(), match)
 				if err != nil {


### PR DESCRIPTION
Currently when globbing the returned error is simply omitted.
If in parsed directory will be dangling symlink this produces no
error but creates violated build.ninja file.

There is a need to check the error and exit if it appears.

Check the error while globbing and report error of the module.

Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>
Change-Id: I08e813ca23851f8dc07c731e0e12cbedd84371f6