### PR TITLE
Depend on shared libs via their toc file

### DIFF
--- a/core/gen_shared.go
+++ b/core/gen_shared.go
@@ -29,6 +29,7 @@ type generateSharedLibrary struct {
 // Verify that the following interfaces are implemented
 var _ generateLibraryInterface = (*generateSharedLibrary)(nil)
 var _ singleOutputModule = (*generateSharedLibrary)(nil)
+var _ sharedLibProducer = (*generateSharedLibrary)(nil)
 var _ blueprint.Module = (*generateSharedLibrary)(nil)
 
 func (m *generateSharedLibrary) generateInouts(ctx blueprint.ModuleContext, g generatorBackend) []inout {
@@ -54,6 +55,12 @@ func (m *generateSharedLibrary) GenerateBuildActions(ctx blueprint.ModuleContext
 
 func (m *generateSharedLibrary) outputFileName() string {
 	return m.altName() + m.libExtension()
+}
+
+//// Support sharedLibProducer
+
+func (m *generateSharedLibrary) getTocName() string {
+	return m.outputFileName() + tocExt
 }
 
 //// Factory functions

--- a/core/library.go
+++ b/core/library.go
@@ -30,6 +30,10 @@ import (
 	"github.com/ARM-software/bob-build/internal/utils"
 )
 
+const (
+	tocExt = ".toc"
+)
+
 var depOutputsVarRegexp = regexp.MustCompile(`^\$\{(.+)_out\}$`)
 
 type propertyExporter interface {
@@ -671,6 +675,7 @@ type sharedLibrary struct {
 }
 
 var _ linkableModule = (*sharedLibrary)(nil)
+var _ sharedLibProducer = (*sharedLibrary)(nil)
 
 func (m *sharedLibrary) getLinkName() string {
 	return m.outputName() + m.fileNameExtension
@@ -730,6 +735,12 @@ func (m *sharedLibrary) outputFileName() string {
 	// -lmod, return the name of the link library here rather than the
 	// real, versioned library.
 	return m.getLinkName()
+}
+
+//// Support sharedLibProducer
+
+func (m *sharedLibrary) getTocName() string {
+	return m.getRealName() + tocExt
 }
 
 type binary struct {

--- a/core/library.go
+++ b/core/library.go
@@ -670,6 +670,8 @@ type sharedLibrary struct {
 	fileNameExtension string
 }
 
+var _ linkableModule = (*sharedLibrary)(nil)
+
 func (m *sharedLibrary) getLinkName() string {
 	return m.outputName() + m.fileNameExtension
 }
@@ -733,6 +735,8 @@ func (m *sharedLibrary) outputFileName() string {
 type binary struct {
 	library
 }
+
+var _ linkableModule = (*binary)(nil)
 
 func (l *binary) strip() bool {
 	return l.Properties.Strip != nil && *l.Properties.Strip

--- a/core/library.go
+++ b/core/library.go
@@ -671,7 +671,7 @@ type sharedLibrary struct {
 }
 
 func (m *sharedLibrary) getLinkName() string {
-	return m.outputFileName()
+	return m.outputName() + m.fileNameExtension
 }
 
 func (m *sharedLibrary) getSoname() string {
@@ -724,7 +724,10 @@ func (m *sharedLibrary) GenerateBuildActions(ctx blueprint.ModuleContext) {
 //// Support singleOutputModule
 
 func (m *sharedLibrary) outputFileName() string {
-	return m.outputName() + m.fileNameExtension
+	// Since we link against libraries using the library flag style,
+	// -lmod, return the name of the link library here rather than the
+	// real, versioned library.
+	return m.getLinkName()
 }
 
 type binary struct {

--- a/core/linux.go
+++ b/core/linux.go
@@ -604,12 +604,7 @@ var symlinkRule = pctx.StaticRule("symlink",
 func (g *linuxGenerator) sharedActions(m *sharedLibrary, ctx blueprint.ModuleContext) {
 	// Calculate and record outputs
 	m.outputdir = g.sharedLibOutputDir(m)
-	var soFile string
-	if m.library.Properties.Library_version == "" {
-		soFile = filepath.Join(m.outputDir(), m.outputName()+m.fileNameExtension)
-	} else {
-		soFile = filepath.Join(m.outputDir(), m.getRealName())
-	}
+	soFile := filepath.Join(m.outputDir(), m.getRealName())
 	m.outs = []string{soFile}
 
 	objectFiles, nonCompiledDeps := m.CompileObjs(ctx)

--- a/core/linux_generated.go
+++ b/core/linux_generated.go
@@ -19,7 +19,6 @@ package core
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/google/blueprint"
@@ -52,7 +51,7 @@ func (g *linuxGenerator) generateCommonActions(m *generateCommon, ctx blueprint.
 
 	ldLibraryPath := ""
 	if _, ok := args["host_bin"]; ok {
-		ldLibraryPath += "LD_LIBRARY_PATH=" + filepath.Join("${BuildDir}", string(hostTarget), "shared") + ":$$LD_LIBRARY_PATH "
+		ldLibraryPath += "LD_LIBRARY_PATH=" + g.sharedLibsDir(hostTarget) + ":$$LD_LIBRARY_PATH "
 	}
 	utils.StripUnusedArgs(args, cmd)
 
@@ -163,7 +162,7 @@ func (g *linuxGenerator) genSharedActions(m *generateSharedLibrary, ctx blueprin
 
 	// Create a rule to copy the generated library
 	// from gen_dir to the common library directory
-	soFile := getSharedLibLinkPath(m)
+	soFile := g.getSharedLibLinkPath(m)
 	ctx.Build(pctx,
 		blueprint.BuildParams{
 			Rule:     copyRule,
@@ -188,7 +187,7 @@ func (g *linuxGenerator) genBinaryActions(m *generateBinary, ctx blueprint.Modul
 		blueprint.BuildParams{
 			Rule:     copyRule,
 			Inputs:   m.outputs(),
-			Outputs:  []string{getBinaryPath(m)},
+			Outputs:  []string{g.getBinaryPath(m)},
 			Optional: true,
 		})
 

--- a/core/linux_generated.go
+++ b/core/linux_generated.go
@@ -171,7 +171,8 @@ func (g *linuxGenerator) genSharedActions(m *generateSharedLibrary, ctx blueprin
 			Optional: true,
 		})
 
-	g.addSharedLibToc(ctx, soFile, m.getTarget())
+	tocFile := g.getSharedLibTocPath(m)
+	g.addSharedLibToc(ctx, soFile, tocFile, m.getTarget())
 
 	installDeps := g.install(m, ctx)
 	addPhony(m, ctx, installDeps, !isBuiltByDefault(m))

--- a/scripts/env_hash.py
+++ b/scripts/env_hash.py
@@ -45,6 +45,7 @@ def hash_env():
         "PATH",
 
         # bob-build
+        "BOB_ALWAYS_LINK_SHARED_LIBS",
         "BOB_CPUPROFILE",
         "BOB_LINK_PARALLELISM",
         "BOB_VERSION",


### PR DESCRIPTION
Depend on toc files to avoid rebuilding callers when the API is
unchanged. When we do this we just need to change the implicit
dependencies on the shared libraries to an implicit dependency on the
toc file.
    
Allow disabling this functionality by setting the environment variable
BOB_ALWAYS_LINK_SHARED_LIBS=1. This allows people who encounter
problems with this mode of operation to work around it while the
majority of developers get the benefits automatically.