### PR TITLE
Allow comments next to help in configs

### DIFF
--- a/config_system/config_system/lex.py
+++ b/config_system/config_system/lex.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -112,7 +112,8 @@ def t_space(t):
 
 
 def t_commandhelp(t):
-    r"help[ \t]*\n"
+    r"help[ \t]*(?:\#.*)?\n"
+
     t.lexer.begin("HELP")
     t.type = "HELP"
     global help_indent

--- a/config_system/tests/choice.test
+++ b/config_system/tests/choice.test
@@ -11,10 +11,14 @@ choice
 
 config OPTION_A
   bool "A"
+  help
+    Cool choice A.
 
 config OPTION_B
   bool "B"
   depends on MODE
+  help # this choice is cooler
+    Cooler choice B.
 
 config OPTION_C
   bool "C"

--- a/config_system/tests/formatter/formatter.expected
+++ b/config_system/tests/formatter/formatter.expected
@@ -21,6 +21,8 @@ config OPTION_B
 config OPTION_C
 	bool "C"
 	depends on MODE
+	help # Help with comment
+	  Help text can also have comments # This should be kept.
 
 endchoice
 choice

--- a/config_system/tests/formatter/formatter.test
+++ b/config_system/tests/formatter/formatter.test
@@ -21,6 +21,8 @@ config OPTION_B
 config OPTION_C
 	bool "C"
 	depends on MODE
+	help # Help with comment
+	  Help text can also have comments # This should be kept.
 
 endchoice
 choice


### PR DESCRIPTION
Previously when we put a line of comment next to help in config files,
help didn't get recognized.

Signed-off-by: Ali Utku Selen <ali.utku.selen@arm.com>
Change-Id: Ie69cbf37f36cd381e34d6200894b78cadcee7be5