### PR TITLE
Fix python failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,8 @@ before_install:
 install:
   - .travis/install-ninja.sh
   - export PATH=$PATH:$TRAVIS_WORK_DIR/ninjabin
-  - python3 -m pip install --user setuptools
-  - python3 -m pip install --user virtualenv
-  - python3 -m virtualenv -p ${PYTHON_SUFFIX} $TRAVIS_WORK_DIR/python_env
+  - python3 -m pip install --user setuptools virtualenv importlib-resources==3.2.1
+  - python3 -m virtualenv -p python${PYTHON_SUFFIX} $TRAVIS_WORK_DIR/python_env
   - source $TRAVIS_WORK_DIR/python_env/bin/activate
   - pip install -r .travis/pip_requirements.txt
 


### PR DESCRIPTION
Specify the python binary we want the virtualenv to use rather than
just the suffix.

virtualenv depends on importlib-resources, but we need to fix this to
3.2.1 to avoid an os.PathLike error - this is only available from
Python 3.6, and Ubuntu 16.04 is providing Python 3.5

Change-Id: Iee8a93bce5e04f03eb68941c80e5ce144658e32f
Signed-off-by: David Kilroy <david.kilroy@arm.com>