### PR TITLE
Rework kernel module properties

### DIFF
--- a/core/defaults.go
+++ b/core/defaults.go
@@ -29,6 +29,7 @@ type defaults struct {
 	Properties struct {
 		Features
 		Build
+		KernelProps
 		// The list of default properties that should prepended to all configuration
 		Defaults []string
 	}
@@ -59,11 +60,15 @@ func (m *defaults) build() *Build {
 }
 
 func (m *defaults) defaultableProperties() []interface{} {
-	return []interface{}{&m.Properties.Build.BuildProps, &m.Properties.Build.SplittableProps}
+	return []interface{}{&m.Properties.Build.BuildProps, &m.Properties.Build.SplittableProps, &m.Properties.KernelProps}
 }
 
 func (m *defaults) featurableProperties() []interface{} {
-	return []interface{}{&m.Properties.Build.BuildProps, &m.Properties.Build.SplittableProps}
+	return []interface{}{&m.Properties.Build.BuildProps, &m.Properties.Build.SplittableProps, &m.Properties.KernelProps}
+}
+
+func (m *defaults) targetableProperties() []interface{} {
+	return []interface{}{&m.Properties.Build.BuildProps, &m.Properties.Build.SplittableProps, &m.Properties.KernelProps}
 }
 
 func (m *defaults) features() *Features {
@@ -80,6 +85,7 @@ func (m *defaults) getTargetSpecific(variant tgtType) *TargetSpecific {
 
 func (m *defaults) processPaths(ctx blueprint.BaseModuleContext, g generatorBackend) {
 	m.Properties.Build.processPaths(ctx, g)
+	m.Properties.KernelProps.processPaths(ctx)
 }
 
 func (m *defaults) GenerateBuildActions(ctx blueprint.ModuleContext) {
@@ -108,7 +114,7 @@ func (m *defaults) getMatchSourcePropNames() []string {
 func defaultsFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &defaults{}
 
-	module.Properties.Features.Init(&config.Properties, BuildProps{}, SplittableProps{})
+	module.Properties.Features.Init(&config.Properties, BuildProps{}, SplittableProps{}, KernelProps{})
 	module.Properties.Host.init(&config.Properties, BuildProps{})
 	module.Properties.Target.init(&config.Properties, BuildProps{})
 

--- a/core/library.go
+++ b/core/library.go
@@ -20,7 +20,6 @@ package core
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -164,26 +163,6 @@ type BuildProps struct {
 	AndroidProps
 	AndroidPGOProps
 
-	// Linux kernel config options to emulate. These are passed to Kbuild in
-	// the 'make' command-line, and set in the source code via EXTRA_CFLAGS
-	Kbuild_options []string
-	// Kernel modules which this module depends on
-	Extra_symbols []string
-	// Arguments to pass to kernel make invocation
-	Make_args []string
-	// Kernel directory location
-	Kernel_dir string
-	// Compiler prefix for kernel build
-	Kernel_cross_compile string
-	// Kernel target compiler
-	Kernel_cc string
-	// Kernel host compiler
-	Kernel_hostcc string
-	// Kernel linker
-	Kernel_ld string
-	// Target triple when using clang as the compiler
-	Kernel_clang_triple string
-
 	TargetType tgtType `blueprint:"mutated"`
 }
 
@@ -284,12 +263,6 @@ func (l *BuildProps) processPaths(ctx blueprint.BaseModuleContext, g generatorBa
 	l.InstallableProps.processPaths(ctx, g)
 	l.Local_include_dirs = utils.PrefixDirs(l.Local_include_dirs, prefix)
 	l.Export_local_include_dirs = utils.PrefixDirs(l.Export_local_include_dirs, prefix)
-
-	// join module dir with relative kernel dir
-	if l.Kernel_dir != "" && !filepath.IsAbs(l.Kernel_dir) {
-		l.Kernel_dir = filepath.Join(prefix, l.Kernel_dir)
-	}
-
 	l.processBuildWrapper(ctx)
 }
 
@@ -343,6 +316,10 @@ func (l *library) build() *Build {
 }
 
 func (l *library) featurableProperties() []interface{} {
+	return []interface{}{&l.Properties.Build.BuildProps, &l.Properties.Build.SplittableProps}
+}
+
+func (l *library) targetableProperties() []interface{} {
 	return []interface{}{&l.Properties.Build.BuildProps, &l.Properties.Build.SplittableProps}
 }
 

--- a/core/properties.go
+++ b/core/properties.go
@@ -164,6 +164,8 @@ func featureApplierMutator(mctx blueprint.TopDownMutatorContext) {
 		// supported, the host-specific and target-specific set.
 		var props = []propmap{propmap{m.featurableProperties(), m.features()}}
 
+		// Apply features in target-specific properties.
+		// This should happen for all modules which support host:{} and target:{}
 		if ts, ok := module.(targetSpecificLibrary); ok {
 			host := ts.getTargetSpecific(tgtTypeHost)
 			target := ts.getTargetSpecific(tgtTypeTarget)

--- a/core/splitter.go
+++ b/core/splitter.go
@@ -50,10 +50,17 @@ type splittable interface {
 // targetSpecificLibrary extends splittable to allow retrieving specific data
 // for host and target.
 type targetSpecificLibrary interface {
-	// Get the target specific properties
-	getTargetSpecific(tgtType) *TargetSpecific
-	getTarget() tgtType
 	splittable
+
+	// Get module target type
+	getTarget() tgtType
+
+	// Get the target specific properties i.e. host:{} or target:{}
+	getTargetSpecific(tgtType) *TargetSpecific
+
+	// Get the set of the module main properties for
+	// that target specific properties would be applied to
+	targetableProperties() []interface{}
 }
 
 // Traverse the core properties of defaults to find out which variations are


### PR DESCRIPTION
Kernel properties are currently closely tied to BuildProps
which forces most of the modules to contain kernel properties
even when they don't need it at all.

Move kernel properties out of BuildProps and create new
KernelProps struct for them. The modules which need such
properties should only incorporate it.

Change-Id: I89f27d7dc466e790247806657beba382601379b4
Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>