### PR TITLE
Refactor generate_androic_inc.mk

### DIFF
--- a/example/Android.mk.blueprint
+++ b/example/Android.mk.blueprint
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +38,6 @@ include $(BUILD_SYSTEM)/ninja_config.mk
 # any shell command that begins with "out/"
 BOB_GEN_CMD:=NINJA=$(NINJA) \
     "$(BOB_$(PROJ)_DIR)/@@BOB_DIR@@/scripts/generate_android_inc.bash" \
-    -c "@@CONFIGNAME@@" \
     -o "./$(BOB_ANDROIDMK_DIR)" \
     -s "$(LOCAL_PATH)" \
     -v "$(PLATFORM_SDK_VERSION)"

--- a/example/bootstrap_androidmk.bash
+++ b/example/bootstrap_androidmk.bash
@@ -96,7 +96,6 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 TMP_ANDROID_MK="$(mktemp)"
 sed -e "s#@@BOB_PROJ_NAME@@#$PROJ_NAME#" \
     -e "s#@@BOB_DIR@@#$BOB_DIR#" \
-    -e "s#@@CONFIGNAME@@#$CONFIGNAME#" \
     "${PROJ_DIR}/Android.mk.blueprint" > "$TMP_ANDROID_MK"
 rsync --checksum "$TMP_ANDROID_MK" "${PROJ_DIR}/Android.mk"
 rm -f "$TMP_ANDROID_MK"

--- a/scripts/generate_android_inc.bash
+++ b/scripts/generate_android_inc.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,18 +30,17 @@ trap 'echo "*** Unexpected error in $0 ***"' ERR
 
 BOB_DIR=$(dirname $(dirname "${BASH_SOURCE[0]}"))
 
-while getopts "c:o:s:v:" opt; do
+while getopts "o:s:v:" opt; do
     case $opt in
-        c) CONFIGNAME="$OPTARG";;
         o) BUILDDIR=`readlink -f "$OPTARG"`;;
         s) PATH_TO_PROJ="$OPTARG";;
         v) PLATFORM_SDK_VERSION="$OPTARG";;
     esac
 done
 
-if [[ -z $BUILDDIR || -z $CONFIGNAME || -z $PATH_TO_PROJ || -z $PLATFORM_SDK_VERSION ]]; then
+if [[ -z $BUILDDIR || -z $PATH_TO_PROJ || -z $PLATFORM_SDK_VERSION ]]; then
     echo "Error: Missing argument to $0"
-    echo "Usage: $0 -c CONFIGNAME -o BUILDDIR -s PATH_TO_PROJ -v PLATFORM_SDK_VERSION"
+    echo "Usage: $0 -o BUILDDIR -s PATH_TO_PROJ -v PLATFORM_SDK_VERSION"
     exit 1
 fi
 
@@ -49,9 +48,6 @@ source "${BOB_DIR}/pathtools.bash"
 
 if ! [[ -x ${BUILDDIR}/buildme ]]; then
     echo "${BUILDDIR}/buildme does not exist!"
-    exit 1
-elif ! [[ -f "${BUILDDIR}/${CONFIGNAME}" ]]; then
-    echo "${BUILDDIR}/${CONFIGNAME} does not exist!"
     exit 1
 elif [[ -z $NINJA ]]; then
     echo "\$NINJA not set!"

--- a/tests/Android.mk.blueprint
+++ b/tests/Android.mk.blueprint
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2020 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +38,6 @@ include $(BUILD_SYSTEM)/ninja_config.mk
 # any shell command that begins with "out/"
 BOB_GEN_CMD:=NINJA=$(NINJA) \
     "$(BOB_$(PROJ)_DIR)/@@BOB_DIR@@/scripts/generate_android_inc.bash" \
-    -c "@@CONFIGNAME@@" \
     -o "./$(BOB_ANDROIDMK_DIR)" \
     -s "$(LOCAL_PATH)" \
     -v "$(PLATFORM_SDK_VERSION)"

--- a/tests/bootstrap_androidmk
+++ b/tests/bootstrap_androidmk
@@ -105,7 +105,6 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 TMP_ANDROID_MK="$(mktemp)"
 sed -e "s#@@BOB_PROJ_NAME@@#$PROJ_NAME#" \
     -e "s#@@BOB_DIR@@#$BOB_DIR#" \
-    -e "s#@@CONFIGNAME@@#$CONFIGNAME#" \
     "${PROJ_DIR}/Android.mk.blueprint" > "$TMP_ANDROID_MK"
 rsync --checksum "$TMP_ANDROID_MK" "${PROJ_DIR}/Android.mk"
 rm -f "$TMP_ANDROID_MK"


### PR DESCRIPTION
This commit prepares for the change of location of the config file.
This commit removes the config file check in generate_android_inc.mk because it was redundant given that this check already exists in buildme.bash
