### PR TITLE
Fix version script paths on Soong

### DIFF
--- a/core/library.go
+++ b/core/library.go
@@ -20,6 +20,7 @@ package core
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -595,7 +596,13 @@ func (l *library) getVersionScript(ctx blueprint.ModuleContext) *string {
 		}
 		return &outputs[0]
 	}
-	return l.Properties.Build.Version_script
+
+	if l.Properties.Build.Version_script != nil {
+		path := getBackendPathInSourceDir(getBackend(ctx), *l.Properties.Build.Version_script)
+		return &path
+	}
+
+	return nil
 }
 
 func (l *library) processPaths(ctx blueprint.BaseModuleContext, g generatorBackend) {
@@ -607,7 +614,7 @@ func (l *library) processPaths(ctx blueprint.BaseModuleContext, g generatorBacke
 		if len(matches) == 2 {
 			l.Properties.VersionScriptModule = &matches[1]
 		} else {
-			*versionScript = getBackendPathInSourceDir(getBackend(ctx), projectModuleDir(ctx), *versionScript)
+			*versionScript = filepath.Join(projectModuleDir(ctx), *versionScript)
 		}
 	}
 }


### PR DESCRIPTION
This commit updates `library.go` to avoid using
`getBackendPathInSourceDir` when computing version script paths
on the Android.bp backend as Soong adds the prefix automatically.

Signed-off-by: Alexander Khabarov <alexander.khabarov@arm.com>
Change-Id: Ifa7428bef6056fd4c25fa86b49cc108560007f16