### PR TITLE
Fix building example for Android with Make

### DIFF
--- a/example/bootstrap_androidmk.bash
+++ b/example/bootstrap_androidmk.bash
@@ -112,7 +112,7 @@ ln -sf "bob" "${BUILDDIR}/buildme"
 
 if [ $MENU -ne 1 ] || [ ! -f "$ANDROIDMK_DIR/$CONFIGNAME" ] ; then
     # Have arguments or missing bob.config. Run config.
-    "$ANDROIDMK_DIR/config" ANDROID=y BUILDER_ANDROID_MK=y "$@"
+    "$ANDROIDMK_DIR/config" ANDROID=y BUILDER_ANDROID_MAKE=y "$@"
 fi
 
 if [ $MENU -eq 1 ] ; then

--- a/example/build.bp
+++ b/example/build.bp
@@ -12,7 +12,15 @@ bob_defaults {
 
 bob_install_group {
     name: "bin",
-    install_path: "out/bin",
+    builder_android_make: {
+        install_path: "$(TARGET_OUT)/bin",
+    },
+    builder_android_bp: {
+        install_path: "bin",
+    },
+    builder_ninja: {
+        install_path: "out/bin",
+    },
 }
 
 bob_binary {


### PR DESCRIPTION
This commit fixes two things:
  * BUILDER_ANDROID_MK variable introduced in commit 73c7566b1931 does not exist.
  * The install path for Android Make in build.bp must be absolute, not relative to the Android source tree.
