### PR TITLE
Save config directory in .bob.bootstrap

### DIFF
--- a/bob.bootstrap.version
+++ b/bob.bootstrap.version
@@ -1,2 +1,2 @@
 # Version number used to identify whether the user needs to re-boostrap their build directory.
-BOB_VERSION="7"
+BOB_VERSION="8"

--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -17,6 +17,7 @@
 
 # SRCDIR - Path to base of source tree. This can be relative to PWD or absolute.
 # BUILDDIR - Build output directory. This can be relative to PWD or absolute.
+# CONFIGDIR - Configuration directory. This can be relative to PWD or absolute.
 # CONFIGNAME - Name of the configuration file.
 # BLUEPRINT_LIST_FILE - Path to file listing all Blueprint input files.
 #                       This can be relative to PWD or absolute.
@@ -43,6 +44,12 @@ fi
 if [[ -z "$BUILDDIR" ]]; then
   echo "BUILDDIR is not set - using ."
   export BUILDDIR=.
+fi
+
+if [[ -z "$CONFIGDIR" ]]; then
+  CONFIGDIR="${BUILDDIR}"
+else
+  mkdir -p "${CONFIGDIR}"
 fi
 
 if [[ -z "$CONFIGNAME" ]]; then
@@ -80,8 +87,8 @@ fi
 
 # Calculate Bob directory relative to the working directory.
 BOB_DIR="$(relative_path $(pwd) "${SCRIPT_DIR}")"
-CONFIG_FILE="${BUILDDIR}/${CONFIGNAME}"
-CONFIG_JSON="${BUILDDIR}/.bob.config.json"
+CONFIG_FILE="${CONFIGDIR}/${CONFIGNAME}"
+CONFIG_JSON="${CONFIGDIR}/.bob.config.json"
 
 export TOPNAME="build.bp"
 export BOOTSTRAP="${BOB_DIR}/bootstrap.bash"

--- a/core/android_make.go
+++ b/core/android_make.go
@@ -364,7 +364,7 @@ func androidLibraryBuildAction(sb *strings.Builder, mod blueprint.Module, ctx bl
 			// Setup args like we do for bob_generated_*
 			args := map[string]string{}
 			args["bob_config"] = configFile
-			args["bob_config_json"] = filepath.Join(getBuildDir(), configJSONFile)
+			args["bob_config_json"] = configJSONFile
 			if m.Properties.Post_install_tool != nil {
 				args["tool"] = *m.Properties.Post_install_tool
 			}

--- a/core/androidbp_generated.go
+++ b/core/androidbp_generated.go
@@ -66,7 +66,7 @@ func expandCmd(s string, moduleDir string) string {
 		case "bob_config":
 			return configFile
 		case "bob_config_json":
-			return filepath.Join(getBuildDir(), configJSONFile)
+			return configJSONFile
 		case "bob_config_opts":
 			return configOpts
 		default:

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -271,7 +271,7 @@ func (s *SourceProps) processPaths(ctx blueprint.BaseModuleContext, g generatorB
 	prefix := projectModuleDir(ctx)
 	var special = map[string]string{
 		"${bob_config}":      configFile,
-		"${bob_config_json}": filepath.Join(getBuildDir(), configJSONFile),
+		"${bob_config_json}": configJSONFile,
 	}
 
 	// Look for special items. Remove from Srcs and add to Specials

--- a/core/generated.go
+++ b/core/generated.go
@@ -472,7 +472,7 @@ func (m *generateCommon) getArgs(ctx blueprint.ModuleContext) (string, map[strin
 		"as":                asBinary,
 		"asflags":           utils.Join(astargetflags, props.Asflags),
 		"bob_config":        configFile,
-		"bob_config_json":   filepath.Join(getBuildDir(), configJSONFile),
+		"bob_config_json":   configJSONFile,
 		"bob_config_opts":   configOpts,
 		"cc":                cc,
 		"cflags":            strings.Join(props.Cflags, " "),

--- a/core/linux_backend.go
+++ b/core/linux_backend.go
@@ -253,7 +253,7 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 		cmd = strings.Replace(cmd, "${args}", strings.Join(props.Post_install_args, " "), -1)
 
 		args["bob_config"] = configFile
-		args["bob_config_json"] = filepath.Join(getBuildDir(), configJSONFile)
+		args["bob_config_json"] = configJSONFile
 		if props.Post_install_tool != nil {
 			args["tool"] = *props.Post_install_tool
 			deps = append(deps, *props.Post_install_tool)

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -33,12 +33,11 @@ import (
 )
 
 var (
-	bobdir     = os.Getenv("BOB_DIR")
-	configFile = os.Getenv("CONFIG_FILE")
-	configOpts = os.Getenv("BOB_CONFIG_OPTS")
-	srcdir     = os.Getenv("SRCDIR")
-
-	configJSONFile = ".bob.config.json"
+	bobdir         = os.Getenv("BOB_DIR")
+	configFile     = os.Getenv("CONFIG_FILE")
+	configOpts     = os.Getenv("BOB_CONFIG_OPTS")
+	srcdir         = os.Getenv("SRCDIR")
+	configJSONFile = os.Getenv("CONFIG_JSON")
 )
 
 type moduleBase struct {
@@ -81,9 +80,8 @@ func Main() {
 	// Load the config first. This is needed because some of the module
 	// types' definitions contain a struct-per-feature, and features are
 	// specified in the config.
-	jsonPath := getPathInBuildDir(configJSONFile)
 	config := &bobConfig{}
-	err := config.Properties.LoadConfig(jsonPath)
+	err := config.Properties.LoadConfig(configJSONFile)
 	if err != nil {
 		panic(err)
 	}
@@ -93,7 +91,7 @@ func Main() {
 	builder_android_make := config.Properties.GetBool("builder_android_make")
 
 	// Depend on the config file
-	pctx.AddNinjaFileDeps(jsonPath, getPathInBuildDir(".env.hash"))
+	pctx.AddNinjaFileDeps(configJSONFile, getPathInBuildDir(".env.hash"))
 
 	var ctx = blueprint.NewContext()
 

--- a/example/bootstrap_androidbp.bash
+++ b/example/bootstrap_androidbp.bash
@@ -40,6 +40,7 @@ Usage:
   profiles and explicit options (like DEBUG=y)
 
 Options
+  -c, --configdir   Set configuration directory
   -m, --menuconfig  Open configuration editor
   -h, --help        Help text
 
@@ -50,13 +51,18 @@ EOF
 }
 
 MENU=0
-PARAMS=$(getopt -o hm -l help,menuconfig --name $(basename "$0") -- "$@")
+PARAMS=$(getopt -o c:hm -l configdir:,help,menuconfig --name $(basename "$0") -- "$@")
 
 eval set -- "$PARAMS"
 unset PARAMS
 
 while true ; do
     case $1 in
+        -c | --configdir)
+            shift
+            CONFIG_DIR="$1"
+            shift
+            ;;
         -m | --menuconfig)
             MENU=1
             shift
@@ -85,6 +91,7 @@ cd "${ANDROID_BUILD_TOP}"
 ### Variables required for Bob and Android.mk bootstrap ###
 BPBUILD_DIR="${OUT}/gen/STATIC_LIBRARIES/bobbp_${PROJ_NAME}_intermediates"
 export BUILDDIR="${BPBUILD_DIR}"
+export CONFIGDIR="${CONFIG_DIR}"
 export CONFIGNAME="bob.config"
 export SRCDIR="${PROJ_DIR}"
 export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"

--- a/example/bootstrap_androidmk.bash
+++ b/example/bootstrap_androidmk.bash
@@ -40,6 +40,7 @@ Usage:
   profiles and explicit options (like DEBUG=y)
 
 Options
+  -c, --configdir  Set configuration directory
   -m, --menuconfig  Open configuration editor
   -h, --help        Help text
 
@@ -50,13 +51,18 @@ EOF
 }
 
 MENU=0
-PARAMS=$(getopt -o hm -l help,menuconfig --name $(basename "$0") -- "$@")
+PARAMS=$(getopt -o c:hm -l configdir:,help,menuconfig --name $(basename "$0") -- "$@")
 
 eval set -- "$PARAMS"
 unset PARAMS
 
 while true ; do
     case $1 in
+        -c | --configdir)
+            shift
+            CONFIG_DIR="$1"
+            shift
+            ;;
         -m | --menuconfig)
             MENU=1
             shift
@@ -88,6 +94,7 @@ cd "${ANDROID_BUILD_TOP}"
 # in Android.mk.blueprint.
 ANDROIDMK_DIR="${OUT}/gen/STATIC_LIBRARIES/${PROJ_NAME}_intermediates"
 export BUILDDIR="${ANDROIDMK_DIR}"
+export CONFIGDIR="${CONFIG_DIR}"
 export CONFIGNAME="bob.config"
 export SRCDIR="${PROJ_DIR}"
 export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"

--- a/tests/bootstrap_androidbp
+++ b/tests/bootstrap_androidbp
@@ -42,6 +42,7 @@ Usage:
   profiles and explicit options (like DEBUG=y)
 
 Options
+  -c, --configdir   Set configuration directory
   -m, --menuconfig  Open configuration editor
   -h, --help        Help text
 
@@ -52,13 +53,18 @@ EOF
 }
 
 MENU=0
-PARAMS=$(getopt -o hm -l help,menuconfig --name $(basename "$0") -- "$@")
+PARAMS=$(getopt -o c:hm -l configdir:,help,menuconfig --name $(basename "$0") -- "$@")
 
 eval set -- "$PARAMS"
 unset PARAMS
 
 while true ; do
     case $1 in
+        -c | --configdir)
+            shift
+            CONFIG_DIR="$1"
+            shift
+            ;;
         -m | --menuconfig)
             MENU=1
             shift
@@ -95,6 +101,7 @@ cd "${ANDROID_BUILD_TOP}"
 
 BPBUILD_DIR="${OUT}/gen/STATIC_LIBRARIES/bobbp_${PROJ_NAME}_intermediates"
 export BUILDDIR="${BPBUILD_DIR}"
+export CONFIGDIR="${CONFIG_DIR}"
 export CONFIGNAME="bob.config"
 export SRCDIR="${PROJ_DIR}"
 export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"

--- a/tests/bootstrap_androidmk
+++ b/tests/bootstrap_androidmk
@@ -42,6 +42,7 @@ Usage:
   profiles and explicit options (like DEBUG=y)
 
 Options
+  -c, --configdir   Set configuration directory
   -m, --menuconfig  Open configuration editor
   -h, --help        Help text
 
@@ -52,13 +53,18 @@ EOF
 }
 
 MENU=0
-PARAMS=$(getopt -o hm -l help,menuconfig --name $(basename "$0") -- "$@")
+PARAMS=$(getopt -o c:hm -l configdir:,help,menuconfig --name $(basename "$0") -- "$@")
 
 eval set -- "$PARAMS"
 unset PARAMS
 
 while true ; do
     case $1 in
+        -c | --configdir)
+            shift
+            CONFIG_DIR="$1"
+            shift
+            ;;
         -m | --menuconfig)
             MENU=1
             shift
@@ -97,6 +103,7 @@ cd "${ANDROID_BUILD_TOP}"
 # in Android.mk.blueprint.
 ANDROIDMK_DIR="${OUT}/gen/STATIC_LIBRARIES/${PROJ_NAME}_intermediates"
 export BUILDDIR="${ANDROIDMK_DIR}"
+export CONFIGDIR="${CONFIG_DIR}"
 export CONFIGNAME="bob.config"
 export SRCDIR="${PROJ_DIR}"
 export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"


### PR DESCRIPTION
This commit implements the feature to save configuration files in its own independent directory, which can be in the source tree.
By default, the configuration directory points to the build directory. Hence, we cannot assume anymore that these configuration files are located in the build directory.
