### PR TITLE
'host_bin's shared libraries as implicit dependencies for generator modules

### DIFF
--- a/core/androidbp_generated.go
+++ b/core/androidbp_generated.go
@@ -89,7 +89,7 @@ func populateCommonProps(gc *generateCommon, mctx blueprint.ModuleContext, m bpw
 		m.AddString("rsp_content", *gc.Properties.Rsp_content)
 	}
 	if gc.Properties.Host_bin != nil {
-		m.AddString("host_bin", ccModuleName(mctx, gc.getHostBinModule(mctx).Name()))
+		m.AddString("host_bin", ccModuleName(mctx, gc.hostBinName(mctx)))
 	}
 	m.AddBool("depfile", proptools.Bool(gc.Properties.Depfile))
 

--- a/tests/bplist
+++ b/tests/bplist
@@ -34,6 +34,7 @@
 ./resources/build.bp
 ./rsp/build.bp
 ./shared_libs/build.bp
+./shared_libs_toc/build.bp
 ./source_encapsulation/build.bp
 ./static_libs/build.bp
 ./templates/build.bp

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -85,6 +85,7 @@ bob_alias {
         "bob_test_reexport_libs",
         "bob_test_resources",
         "bob_test_shared_libs",
+        "bob_test_shared_libs_toc",
         "bob_test_simple_binary",
         "bob_test_source_encapsulation",
         "bob_test_static_libs",

--- a/tests/build_tests.sh
+++ b/tests/build_tests.sh
@@ -280,6 +280,12 @@ if [ "$OS" != "OSX" ] ; then
     SRC=tests/kernel_module/kdir/include/kernel_header.h
     UPDATE=(${build_dir}/target/kernel_modules/test_module1/test_module1.ko)
     check_dep_updated "kernel headers" "${build_dir}" "${SRC}" "${UPDATE[@]}"
+
+    # 'host_bin's shared libs dependency
+    SRC=tests/shared_libs_toc/srcs/lib.c
+    UPDATE=(${build_dir}/gen/gen_output/input_one.gen
+            ${build_dir}/gen/gen_output/input_two.gen)
+    check_dep_updated "host_bin toc linking" "${build_dir}" "${SRC}" "${UPDATE[@]}"
 fi
 
 # Clean up

--- a/tests/shared_libs_toc/build.bp
+++ b/tests/shared_libs_toc/build.bp
@@ -1,0 +1,40 @@
+bob_shared_library {
+    name: "libsharedtest",
+    srcs: ["srcs/lib.c"],
+    cflags: ["-fPIC"],
+    host_supported: true,
+    target_supported: true,
+}
+
+bob_binary {
+    name: "utility",
+    srcs: ["srcs/main.c"],
+    shared_libs: [
+        "libsharedtest",
+    ],
+    host_supported: true,
+    target_supported: true,
+}
+
+bob_transform_source {
+    name: "gen_output",
+    srcs: [
+        "input/input_one.in",
+        "input/input_two.in",
+    ],
+    out: {
+        match: ".*/([^/]+)\\.(in)",
+        replace: ["$1.gen"],
+    },
+    host_bin: "utility",
+    cmd: "${tool} -u ${host_bin} -i ${in} -o ${out}",
+    tool: "transform.py",
+    target: "host",
+}
+
+bob_alias {
+    name: "bob_test_shared_libs_toc",
+    srcs: [
+        "gen_output",
+    ],
+}

--- a/tests/shared_libs_toc/input/input_one.in
+++ b/tests/shared_libs_toc/input/input_one.in
@@ -1,0 +1,1 @@
+Test input one

--- a/tests/shared_libs_toc/input/input_two.in
+++ b/tests/shared_libs_toc/input/input_two.in
@@ -1,0 +1,1 @@
+Test input two

--- a/tests/shared_libs_toc/srcs/lib.c
+++ b/tests/shared_libs_toc/srcs/lib.c
@@ -1,0 +1,15 @@
+/*
+ * Simple function to return defined int value
+ */
+int getValue(void)
+{
+    return 12345;
+}
+
+/*
+ * Simple function to return defined output hash
+ */
+const char* output_hash(void)
+{
+    return "6f720a588e1159f839a5b48a1f5f36b4eb57e072896e7bdd57c97fa43a9f0e98";
+}

--- a/tests/shared_libs_toc/srcs/main.c
+++ b/tests/shared_libs_toc/srcs/main.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+const char* output_hash(void);
+int getValue(void);
+
+int main(int argc, char **argv) {
+
+    printf("%s%d\n", output_hash(), getValue());
+
+    return 0;
+}

--- a/tests/shared_libs_toc/transform.py
+++ b/tests/shared_libs_toc/transform.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+# This confidential and proprietary software may be used only as
+# authorised by a licensing agreement from ARM Limited
+# (C) COPYRIGHT 2020 ARM Limited
+# ALL RIGHTS RESERVED
+# The entire notice above must be reproduced on all authorised
+# copies and copies may only be made to the extent permitted
+# by a licensing agreement from ARM Limited.
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def generate_out_file(utility):
+    return subprocess.check_output(utility).decode("utf-8")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--input', required=True,
+                        type=argparse.FileType('rt'), help="Input file")
+    parser.add_argument('-o', '--out', required=True,
+                        type=argparse.FileType('wt'), help="Output file name to be generated")
+    parser.add_argument('-u', '--utility', required=True,
+                        help="Binary utility to produce output")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    args.out.write(generate_out_file(args.utility))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
After introduced shared library .toc linking functionality, binary
for source generators ('host_bin' property) is not relinked if just
the shared libraries are updated leaving APIs unchanged (.toc unchanged).
Thus shared libraries of used binaries must be added as implicit
dependencies of the generator modules.

Add test case which covers this case.

Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>
Change-Id: Ic5268a56610dc46d806273bb1855a0f6fc6f8412