### PR TITLE
Install virtualenv from APT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ addons:
       - python
       - python3
       - python3-pip
+      - python3-setuptools
+      - python3-virtualenv
       - rsync
   homebrew:
     packages:
@@ -32,7 +34,7 @@ before_install:
 install:
   - .travis/install-ninja.sh
   - export PATH=$PATH:$TRAVIS_WORK_DIR/ninjabin
-  - python3 -m pip install --user setuptools virtualenv importlib-resources==3.2.1
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then python3 -m pip install --user setuptools virtualenv; fi
   - python3 -m virtualenv -p python${PYTHON_SUFFIX} $TRAVIS_WORK_DIR/python_env
   - source $TRAVIS_WORK_DIR/python_env/bin/activate
   - pip install -r .travis/pip_requirements.txt


### PR DESCRIPTION
Ensure python3-virtualenv is compatible with the system Python version
by getting both from APT. Other packages can then be installed with Pip
inside the virtualenv, which will insulate us from the effects of
different Python library versions, but the virtualenv creation itself
needs to be done with the system Python.

Change-Id: I545efb598a0da6760a164f7be47d487a5a3c05c2
Signed-off-by: Chris Diamand <chris.diamand@arm.com>