### PR TITLE
Remove virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
   - .travis/install-ninja.sh
   - export PATH=$PATH:$TRAVIS_WORK_DIR/ninjabin
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then python3 -m pip install --user setuptools virtualenv; fi
+  - rm -Rf $TRAVIS_WORK_DIR/python_env
   - python3 -m virtualenv -p python${PYTHON_SUFFIX} $TRAVIS_WORK_DIR/python_env
   - source $TRAVIS_WORK_DIR/python_env/bin/activate
   - pip install -r .travis/pip_requirements.txt


### PR DESCRIPTION
Virtualenv creation is cheap, and virtualenv itself has an issue where
it will not overwrite existing Python instances in a virtualenv's `bin`
directory. This causes env activation to fail, breaking our tests.

In theory we could just clear Travis' caches, but this doesn't seem to
be having any effect. So instead, work around this by removing the
virtualenv directory first.

Change-Id: I8cff58b75c7b2d7637bd002f7f5a6ef7af405ff8
Signed-off-by: Chris Diamand <chris.diamand@arm.com>