### PR TITLE
Filter -march and -mtune from Android 'cflags' and 'ldflags'

### DIFF
--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -228,7 +228,7 @@ func addCcLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContex
 	m.AddStringList("export_shared_lib_headers", reexportShared)
 	m.AddStringList("export_static_lib_headers", reexportStatic)
 	m.AddStringList("export_header_lib_headers", reexportHeaders)
-	m.AddStringList("ldflags", l.Properties.Ldflags)
+	m.AddStringList("ldflags", utils.Filter(ccflags.AndroidLinkFlags, l.Properties.Ldflags))
 
 	_, installRel, ok := getSoongInstallPath(l.getInstallableProps())
 	if ok && installRel != "" {


### PR DESCRIPTION
Fix removal of -mXXX flags from 'ldflags' on Android.bp backend.

Change-Id: I8e10973b5887753a6913442463fa555c7ccb5063
Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>