### PR TITLE
travis: Don't cache Python venv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ git:
 cache:
   directories:
     - ../../ninjabin
-    - ../../python_env
 
 addons:
   apt:
@@ -35,7 +34,6 @@ install:
   - .travis/install-ninja.sh
   - export PATH=$PATH:$TRAVIS_WORK_DIR/ninjabin
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then python3 -m pip install --user setuptools virtualenv; fi
-  - rm -Rf $TRAVIS_WORK_DIR/python_env
   - python3 -m virtualenv -p python${PYTHON_SUFFIX} $TRAVIS_WORK_DIR/python_env
   - source $TRAVIS_WORK_DIR/python_env/bin/activate
   - pip install -r .travis/pip_requirements.txt


### PR DESCRIPTION
Remove the `rm` workaround for the Python environment, and instead,
remove the directory from the list of places we ask Travis to cache.

Change-Id: I7aee9afc972347fdd680b9bfda3a3ac08d2035c2
Signed-off-by: Chris Diamand <chris.diamand@arm.com>