### PR TITLE
Fix bob_kernel_module add_to_alias

### DIFF
--- a/core/generated.go
+++ b/core/generated.go
@@ -154,13 +154,18 @@ type generateCommon struct {
 	}
 }
 
-// generateCommon support {{match_srcs}} on some properties
+// generateCommon supports:
+// * feature-specific properties
+// * module enabling/disabling
+// * module splitting for targets
+// * use of {{match_srcs}} on some properties
+// * properties that require escaping
+// * sharing properties from defaults via `flag_defaults` property
+var _ featurable = (*generateCommon)(nil)
+var _ enableable = (*generateCommon)(nil)
+var _ splittable = (*generateCommon)(nil)
 var _ matchSourceInterface = (*generateCommon)(nil)
-
-// generateCommon have properties that require escaping
 var _ propertyEscapeInterface = (*generateCommon)(nil)
-
-// generateCommon uses other defaults by `flag_defaults` property
 var _ defaultable = (*generateCommon)(nil)
 
 // Modules implementing hostBin are able to supply a host binary that can be executed
@@ -358,6 +363,9 @@ type generateSource struct {
 		GenerateSourceProps
 	}
 }
+
+// generateSource supports installation
+var _ installable = (*generateSource)(nil)
 
 func (m *generateSource) GenerateBuildActions(ctx blueprint.ModuleContext) {
 	if isEnabled(m) {
@@ -717,6 +725,9 @@ type transformSource struct {
 		TransformSourceProps
 	}
 }
+
+// transformSource supports installation
+var _ installable = (*transformSource)(nil)
 
 func generateSourceFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	module := &generateSource{}

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -67,6 +67,18 @@ type kernelModule struct {
 	}
 }
 
+// kernelModule supports the following functionality:
+// * sharing properties via defaults
+// * feature-specific properties
+// * installation
+// * module enabling/disabling
+// * appending to aliases
+var _ defaultable = (*kernelModule)(nil)
+var _ featurable = (*kernelModule)(nil)
+var _ installable = (*kernelModule)(nil)
+var _ enableable = (*kernelModule)(nil)
+var _ aliasable = (*kernelModule)(nil)
+
 func (m *kernelModule) defaults() []string {
 	return m.Properties.Defaults
 }
@@ -101,6 +113,10 @@ func (m *kernelModule) shortName() string {
 
 func (m *kernelModule) getEnableableProps() *EnableableProps {
 	return &m.Properties.EnableableProps
+}
+
+func (m *kernelModule) getAliasList() []string {
+	return m.Properties.getAliasList()
 }
 
 func (m *kernelModule) filesToInstall(ctx blueprint.BaseModuleContext) []string {

--- a/core/library.go
+++ b/core/library.go
@@ -292,13 +292,25 @@ type library struct {
 	}
 }
 
+// library supports the following functionality:
+// * sharing properties via defaults
+// * feature-specific properties
+// * target-specific properties
+// * installation
+// * module enabling/disabling
+// * exporting properties to other modules
+// * use of {{match_srcs}} on some properties
+// * properties that require escaping
+// * appending to aliases
+var _ defaultable = (*library)(nil)
+var _ featurable = (*library)(nil)
+var _ targetSpecificLibrary = (*library)(nil)
+var _ installable = (*library)(nil)
+var _ enableable = (*library)(nil)
 var _ propertyExporter = (*library)(nil)
-
-// library support {{match_srcs}} on some properties
 var _ matchSourceInterface = (*library)(nil)
-
-// library have properties that require escaping
 var _ propertyEscapeInterface = (*library)(nil)
+var _ aliasable = (*library)(nil)
 
 func (l *library) defaults() []string {
 	return l.Properties.Defaults
@@ -666,8 +678,13 @@ type sharedLibrary struct {
 	fileNameExtension string
 }
 
+// sharedLibrary supports:
+// * producing output using the linker
+// * producing a shared library
+// * stripping symbols from output
 var _ linkableModule = (*sharedLibrary)(nil)
 var _ sharedLibProducer = (*sharedLibrary)(nil)
+var _ stripable = (*sharedLibrary)(nil)
 
 func (m *sharedLibrary) getLinkName() string {
 	return m.outputName() + m.fileNameExtension
@@ -739,7 +756,11 @@ type binary struct {
 	library
 }
 
+// binary supports:
+// * producing output using the linker
+// * stripping symbols from output
 var _ linkableModule = (*binary)(nil)
+var _ stripable = (*binary)(nil)
 
 func (l *binary) strip() bool {
 	return l.Properties.Strip != nil && *l.Properties.Strip


### PR DESCRIPTION
Kernel modules should be able to extend existing aliases by using the
add_to_alias property. When we moved the common properties out
BuildProps, we missed implementing getAliasList on kernelModule.

While here, add interface checks to ensure that if interfaces change,
the appropriate modules will get updated.

Change-Id: Ia41cc3b32fdb9423c86199e3f02ae35e6c81029c
Signed-off-by: David Kilroy <david.kilroy@arm.com>