### PR TITLE
Rename module_{srcs,deps} to generated_{sources,deps}

### DIFF
--- a/core/androidbp_generated.go
+++ b/core/androidbp_generated.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Arm Limited.
+ * Copyright 2020-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -93,8 +93,8 @@ func populateCommonProps(gc *generateCommon, mctx blueprint.ModuleContext, m bpw
 	}
 	m.AddBool("depfile", proptools.Bool(gc.Properties.Depfile))
 
-	m.AddStringList("module_deps", getShortNamesForDirectDepsWithTags(mctx, generatedDepTag))
-	m.AddStringList("module_srcs", getShortNamesForDirectDepsWithTags(mctx, generatedSourceTag))
+	m.AddStringList("generated_deps", getShortNamesForDirectDepsWithTags(mctx, generatedDepTag))
+	m.AddStringList("generated_sources", getShortNamesForDirectDepsWithTags(mctx, generatedSourceTag))
 	m.AddStringList("encapsulates", gc.Properties.Encapsulates)
 	m.AddStringList("export_gen_include_dirs", gc.Properties.Export_gen_include_dirs)
 	m.AddStringList("cflags", gc.Properties.FlagArgsBuild.Cflags)

--- a/core/androidbp_kernel_module.go
+++ b/core/androidbp_kernel_module.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Arm Limited.
+ * Copyright 2020-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,9 +59,9 @@ func (g *androidBpGenerator) kernelModuleActions(l *kernelModule, mctx blueprint
 	kmod_build := getBackendPathInBobScriptsDir(g, "kmod_build.py")
 
 	sources_param := "${in}"
-	var module_deps []string
+	var generated_deps []string
 	for _, mod := range l.extraSymbolsModules(mctx) {
-		module_deps = append(module_deps, mod.Name())
+		generated_deps = append(generated_deps, mod.Name())
 		// reference all dependent modules outputs, needed for related symvers files
 		sources_param += " ${" + mod.Name() + "_dir}/Module.symvers"
 	}
@@ -73,7 +73,7 @@ func (g *androidBpGenerator) kernelModuleActions(l *kernelModule, mctx blueprint
 
 	addProvenanceProps(bpmod, l.Properties.AndroidProps)
 	bpmod.AddStringList("srcs", l.Properties.getSources(mctx))
-	bpmod.AddStringList("module_deps", module_deps)
+	bpmod.AddStringList("generated_deps", generated_deps)
 	bpmod.AddStringList("out", l.outs)
 	bpmod.AddStringList("implicit_outs", []string{"Module.symvers"})
 	bpmod.AddString("tool", kmod_build)

--- a/core/generated.go
+++ b/core/generated.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -108,10 +108,10 @@ type GenerateProps struct {
 
 	// A list of other modules that this generator depends on. The dependencies can be used in the command through
 	// $name_of_dependency_dir .
-	Module_deps []string
+	Generated_deps []string
 
 	// A list of other modules that this generator depends on. The dependencies will be add to the list of srcs
-	Module_srcs []string
+	Generated_sources []string
 
 	// A list of args that will be spaceseparated and add to the cmd
 	Args []string
@@ -821,9 +821,9 @@ func generatedDependerMutator(mctx blueprint.BottomUpMutatorContext) {
 		// Generated sources can use the outputs of another generated
 		// source or library as a source file or dependency.
 		parseAndAddVariationDeps(mctx, generatedDepTag,
-			gsc.Properties.Module_deps...)
+			gsc.Properties.Generated_deps...)
 		parseAndAddVariationDeps(mctx, generatedSourceTag,
-			gsc.Properties.Module_srcs...)
+			gsc.Properties.Generated_sources...)
 		parseAndAddVariationDeps(mctx, encapsulatesTag,
 			gsc.Properties.Encapsulates...)
 	}

--- a/docs/module_types/bob_generate_library.md
+++ b/docs/module_types/bob_generate_library.md
@@ -52,8 +52,8 @@ bob_generate_shared_library {
     host_bin: "name_of_host_binary",
     tags: ["optional"],
 
-    module_deps: ["bob_generate_source.name"],
-    module_srcs: ["bob_generate_source.name"],
+    generated_deps: ["bob_generate_source.name"],
+    generated_sources: ["bob_generate_source.name"],
 
     args: ["-i graphic/ui.h"],
 

--- a/docs/module_types/bob_generate_source.md
+++ b/docs/module_types/bob_generate_source.md
@@ -39,8 +39,8 @@ bob_generate_source {
     host_bin: "clang-tblgen",
     tags: ["optional"],
 
-    module_deps: ["bob_generate_source.name"],
-    module_srcs: ["bob_generate_source.name"],
+    generated_deps: ["bob_generate_source.name"],
+    generated_sources: ["bob_generate_source.name"],
 
     args: ["-i graphic/ui.h"],
 

--- a/docs/module_types/bob_transform_source.md
+++ b/docs/module_types/bob_transform_source.md
@@ -46,8 +46,8 @@ bob_transform_source {
     host_bin: "clang-tblgen",
     tags: ["optional"],
 
-    module_deps: ["bob_generate_source.name"],
-    module_srcs: ["bob_generate_source.name"],
+    generated_deps: ["bob_generate_source.name"],
+    generated_sources: ["bob_generate_source.name"],
 
     args: ["-i graphic/ui.h"],
 

--- a/docs/module_types/common_generate_module_properties.md
+++ b/docs/module_types/common_generate_module_properties.md
@@ -26,8 +26,8 @@ available substitutions are:
 - `${host_bin}` - the path to the binary specified by `host_bin`
 - `${module_dir}` - the path this module's source directory
 - `${gen_dir}` - the path to the output directory for this module
-- `${(name)_dir}` - the output directory for the `module_deps` dependency with `name`
-- `${(name)_out}` - the outputs of the `module_deps` dependency with `name`
+- `${(name)_dir}` - the output directory for the `generated_deps` dependency with `name`
+- `${(name)_out}` - the outputs of the `generated_deps` dependency with `name`
 - `${src_dir}` - the path to the project source directory - this will be different
   than the build source directory for Android.
 
@@ -54,13 +54,13 @@ module's command. Specifying this in `host_bin` ensures that the host tool will
 be built before the `bob_generated`.
 
 ----
-### **bob_generated.module_deps** (optional)
+### **bob_generated.generated_deps** (optional)
 A list of other modules that this generator depends on. The dependencies can be
 used in the command through `${(name_of_dependency)_dir}` (that is, the variable's
 name is the name of the dependency, with the `_dir` suffix).
 
 ----
-### **bob_generated.module_srcs** (optional)
+### **bob_generated.generated_sources** (optional)
 A list of other modules that this generator depends on.
 The dependencies will be added to the list of srcs.
 

--- a/docs/user_guide/code_generation.md
+++ b/docs/user_guide/code_generation.md
@@ -305,17 +305,17 @@ The output of a generator can be used by another generator. There are
 a few different ways to specify this depending on what needs to be used
 from the output.
 
-Use `module_srcs` when every output of a generator should be used as
+Use `generated_sources` when every output of a generator should be used as
 an input in the next generator.
 
-Use `module_deps` when you only want to use certain outputs from the
+Use `generated_deps` when you only want to use certain outputs from the
 earlier generator. The command(s) have access to the output directory
 of the earlier generator.
 
 Use `encapsulates` to make one generator wrap all the output of a set
 of other generators.
 
-The following example uses `module_srcs` to pass a generated source
+The following example uses `generated_sources` to pass a generated source
 file through a `bob_transform_source` as well.
 
 ```
@@ -336,7 +336,7 @@ bob_transform_source {
         "inc/a.hpp.source",
         "inc/b.hpp.source",
     ],
-    module_srcs: ["wayland_custom_protocol_code"],
+    generated_sources: ["wayland_custom_protocol_code"],
     outs: {
         match: "(.*)\.source",
         replace: "$1",
@@ -354,8 +354,8 @@ bob_static_library {
 }
 ```
 
-The next example shows how `module_deps` might be used. Note that for
-each module named in `module_deps` there are variables to get the
+The next example shows how `generated_deps` might be used. Note that for
+each module named in `generated_deps` there are variables to get the
 intermediate directory as well as all the outputs for that module. The
 variables are `${mod_dir}` and `${mod_outs}` where `mod` is the module
 name.
@@ -381,7 +381,7 @@ bob_generate_source {
 
 bob_generate_source {
     name: "x_code",
-    module_deps: ["templates"],
+    generated_deps: ["templates"],
     outs: [
         "src/x.cpp",
         "inc/x.h",
@@ -393,7 +393,7 @@ bob_generate_source {
 
 bob_generate_source {
     name: "y_code",
-    module_deps: ["templates"],
+    generated_deps: ["templates"],
     outs: [
         "src/y.cpp",
         "inc/y.h",
@@ -560,7 +560,7 @@ files on the command line:
 bob_generate_source {
     name: "combine_multiple_files",
     srcs: ["file1.in", ..., "file999.in"],
-    module_srcs: ["module_generating_many_files"],
+    generated_sources: ["module_generating_many_files"],
     out: ["combined.c"],
     tool: "combine.sh",
     rsp_content: "${in}",

--- a/plugins/genrulebob/genrule.go
+++ b/plugins/genrulebob/genrule.go
@@ -1,7 +1,7 @@
 // +build soong
 
 /*
- * Copyright 2020 Arm Limited.
+ * Copyright 2020-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,8 +40,8 @@ type commonProps struct {
 	Host_bin                string
 	Tool                    string
 	Depfile                 bool
-	Module_deps             []string
-	Module_srcs             []string
+	Generated_deps          []string
+	Generated_sources       []string
 	Encapsulates            []string
 	Cflags                  []string
 	Conlyflags              []string
@@ -275,15 +275,15 @@ func (m *genrulebobCommon) DepsMutator(mctx android.BottomUpMutatorContext) {
 			hostToolBinTag, m.Properties.Host_bin)
 	}
 
-	// `module_deps` and `module_srcs` can refer not only to source
+	// `generated_deps` and `generated_sources` can refer not only to source
 	// generation modules, but to binaries and libraries. In this case we
 	// need to handle multilib builds, where a 'target' library could be
 	// split into 32 and 64-bit variants. Use `AddFarVariationDependencies`
 	// here, because this will automatically choose the first available
 	// variant, rather than the other dependency-adding functions, which
 	// will error when multiple variants are present.
-	mctx.AddFarVariationDependencies(nil, generatedDepTag, m.Properties.Module_deps...)
-	mctx.AddFarVariationDependencies(nil, generatedSourceTag, m.Properties.Module_srcs...)
+	mctx.AddFarVariationDependencies(nil, generatedDepTag, m.Properties.Generated_deps...)
+	mctx.AddFarVariationDependencies(nil, generatedSourceTag, m.Properties.Generated_sources...)
 	// We can only encapsulate other generated/transformed source modules,
 	// so use the normal `AddDependency` function for these.
 	mctx.AddDependency(mctx.Module(), encapsulatesTag, m.Properties.Encapsulates...)

--- a/tests/command_vars/build.bp
+++ b/tests/command_vars/build.bp
@@ -11,7 +11,7 @@ bob_generate_source {
 
 bob_generate_source {
     name: "bob_test_module_dep_dir_and_outs",
-    module_deps: ["bob_test_generate_source_single"],
+    generated_deps: ["bob_test_generate_source_single"],
     out: [
         "dir_and_outs.c",
         "dir_and_outs.h",

--- a/tests/encapsulates/build.bp
+++ b/tests/encapsulates/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Arm Limited.
+ * Copyright 2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@
  *                encapsulates_1_2_3
  *               /        |         \
  *              /   encapsulated2    encapsulated3
- * encapsulated1          |                 \ (module_deps)
+ * encapsulated1          |                 \ (generated_deps)
  *              encapsulated2_actual     not_encapsulated
  */
 
@@ -70,8 +70,8 @@ bob_generate_source {
     name: "encapsulated3",
     out: ["3.h"],
     export_gen_include_dirs: ["."],
-    module_srcs: ["not_encapsulated"],
-    module_deps: ["not_encapsulated"],
+    generated_sources: ["not_encapsulated"],
+    generated_deps: ["not_encapsulated"],
     cmd: "echo '#define D3 3' > ${out}",
 }
 
@@ -88,7 +88,7 @@ bob_generate_source {
     // While we're here, ensure that ${outs} *doesn't* include the encapsulated
     // outputs - only downstream modules should include those. Also - we can't
     // test this, but this command should *not* have access to e.g.
-    // ${encapsulated1_out} - that should only be provided by module_deps.
+    // ${encapsulated1_out} - that should only be provided by generated_deps.
     tool: "check_basenames.py",
     cmd: "${tool} -o ${out} --expected unused.txt --actual ${out}",
 }
@@ -101,19 +101,19 @@ bob_binary {
 
 // Check that ${modname_out} includes ${modname}'s encapsulated oututs
 bob_generate_source {
-    name: "check_outputs_via_module_deps",
+    name: "check_outputs_via_generated_deps",
     out: ["unused.txt"],
-    module_deps: ["encapsulates_1_2_3"],
+    generated_deps: ["encapsulates_1_2_3"],
     tool: "check_basenames.py",
     cmd: "${tool} -o ${out} --expected encapsulates_1_2_3/unused.txt encapsulated2/unused2.txt subdir/1.h 2.h 3.h --actual ${encapsulates_1_2_3_out}",
     build_by_default: true,
 }
 
-// Check that module_srcs: [${modname}] includes ${modname}'s encapsulated oututs
+// Check that generated_sources: [${modname}] includes ${modname}'s encapsulated oututs
 bob_generate_source {
-    name: "check_outputs_via_module_srcs",
+    name: "check_outputs_via_generated_sources",
     out: ["unused.txt"],
-    module_srcs: ["encapsulates_1_2_3"],
+    generated_sources: ["encapsulates_1_2_3"],
     tool: "check_basenames.py",
     cmd: "${tool} -o ${out} --expected encapsulates_1_2_3/unused.txt encapsulated2/unused2.txt subdir/1.h 2.h 3.h --actual ${in}",
     build_by_default: true,
@@ -123,7 +123,7 @@ bob_alias {
     name: "bob_test_encapsulates",
     srcs: [
         "check_includes",
-        "check_outputs_via_module_deps",
-        "check_outputs_via_module_srcs",
+        "check_outputs_via_generated_deps",
+        "check_outputs_via_generated_sources",
     ],
 }

--- a/tests/generate_libs/build.bp
+++ b/tests/generate_libs/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -177,7 +177,7 @@ bob_binary {
 bob_generate_source {
     name: "check_renamed_gen_library",
     out: ["success.txt"],
-    module_srcs: ["binary_linked_to_gen_shared_rename"],
+    generated_sources: ["binary_linked_to_gen_shared_rename"],
     tool: "check_library_link.py",
     cmd: "${tool} --links-to libblah_shared2 ${args} ${in} && touch ${out}",
     osx: {

--- a/tests/generate_source/build.bp
+++ b/tests/generate_source/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,7 +83,7 @@ bob_generate_source {
 
 bob_generate_source {
     name: "generate_source_single_level1",
-    module_srcs: ["generate_source_single"],
+    generated_sources: ["generate_source_single"],
 
     out: ["level_1_single.cpp"],
 
@@ -93,7 +93,7 @@ bob_generate_source {
 
 bob_generate_source {
     name: "generate_source_single_level2",
-    module_srcs: ["generate_source_single_level1"],
+    generated_sources: ["generate_source_single_level1"],
 
     out: ["level_2_single.cpp"],
 
@@ -103,7 +103,7 @@ bob_generate_source {
 
 bob_generate_source {
     name: "generate_source_single_level3",
-    module_srcs: ["generate_source_single_level2"],
+    generated_sources: ["generate_source_single_level2"],
 
     out: ["level_3_single.cpp"],
 
@@ -113,7 +113,7 @@ bob_generate_source {
 
 bob_generate_source {
     name: "generate_source_single_nested_with_extra",
-    module_srcs: ["generate_source_single_level2"],
+    generated_sources: ["generate_source_single_level2"],
 
     srcs: [
         "before_generate.in",
@@ -132,7 +132,7 @@ bob_generate_source {
 
 bob_generate_source {
     name: "generate_source_single_dependend",
-    module_deps: ["generate_source_single"],
+    generated_deps: ["generate_source_single"],
 
     srcs: [
         "before_generate.in",
@@ -145,7 +145,7 @@ bob_generate_source {
 
 bob_generate_source {
     name: "generate_source_single_dependend_nested",
-    module_srcs: ["generate_source_single_dependend"],
+    generated_sources: ["generate_source_single_dependend"],
 
     srcs: [
         "before_generate.in",
@@ -277,7 +277,7 @@ bob_binary {
 bob_generate_source {
     name: "use_target_specific_library",
     out: ["libout.a"],
-    module_deps: ["host_and_target_supported_binary:host"],
+    generated_deps: ["host_and_target_supported_binary:host"],
     cmd: "test $$(basename ${host_and_target_supported_binary_out}) = host_binary && cp ${host_and_target_supported_binary_out} ${out}",
     build_by_default: true,
 }

--- a/tests/output/build.bp
+++ b/tests/output/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 Arm Limited.
+ * Copyright 2019-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,7 @@ bob_binary {
 
 bob_generate_source {
     name: "verify_output",
-    module_deps: [
+    generated_deps: [
         "binary_output",
         "lib_sh_output",
         "lib_st_output",

--- a/tests/rsp/build.bp
+++ b/tests/rsp/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Arm Limited.
+ * Copyright 2020-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,7 @@ bob_transform_source {
 bob_generate_source {
     name: "merge_multiple_sources",
     srcs: ["first.in"],
-    module_srcs: ["generate_multiple_sources"],
+    generated_sources: ["generate_multiple_sources"],
     out: ["merged.c"],
     rsp_content: "${in}",
     tool: "rspcat.py",

--- a/tests/source_encapsulation/build.bp
+++ b/tests/source_encapsulation/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 Arm Limited.
+ * Copyright 2019-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -70,9 +70,9 @@ bob_binary {
 
 //////////////////////////////////////////////////////////////////////////////
 // Case B - generated headers: direct encapsulation of outputs.
-// Test checks interaction of encapsulation with 'module_deps'.
+// Test checks interaction of encapsulation with 'generated_deps'.
 //
-// Module 2 depends on module 1 due to 'module_deps' property.
+// Module 2 depends on module 1 due to 'generated_deps' property.
 // Module 3 encapsulates module 2 which can see must_have.h but
 // not must_not_have.h
 //
@@ -84,7 +84,7 @@ bob_binary {
 //                    3 (root module)
 //    (encapsulates) /
 //                  2
-//   (module_deps) /
+//   (generated_deps) /
 //                1
 //
 bob_generate_source {
@@ -99,7 +99,7 @@ bob_generate_source {
     out: ["must_have.h"],
     export_gen_include_dirs: ["."],
     cmd: "cat ${gen_srcs_one_out} > ${out}",
-    module_deps: ["gen_srcs_one"],
+    generated_deps: ["gen_srcs_one"],
 }
 
 bob_generate_source {
@@ -121,9 +121,9 @@ bob_binary {
 
 //////////////////////////////////////////////////////////////////////////////
 // Case C - generated headers: direct encapsulation of outputs.
-// Test checks interaction of encapsulation with 'module_srcs'.
+// Test checks interaction of encapsulation with 'generated_sources'.
 //
-// Module 2 depends on module 1 due to 'module_srcs' property.
+// Module 2 depends on module 1 due to 'generated_sources' property.
 // Module 3 encapsulates module 2 which can see must_have.h but
 // not must_not_have.h
 //
@@ -135,7 +135,7 @@ bob_binary {
 //                    3 (root module)
 //    (encapsulates) /
 //                  2
-//   (module_srcs) /
+//   (generated_sources) /
 //                1
 //
 bob_generate_source {
@@ -150,7 +150,7 @@ bob_generate_source {
     out: ["must_have.h"],
     export_gen_include_dirs: ["."],
     cmd: "cat ${in} > ${out}",
-    module_srcs: ["gen_srcs_three"],
+    generated_sources: ["gen_srcs_three"],
 }
 
 bob_generate_source {
@@ -206,9 +206,9 @@ bob_binary {
 //////////////////////////////////////////////////////////////////////////////
 // Case E - generated sources: direct and transitive encapsulation of outputs.
 // Test should check complex case of direct and transitive encapsulation
-// together with use of 'module_srcs' property.
+// together with use of 'generated_sources' property.
 //
-// Module 3 uses output of module 4 through 'module_srcs' relation while module
+// Module 3 uses output of module 4 through 'generated_sources' relation while module
 // 4 encapsulates 5.
 // This way module 3 should have input of: encapsulation_generated_sources4/funcs.txt
 // and encapsulation_generated_sources5/fun5.c. Also it can see:
@@ -223,7 +223,7 @@ bob_binary {
 // 5 - encapsulation_generated_sources5
 //
 //                     3
-//     (encapsulates) / \ (module_srcs)
+//     (encapsulates) / \ (generated_sources)
 //                   2   4
 //   (encapsulates) /     \ (encapsulates)
 //                 1       5
@@ -270,7 +270,7 @@ bob_generate_source {
 
 bob_generate_source {
     name: "encapsulation_generated_sources3",
-    module_srcs: ["encapsulation_generated_sources4"],
+    generated_sources: ["encapsulation_generated_sources4"],
 
     out: ["fun3.c"],
 

--- a/tests/source_encapsulation/check_includes.py
+++ b/tests/source_encapsulation/check_includes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2019-2020 Arm Limited.
+# Copyright 2019-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,7 @@
 #                    3 (root module)
 #    (encapsulates) /
 #                  2
-#   (module_deps) /
+#   (generated_deps) /
 #                1
 #
 

--- a/tests/transform_source/build.bp
+++ b/tests/transform_source/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,7 +66,7 @@ bob_transform_source {
         "f3.in",
         "f4.in",
     ],
-    module_srcs: ["generate_source_to_transform"],
+    generated_sources: ["generate_source_to_transform"],
     out: {
         match: "(.+)\\.in",
         replace: [
@@ -90,8 +90,8 @@ bob_generate_source {
 }
 
 bob_transform_source {
-    name: "transform_source_module_deps",
-    module_deps: ["generate_template_source_used_by_transform"],
+    name: "transform_source_generated_deps",
+    generated_deps: ["generate_template_source_used_by_transform"],
     srcs: [
         "f6.in",
     ],
@@ -108,14 +108,14 @@ bob_transform_source {
 }
 
 bob_generate_source {
-    name: "generate_source_module_srcs_only",
+    name: "generate_source_generated_sources_only",
     out: ["f7.in"],
     cmd: "echo '// Dummy File' > ${out}",
 }
 
 bob_transform_source {
-    name: "transform_source_module_srcs_only",
-    module_srcs: ["generate_source_module_srcs_only"],
+    name: "transform_source_generated_sources_only",
+    generated_sources: ["generate_source_generated_sources_only"],
     out: {
         match: "(.+)\\.in",
         replace: [
@@ -134,14 +134,14 @@ bob_binary {
         "transform_source_single_dir",
         "transform_source_single",
         "transform_source_multiple_in",
-        "transform_source_module_deps",
-        "transform_source_module_srcs_only",
+        "transform_source_generated_deps",
+        "transform_source_generated_sources_only",
     ],
     generated_headers: [
         "transform_source_single_dir",
         "transform_source_single",
         "transform_source_multiple_in",
-        "transform_source_module_deps",
+        "transform_source_generated_deps",
     ],
     srcs: ["main.cpp"],
 }


### PR DESCRIPTION
Library modules already use generated_sources/generated_deps to specify dependencies to a generator module.
Generator modules are using module_srcs/module_deps instead.
This commit makes the syntax consistent for library and generator modules.