### PR TITLE
Allow pkg-config binary to be specified

### DIFF
--- a/docs/user_guide/libraries_3.md
+++ b/docs/user_guide/libraries_3.md
@@ -87,6 +87,9 @@ bob_binary {
 }
 ```
 
+If you need to use a particular `pkg-config` binary, then use the config
+`PKG_CONFIG_BINARY` to specify it.
+
 ## Android libraries
 
 When a Bob project is built as part of Android, the project may need

--- a/mconfig/toolchain.Mconfig
+++ b/mconfig/toolchain.Mconfig
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 Arm Limited.
+# Copyright 2016-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,13 @@ config AS_BINARY
 	help
 	  The name of the assembly compiler used to compile
 	  hand-written assembly code.
+
+config PKG_CONFIG_BINARY
+	string "pkg-config binary"
+	default "pkg-config"
+	help
+	  The name of the pkg-config tool used to retrieve information
+	  on installed libraries.
 
 ###################################
 

--- a/scripts/host_explore.py
+++ b/scripts/host_explore.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2018-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,7 +53,7 @@ def pkg_config():
     Where no package information exists the default configuration value will be used.
     """
     if get_config_bool('PKG_CONFIG'):
-        cmd = ['pkg-config']
+        cmd = [get_config_string('PKG_CONFIG_BINARY')]
         pkg_config_flags = get_config_string('PKG_CONFIG_FLAGS')
         pkg_config_flags = pkg_config_flags.replace("%MCONFIGDIR%", get_mconfig_dir())
         cmd.extend(pkg_config_flags.split(' '))


### PR DESCRIPTION
This may be necessary if a certain pkg-config needs to be used for the
platform. For example there are Debian arch specific pkg-config
packages where the binary is aarch64-gnu-linux-pkg-config.

If necessary an absolute path can be used for the binary.

Change-Id: I73098158182323e7e2cee80e6eaa03420219f52c
Reported-by: Fei Shao <fshao@chromium.org>
Signed-off-by: David Kilroy <david.kilroy@arm.com>