### PR TITLE
Fix macOS rebootstrap issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,11 +156,9 @@ jobs:
           - go: '1.11'
             os: ubuntu-latest
             python: '2.7'
-#       Disable macos for now. 10.15 has a problem with the rebootstrap with different directory
-#        include:
-#          - go: '1.13'
-#            os: macos-latest
-#            python: '3.x'
+          - go: '1.13'
+            os: macos-latest
+            python: '3.x'
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2018-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -82,6 +82,10 @@ if [ -f "${BOOTSTRAP_GLOBFILE}" ]; then
         # BOOTSTRAP_GLOBFILE is invalid if BUILDDIR has changed
         # Invalidate it so that the bootstrap builder can be built
         cat /dev/null > "${BOOTSTRAP_GLOBFILE}"
+        # On OSX, also force a rebuild of microfactory
+        if [ "$(uname)" = "Darwin" ] ; then
+            rm -f "${BUILDDIR}/.minibootstrap/microfactory_$(uname)"
+        fi
     fi
 fi
 

--- a/tests/relative_path_tests.sh
+++ b/tests/relative_path_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2018-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,7 +86,7 @@ test_relpath "a/b2/c" "a/b"  "../../b"
 # Check the special case where the common root is `/`
 test_relpath "/usr" "/bin" "../bin"
 test_relpath "/usr/local/bin" "/bin/bash" "../../../bin/bash"
-test_relpath "/" "/usr/include/stdio.h" "usr/include/stdio.h"
+test_relpath "/" "/bin/bash" "bin/bash"
 # On merged-usr systems, `/bin` is a symlink to `/usr/bin`, so needs an extra
 # `..` for this case.
 [[ -L /bin ]] && test_relpath "/bin" "/" "../.." || test_relpath "/bin" "/" ".."


### PR DESCRIPTION
When rebootstraping an existing build directory to use a different
working directory, it appears that the microfactory built with the
previous working directory doesn't work on macOS. On detecting the
working directory change, delete the microfactory binary so that it
gets rebuilt.

Change-Id: Ifc25cde20b989ab63514667cac9340fa198323be
Signed-off-by: David Kilroy <david.kilroy@arm.com>