### PR TITLE
Add kernel config dependency to kernel modules

### DIFF
--- a/scripts/kernel_config_parser.py
+++ b/scripts/kernel_config_parser.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2018-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,9 +21,13 @@ logger = logging.getLogger(__name__)
 g_kernel_configs = dict()
 
 
+def get_config_file_path(kdir):
+    return os.path.join(kdir, '.config')
+
+
 def parse_kernel_config(kdir):
     """Parse kernel configuration from provided directory"""
-    config_file = os.path.join(kdir, '.config')
+    config_file = get_config_file_path(kdir)
     config = dict()
 
     try:

--- a/scripts/kmod_build.py
+++ b/scripts/kmod_build.py
@@ -277,6 +277,18 @@ def main():
     extra_cflags = " ".join(includes) + " " + args.extra_cflags + " " + \
                    " ".join(kbuild_cflags)
 
+    # If kconfig.h is older than kernel config, the kernel needs to be rebuilt
+    # to update this file.
+    kconfig_file = os.path.join(abs_kdir, "include", "linux", "kconfig.h")
+    kernel_config_file = kernel_config_parser.get_config_file_path(abs_kdir)
+    if os.path.exists(kconfig_file):
+        if os.path.getmtime(kconfig_file) < os.path.getmtime(kernel_config_file):
+            msg = "%s is older than %s. make modules_prepare needs to be run."
+            logger.warning(msg, kconfig_file, kernel_config_file)
+    else:
+        msg = "%s not found. make modules_prepare needs to be run"
+        logger.warning(msg, kconfig_file)
+
     deps = []
 
     # Add commonly needed search paths for copy_with_deps
@@ -302,6 +314,10 @@ def main():
     # dependencies on every part of the kernel's build system - this is just
     # enough to ensure that incremental builds of the Bob tests work OK.
     deps.append(os.path.join(abs_kdir, "Makefile"))
+
+    # Add a dependency to kernel config because we are parsing it to
+    # populate CFLAGS.
+    deps.append(kernel_config_file)
 
     copy_with_deps.write_depfile(args.depfile, args.output, deps)
 


### PR DESCRIPTION
If the kernel config is modified, the kernel build system might choose to rebuild kernel modules. This only happens if the kernel
config is explicitly added as a dependency of kernel modules.
