### PR TITLE
Fix shared_lib_toc test on Android

### DIFF
--- a/tests/shared_libs_toc/srcs/main.c
+++ b/tests/shared_libs_toc/srcs/main.c
@@ -3,7 +3,7 @@
 const char* output_hash(void);
 int getValue(void);
 
-int main(int argc, char **argv) {
+int main(void) {
 
     printf("%s%d\n", output_hash(), getValue());
 


### PR DESCRIPTION
In the shared_libs_toc test, the compiler complains about unused
arguments to main(), so just declare it with a void parameter list.

Change-Id: I5c5074c1012fec7c84d11fa1d8e5b7a0b74959b4
Signed-off-by: David Kilroy <david.kilroy@arm.com>