### PR TITLE
Set up clang toolchain per Android release

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -95,11 +95,11 @@ release and the one before that.
 
 | Version | Status |
 |---|---|
-| Nougat | Some features may no longer work |
-| Oreo | Supported |
+| Oreo | Not supported |
 | Pie | Supported |
-| Q | In progress |
-| earlier | not supported |
+| Android 10 | Supported |
+| Android 11 | Supported |
+| earlier | Not supported |
 
 Note that not all Bob features are supported on Android. This includes:
 

--- a/example/bootstrap_androidbp.bash
+++ b/example/bootstrap_androidbp.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020 Arm Limited.
+# Copyright 2020-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -103,9 +103,11 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 # Pick up some info that bob has worked out
 source "${BUILDDIR}/.bob.bootstrap"
 
+ANDROID_VERSION="$("${SCRIPT_DIR}/${BOB_DIR}/scripts/android_version.py")"
+
 if [ $MENU -ne 1 ] || [ ! -f "${BPBUILD_DIR}/${CONFIGNAME}" ] ; then
     # Have arguments or missing bob.config. Run config.
-    "${BPBUILD_DIR}/config" ANDROID=y BUILDER_ANDROID_BP=y "$@"
+    "${BPBUILD_DIR}/config" ANDROID=y BUILDER_ANDROID_BP=y ANDROID_PLATFORM_VERSION=${ANDROID_VERSION} "$@"
 fi
 
 if [ $MENU -eq 1 ] ; then

--- a/example/bootstrap_androidmk.bash
+++ b/example/bootstrap_androidmk.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2018-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -114,12 +114,14 @@ rm -f "$TMP_ANDROID_MK"
 # Pick up some info that bob has worked out
 source "${BUILDDIR}/.bob.bootstrap"
 
+ANDROID_VERSION="$("${SCRIPT_DIR}/${BOB_DIR}/scripts/android_version.py")"
+
 # Setup the buildme script to just run bob
 ln -sf "bob" "${BUILDDIR}/buildme"
 
 if [ $MENU -ne 1 ] || [ ! -f "$ANDROIDMK_DIR/$CONFIGNAME" ] ; then
     # Have arguments or missing bob.config. Run config.
-    "$ANDROIDMK_DIR/config" ANDROID=y BUILDER_ANDROID_MAKE=y "$@"
+    "$ANDROIDMK_DIR/config" ANDROID=y BUILDER_ANDROID_MAKE=y ANDROID_PLATFORM_VERSION=${ANDROID_VERSION} "$@"
 fi
 
 if [ $MENU -eq 1 ] ; then

--- a/mconfig/basics.Mconfig
+++ b/mconfig/basics.Mconfig
@@ -1,4 +1,4 @@
-# Copyright 2020 Arm Limited.
+# Copyright 2020-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,3 +61,7 @@ config BUILDER_NINJA
 	  Generate build.ninja output to use with ninja.
 
 endchoice
+
+config ANDROID_PLATFORM_VERSION
+	int "Android PLATFORM_VERSION"
+	depends on ANDROID

--- a/mconfig/host_toolchain.Mconfig
+++ b/mconfig/host_toolchain.Mconfig
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 Arm Limited.
+# Copyright 2016-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,10 @@ config HOST_GNU_CXX_BINARY
 
 config HOST_CLANG_PREFIX
 	string "Host Clang compiler prefix"
-	default "prebuilts/clang/host/linux-x86/clang-r370808/bin/" if BUILDER_ANDROID_MAKE || BUILDER_ANDROID_BP
+	default "prebuilts/clang/host/linux-x86/clang-4691093/bin/" if ANDROID_PLATFORM_VERSION = 9 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE) # pie-release
+	default "prebuilts/clang/host/linux-x86/clang-r353983c/bin/" if ANDROID_PLATFORM_VERSION = 10 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE) # android-10-release
+	default "prebuilts/clang/host/linux-x86/clang-r383902b/bin/" if ANDROID_PLATFORM_VERSION = 11 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE) # android-11-release
+	default "prebuilts/clang/host/linux-x86/clang-r399163b/bin/" if ANDROID_PLATFORM_VERSION > 11 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE)
 	default ""
 
 config HOST_CLANG_CC_BINARY

--- a/mconfig/target_toolchain.Mconfig
+++ b/mconfig/target_toolchain.Mconfig
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 Arm Limited.
+# Copyright 2016-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,10 @@
 
 config TARGET_CLANG_PREFIX
 	string "Target Clang compiler prefix"
+	default "prebuilts/clang/host/linux-x86/clang-4691093/bin/" if ANDROID_PLATFORM_VERSION = 9 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE) # pie-release
+	default "prebuilts/clang/host/linux-x86/clang-r353983c/bin/" if ANDROID_PLATFORM_VERSION = 10 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE) # android-10-release
+	default "prebuilts/clang/host/linux-x86/clang-r383902b/bin/" if ANDROID_PLATFORM_VERSION = 11 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE) # android-11-release
+	default "prebuilts/clang/host/linux-x86/clang-r399163b/bin/" if ANDROID_PLATFORM_VERSION > 11 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE)
 	default ""
 
 config TARGET_CLANG_CC_BINARY

--- a/scripts/android_version.py
+++ b/scripts/android_version.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+# Copyright 2018-2021 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_platform_version():
+    android_build_top = os.getenv("ANDROID_BUILD_TOP")
+    if android_build_top is None:
+        logger.error("ANDROID_BUILD_TOP not set")
+        return None
+
+    soong_ui = os.path.join(android_build_top, "build", "soong", "soong_ui.bash")
+    try:
+        cmd = [soong_ui, "--dumpvar-mode", "PLATFORM_VERSION"]
+        # Ignore soong_ui's stderr output by redirecting it. This does not end
+        # up in the captured output.
+        platform_version = subprocess.check_output(cmd,
+                                                   stderr=subprocess.PIPE).decode().strip()
+    except (OSError, subprocess.CalledProcessError) as e:
+        logger.error("%s", str(e))
+        return None
+
+    if platform_version.isalpha():
+        # aosp master may have a single letter for PLATFORM_VERSION eg. 'Q' for Android 10
+        platform_version = ord(platform_version) - 71
+    return int(platform_version)
+
+
+if __name__ == "__main__":
+    logging.basicConfig()
+
+    version = get_platform_version()
+    if version is not None:
+        sys.stdout.write(str(version) + "\n")
+    else:
+        sys.stderr.write("Could not get Android version\n")
+        sys.exit(1)

--- a/tests/bootstrap_androidbp
+++ b/tests/bootstrap_androidbp
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020 Arm Limited.
+# Copyright 2020-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -113,9 +113,11 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 # Pick up some info that bob has worked out
 source "${BUILDDIR}/.bob.bootstrap"
 
+ANDROID_VERSION="$("${SCRIPT_DIR}/${BOB_DIR}/scripts/android_version.py")"
+
 if [ $MENU -ne 1 ] || [ ! -f "${BPBUILD_DIR}/${CONFIGNAME}" ] ; then
     # Have arguments or missing bob.config. Run config.
-    "${BPBUILD_DIR}/config" ANDROID=y BUILDER_ANDROID_BP=y "$@"
+    "${BPBUILD_DIR}/config" ANDROID=y BUILDER_ANDROID_BP=y ANDROID_PLATFORM_VERSION=${ANDROID_VERSION} "$@"
 fi
 
 if [ $MENU -eq 1 ] ; then

--- a/tests/bootstrap_androidmk
+++ b/tests/bootstrap_androidmk
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2018-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -123,12 +123,14 @@ rm -f "$TMP_ANDROID_MK"
 # Pick up some info that bob has worked out
 source "${BUILDDIR}/.bob.bootstrap"
 
+ANDROID_VERSION="$("${SCRIPT_DIR}/${BOB_DIR}/scripts/android_version.py")"
+
 # Setup the buildme script to just run bob
 ln -sf "bob" "${BUILDDIR}/buildme"
 
 if [ $MENU -ne 1 ] || [ ! -f "$ANDROIDMK_DIR/$CONFIGNAME" ] ; then
     # Have arguments or missing bob.config. Run config.
-    "$ANDROIDMK_DIR/config" ANDROID=y "$@"
+    "$ANDROIDMK_DIR/config" ANDROID=y ANDROID_PLATFORM_VERSION=${ANDROID_VERSION} "$@"
 fi
 
 if [ $MENU -eq 1 ] ; then


### PR DESCRIPTION
Each Android release has its compiler at a specific location. Set up
HOST_CLANG_PREFIX and TARGET_CLANG_PREFIX to point at this location so
that flag_supported and host explore uses the right compiler.

Note that a release may have moved Clang on slightly. For our purposes
though, the older compiler should report the same capabilities.

In order to support this, we also need to detect the Android version we are
using.
    