### PR TITLE
Expand match_srcs feature for cflags, conlyflags and cxxflags

### DIFF
--- a/core/defaults.go
+++ b/core/defaults.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -122,8 +122,11 @@ func (m *defaults) getSourceProperties() *SourceProps {
 // {{match_srcs}} template is only applied in specific properties where we've
 // seen sensible use-cases and for `BuildProps` this is:
 //  - Ldflags
+//  - Cflags
+//  - Conlyflags
+//  - Cxxflags
 func (m *defaults) getMatchSourcePropNames() []string {
-	return []string{"Ldflags"}
+	return []string{"Ldflags", "Cflags", "Conlyflags", "Cxxflags"}
 }
 
 func defaultsFactory(config *bobConfig) (blueprint.Module, []interface{}) {

--- a/core/library.go
+++ b/core/library.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -460,8 +460,11 @@ func (l *library) getSourceProperties() *SourceProps {
 // {{match_srcs}} template is only applied in specific properties where we've
 // seen sensible use-cases and for `BuildProps` this is:
 //  - Ldflags
+//  - Cflags
+//  - Conlyflags
+//  - Cxxflags
 func (l *library) getMatchSourcePropNames() []string {
-	return []string{"Ldflags"}
+	return []string{"Ldflags", "Cflags", "Conlyflags", "Cxxflags"}
 }
 
 // Returns the shortname for the output, which is used as a phony target. If it

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -119,6 +119,9 @@ For example to define a string literal:
     cflags: ["-DCOLOR_DEF=\"blue\""]
 ```
 
+The [`match_srcs`](../strings.md#match_srcs) function can be used in
+this property to reference files listed in `srcs`.
+
 ----
 ### **bob_module.export_cflags** (optional)
 Flags exported to modules which depend on the current one. These will
@@ -130,6 +133,8 @@ If `libB` wishes to propagate `libC`'s flags to `libA`, it should add
 `libC` to its `reexport_libs` list.
 
 Also see `cflags`.
+Note that we do not support [`match_srcs`](../strings.md#match_srcs)
+function for `export_cflags`.
 
 ----
 ### **bob_module.conlyflags** (optional)

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -67,8 +67,8 @@ Transform the value of `.param` as directed by `regexp` and
 
 Return paths of files that match the glob `file_glob` from the
 module's `srcs` property. This function can only be used in the
-`ldflags`, `cmd` or `args` properties. Other properties are not
-expected to reference files.
+`cflags`, `conlyflags`, `cxxflags`, `ldflags`, `cmd` or `args`
+properties. Other properties are not expected to reference files.
 
 It is an error if no files match.
 

--- a/tests/match_source/build.bp
+++ b/tests/match_source/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 Arm Limited.
+ * Copyright 2019-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,13 +32,19 @@ bob_generate_source {
 
 // Test that we can refer to specific files in the srcs list of a
 // bob_binary via {{match_srcs}}. The test case is to pass a filename
-// to the linker.
+// to the compiler and the linker.
 //
 // Also compile the output of match_source_gen, which checks that it
 // worked as expected.
 bob_binary {
     name: "match_source_bin",
-    srcs: ["source.c"],
+    srcs: [
+        "source.c",
+        "test_cpp.cpp",
+        "cflags.h",
+        "conlyflags.h",
+        "cxxflags.h",
+    ],
     generated_sources: ["match_source_gen"],
     not_osx: {
         srcs: ["exports.txt"],
@@ -48,6 +54,9 @@ bob_binary {
         srcs: ["order_file.txt"],
         ldflags: ["-Wl,-order_file,{{match_srcs \"*.txt\"}}"],
     },
+    cflags: ["-include {{match_srcs \"cflags.h\"}}"],
+    conlyflags: ["-include {{match_srcs \"conlyflags.h\"}}"],
+    cxxflags: ["-include {{match_srcs \"cxxflags.h\"}}"],
 }
 
 bob_alias {

--- a/tests/match_source/cflags.h
+++ b/tests/match_source/cflags.h
@@ -1,0 +1,1 @@
+#define CFLAGS_TEST

--- a/tests/match_source/conlyflags.h
+++ b/tests/match_source/conlyflags.h
@@ -1,0 +1,1 @@
+#define CONLYFLAGS_TEST

--- a/tests/match_source/cxxflags.h
+++ b/tests/match_source/cxxflags.h
@@ -1,0 +1,1 @@
+#define CXXFLAGS_TEST

--- a/tests/match_source/main.c
+++ b/tests/match_source/main.c
@@ -2,10 +2,28 @@
 // prepended to this file to test {{match_srcs}}
 
 extern int another_function(void);
+extern int test_cxxflags();
 
 int main(void)
 {
-	int result = exported_function();
-	result += another_function();
-	return (result == 46) ? 0 : 1;
+	int result = 0;
+
+	{
+		int tmp = exported_function();
+		tmp += another_function();
+		if (tmp != 46)
+			result = 1;
+	}
+
+#ifndef CFLAGS_TEST
+	result = 1;
+#endif
+
+#ifndef CONLYFLAGS_TEST
+	result = 1;
+#endif
+
+	result = test_cxxflags();
+
+	return result;
 }

--- a/tests/match_source/test_cpp.cpp
+++ b/tests/match_source/test_cpp.cpp
@@ -1,0 +1,12 @@
+extern "C" {
+
+int test_cxxflags()
+{
+#ifdef CXXFLAGS_TEST
+    return 0;
+#else
+    return 1;
+#endif
+}
+
+}


### PR DESCRIPTION
match_srcs was only implemented for ldflags. However, in some
cases it is also convenient to use this features for cflags.
For instance, being able to give a sanitizer file to the
compiler as such:

    cflags: [
        "-fsanitize-blacklist={{match_srcs 'sanitize.blacklist'}}"
    ]

avoids using an environment variable and causes further UX issues.

This commit expands match_srcs feature for cflags, conlyflags
and cxxflags. It also expands the existing match_srcs test.