### PR TITLE
Fix checking for outdated kernel config

### DIFF
--- a/scripts/kmod_build.py
+++ b/scripts/kmod_build.py
@@ -277,17 +277,17 @@ def main():
     extra_cflags = " ".join(includes) + " " + args.extra_cflags + " " + \
                    " ".join(kbuild_cflags)
 
-    # If kconfig.h is older than kernel config, the kernel needs to be rebuilt
+    # If autoconf.h is older than kernel config, the kernel needs to be rebuilt
     # to update this file.
-    kconfig_file = os.path.join(abs_kdir, "include", "linux", "kconfig.h")
+    autoconf_file = os.path.join(abs_kdir, "include", "generated", "autoconf.h")
     kernel_config_file = kernel_config_parser.get_config_file_path(abs_kdir)
-    if os.path.exists(kconfig_file):
-        if os.path.getmtime(kconfig_file) < os.path.getmtime(kernel_config_file):
+    if os.path.exists(autoconf_file):
+        if os.path.getmtime(autoconf_file) < os.path.getmtime(kernel_config_file):
             msg = "%s is older than %s. make modules_prepare needs to be run."
-            logger.warning(msg, kconfig_file, kernel_config_file)
+            logger.warning(msg, autoconf_file, kernel_config_file)
     else:
         msg = "%s not found. make modules_prepare needs to be run"
-        logger.warning(msg, kconfig_file)
+        logger.warning(msg, autoconf_file)
 
     deps = []
 


### PR DESCRIPTION
`include/linux/kconfig.h` is a wrapper around `include/generated/autoconf.h` that contains kernel config options.
This also removes spurrious warnings triggered if the user checked out the kernel from git as autoconf.h is not part of the git tree.