### PR TITLE
Update clang toolchain to r407598b

### DIFF
--- a/mconfig/host_toolchain.Mconfig
+++ b/mconfig/host_toolchain.Mconfig
@@ -42,7 +42,7 @@ config HOST_CLANG_PREFIX
 	default "prebuilts/clang/host/linux-x86/clang-4691093/bin/" if ANDROID_PLATFORM_VERSION = 9 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE) # pie-release
 	default "prebuilts/clang/host/linux-x86/clang-r353983c/bin/" if ANDROID_PLATFORM_VERSION = 10 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE) # android-10-release
 	default "prebuilts/clang/host/linux-x86/clang-r383902b/bin/" if ANDROID_PLATFORM_VERSION = 11 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE) # android-11-release
-	default "prebuilts/clang/host/linux-x86/clang-r399163b/bin/" if ANDROID_PLATFORM_VERSION > 11 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE)
+	default "prebuilts/clang/host/linux-x86/clang-r407598b/bin/" if ANDROID_PLATFORM_VERSION > 11 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE)
 	default ""
 
 config HOST_CLANG_CC_BINARY

--- a/mconfig/target_toolchain.Mconfig
+++ b/mconfig/target_toolchain.Mconfig
@@ -26,7 +26,7 @@ config TARGET_CLANG_PREFIX
 	default "prebuilts/clang/host/linux-x86/clang-4691093/bin/" if ANDROID_PLATFORM_VERSION = 9 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE) # pie-release
 	default "prebuilts/clang/host/linux-x86/clang-r353983c/bin/" if ANDROID_PLATFORM_VERSION = 10 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE) # android-10-release
 	default "prebuilts/clang/host/linux-x86/clang-r383902b/bin/" if ANDROID_PLATFORM_VERSION = 11 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE) # android-11-release
-	default "prebuilts/clang/host/linux-x86/clang-r399163b/bin/" if ANDROID_PLATFORM_VERSION > 11 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE)
+	default "prebuilts/clang/host/linux-x86/clang-r407598b/bin/" if ANDROID_PLATFORM_VERSION > 11 && (BUILDER_ANDROID_BP || BUILDER_ANDROID_MAKE)
 	default ""
 
 config TARGET_CLANG_CC_BINARY


### PR DESCRIPTION
Soong was recently updated to use a more recent version of clang (commit: 5e3d82ebdbc791711f7d67af09f3e53b83ad5188).