### PR TITLE
Respect build_by_default in kernel modules

### DIFF
--- a/core/linux_kernel_module.go
+++ b/core/linux_kernel_module.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,6 +53,7 @@ func (g *linuxGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.Modu
 	// Calculate and record outputs
 	m.outputdir = g.kernelModOutputDir(m)
 	m.outs = []string{filepath.Join(m.outputDir(), m.outputName()+".ko")}
+	optional := !isBuiltByDefault(m)
 
 	args := m.generateKbuildArgs(ctx).toDict()
 	delete(args, "kmod_build")
@@ -66,7 +67,7 @@ func (g *linuxGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.Modu
 			Rule:     kbuildRule,
 			Outputs:  m.outputs(),
 			Inputs:   sources,
-			Optional: false,
+			Optional: true,
 			Args:     args,
 		})
 
@@ -82,5 +83,5 @@ func (g *linuxGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.Modu
 		})
 
 	installDeps := g.install(m, ctx)
-	addPhony(m, ctx, installDeps, false)
+	addPhony(m, ctx, installDeps, optional)
 }


### PR DESCRIPTION
Kernel modules on Linux currently hard-code `optional` to `false`,
regardless of the setting of `build_by_default`. This means they are
always built when enabled, even if explicitly requested to be excluded
from the default build.

Fix this by using `!isBuiltByDefault()` when generating the phony rule,
and setting the actual build targets to `optional: true`.

Change-Id: I6d9acd6e4c607463958566da69d5ef20f3c93356
Signed-off-by: Chris Diamand <chris.diamand@arm.com>