### PR TITLE
Disable CCACHE_BASEDIR to fix depfiles

### DIFF
--- a/bob.bash
+++ b/bob.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2018-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,16 +51,16 @@ python "${BOB_DIR}/config_system/generate_config_json.py" \
 # regenerate the build.ninja
 python "${BOB_DIR}/scripts/env_hash.py" "${BUILDDIR}/.env.hash"
 
-# Source the pathtools script - we need bob_realpath for CCACHE_BASEDIR.
-source "${BOB_DIR}/pathtools.bash"
-
 # If enabled, the following environment variables optimize the performance
 # of ccache. Otherwise they have no effect.
 # To build with ccache, set the environment variable CCACHE_DIR to where the
 # cache is to reside and add CCACHE=y to the build config to enable.
-export CCACHE_BASEDIR="$(bob_realpath ${SRCDIR})"
 export CCACHE_CPP2=y
 export CCACHE_SLOPPINESS=file_macro,time_macros
+# Explicitly disable CCACHE_BASEDIR - when it's enabled, ccache will rewrite
+# paths in depfiles to be relative to it, but that will cause Ninja to miss
+# dependencies on builds where everything else is using absolute paths.
+export CCACHE_BASEDIR=
 
 # Build the builder if necessary
 BUILDDIR="${BUILDDIR}" SKIP_NINJA=true ${BOB_DIR}/blueprint/blueprint.bash

--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -65,16 +65,6 @@ if [[ -z "$BOB_CONFIG_PLUGINS" ]]; then
   BOB_CONFIG_PLUGINS=""
 fi
 
-# FIXME: It was found that using an absolute path for the build directory (inside srcdir)
-# could lead to dependency issues later, in part due to ninja not being able to handle well
-# absolute depfile paths (see https://github.com/ninja-build/ninja/issues/1251).
-# This issue only happens if the build directory is located in the source directory.
-# For now, let's warn users about this potential issue.
-if [ "${BUILDDIR:0:1}" = '/' ] && $(path_is_parent $(bob_abspath "${SRCDIR}") "${BUILDDIR}"); then
-  echo "WARNING! Using an absolute path for the build directory located inside the source directory" \
-" can lead to dependency issues. Recommend using a relative path for the build directory."
-fi
-
 if [ "${BUILDDIR}" = "." ] ; then
     WORKDIR=.
 else


### PR DESCRIPTION
Bob currently sets CCACHE_BASEDIR to the project root, which in theory
increases cache hits by allowing caches to be used across multiple
copies of the source tree.

Unfortunately, this also causes ccache to rewrite paths inside depfiles
so that they are relative to CCACHE_BASEDIR. As a result, the
now-relative depfile paths do not match the corresponding `build.ninja`
paths, which can be absolute.

As a result, dependencies can be missed on builds using absolute paths,
causing incorrect builds.

Avoid this by explicitly unsetting CCACHE_BASEDIR.

Also remove the warning added in `b0c5003` now that the issue is fixed.

Change-Id: I4d34b60b59a90be42b7d2cbafe65cfb4b42c7574
Signed-off-by: Chris Diamand <chris.diamand@arm.com>