### PR TITLE
Soong compatibility layer

### DIFF
--- a/core/config_props.go
+++ b/core/config_props.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,6 +58,26 @@ func (properties configProperties) GetBool(name string) bool {
 		return ret
 	}
 	panic(fmt.Sprintf("Property %s is not a bool", name))
+}
+
+func (properties configProperties) GetInt(name string) int {
+	number, ok := properties.getProp(name).(json.Number)
+	if !ok {
+		panic(fmt.Sprintf("Property %s with value '%v' is not an int",
+			name, properties.getProp(name)))
+	}
+
+	ret, err := number.Int64()
+	if err != nil {
+		panic(fmt.Sprintf("Property %s contains invalid int value '%s': %v",
+			name, number.String(), err))
+	}
+
+	if int64(int(ret)) != ret {
+		panic(fmt.Sprintf("Property %s value out of `int` range: %d", name, ret))
+	}
+
+	return int(ret)
 }
 
 func (properties configProperties) GetString(name string) string {

--- a/internal/soong_compat/androidmk_entries.go
+++ b/internal/soong_compat/androidmk_entries.go
@@ -1,0 +1,26 @@
+// +build soong
+
+/*
+ * Copyright 2021 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package soong_compat
+
+import (
+	"android/soong/android"
+)
+
+type AndroidMkExtraEntriesFunc = func(*android.AndroidMkEntries)

--- a/internal/soong_compat/soong_compat_00_pqr.go
+++ b/internal/soong_compat/soong_compat_00_pqr.go
@@ -1,0 +1,35 @@
+// +build soong
+
+/*
+ * Copyright 2021 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package soong_compat
+
+import (
+	"android/soong/android"
+)
+
+// This definition is compatible with Soong SHAs _before_ `aa2555387 Add ctx to
+// AndroidMkExtraEntriesFunc` It requires Soong SHA `0b0e1b980 AndroidMkEntries()
+// returns multiple AndroidMkEntries structs` or later.
+func ConvertAndroidMkExtraEntriesFunc(f AndroidMkExtraEntriesFunc) []android.AndroidMkExtraEntriesFunc {
+	return []android.AndroidMkExtraEntriesFunc{
+		func(entries *android.AndroidMkEntries) {
+			f(entries)
+		},
+	}
+}

--- a/internal/soong_compat/soong_compat_01_AndroidMkExtraEntries_ctx.go
+++ b/internal/soong_compat/soong_compat_01_AndroidMkExtraEntries_ctx.go
@@ -1,0 +1,34 @@
+// +build soong
+
+/*
+ * Copyright 2021 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package soong_compat
+
+import (
+	"android/soong/android"
+)
+
+// This definition is compatible with Soong SHAs after `aa2555387 Add ctx to
+// AndroidMkExtraEntriesFunc`
+func ConvertAndroidMkExtraEntriesFunc(f AndroidMkExtraEntriesFunc) []android.AndroidMkExtraEntriesFunc {
+	return []android.AndroidMkExtraEntriesFunc{
+		func(ctx android.AndroidMkExtraEntriesContext, entries *android.AndroidMkEntries) {
+			f(entries)
+		},
+	}
+}

--- a/plugins/Android.bp.in
+++ b/plugins/Android.bp.in
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Arm Limited.
+ * Copyright 2020-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,19 @@
  */
 
 bootstrap_go_package {
+    name: "bob-soong_compat-@@PROJ_UID@@",
+    pluginFor: ["soong_build"],
+    deps: [
+        "soong-android",
+    ],
+    srcs: [
+        "@@BOB_DIR@@/internal/soong_compat/androidmk_entries.go",
+        "@@BOB_DIR@@/internal/soong_compat/@@SOONG_COMPAT@@",
+    ],
+    pkgPath: "github.com/ARM-software/bob-build/internal/soong_compat",
+}
+
+bootstrap_go_package {
     name: "bob-utils-@@PROJ_UID@@",
     pluginFor: ["soong_build"],
     srcs: [
@@ -30,6 +43,7 @@ bootstrap_go_package {
     deps: [
         "soong-android",
         "soong-etc",
+        "bob-soong_compat-@@PROJ_UID@@",
     ],
     srcs: [
         "@@BOB_DIR@@/plugins/prebuilt/prebuilt_data.go",
@@ -45,6 +59,7 @@ bootstrap_go_package {
         "soong-android",
         "soong-cc",
         "soong-genrule",
+        "bob-soong_compat-@@PROJ_UID@@",
         "bob-utils-@@PROJ_UID@@",
     ],
     srcs: [

--- a/plugins/genrulebob/genrule.go
+++ b/plugins/genrulebob/genrule.go
@@ -28,6 +28,7 @@ import (
 	"android/soong/cc"
 	"android/soong/genrule"
 
+	"github.com/ARM-software/bob-build/internal/soong_compat"
 	"github.com/ARM-software/bob-build/internal/utils"
 
 	"github.com/google/blueprint"
@@ -617,12 +618,12 @@ func (m *genrulebobCommon) AndroidMkEntries() []android.AndroidMkEntries {
 			// if module has more than one output, keep LOCAL_MODULE unique
 			SubName: "__" + utils.FlattenPath(outfile.Path().Rel()),
 			Include: "$(BUILD_PREBUILT)",
-			ExtraEntries: []android.AndroidMkExtraEntriesFunc{
+			ExtraEntries: soong_compat.ConvertAndroidMkExtraEntriesFunc(
 				func(entries *android.AndroidMkEntries) {
 					// don't install in data partition (which is enforced behavior when class is DATA)
 					entries.SetBool("LOCAL_UNINSTALLABLE_MODULE", true)
 				},
-			},
+			),
 		})
 
 	}

--- a/plugins/prebuilt/prebuilt_data.go
+++ b/plugins/prebuilt/prebuilt_data.go
@@ -1,7 +1,7 @@
 // +build soong
 
 /*
- * Copyright 2020 Arm Limited.
+ * Copyright 2020-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,8 @@ package prebuilt
 import (
 	"android/soong/android"
 	"android/soong/etc"
+
+	"github.com/ARM-software/bob-build/internal/soong_compat"
 )
 
 func init() {
@@ -55,12 +57,12 @@ func (m *PrebuiltData) AndroidMkEntries() []android.AndroidMkEntries {
 		Class:      "DATA",
 		OutputFile: android.OptionalPathForPath(m.OutputFile()),
 		Include:    "$(BUILD_PREBUILT)",
-		ExtraEntries: []android.AndroidMkExtraEntriesFunc{
+		ExtraEntries: soong_compat.ConvertAndroidMkExtraEntriesFunc(
 			func(entries *android.AndroidMkEntries) {
 				entries.SetString("LOCAL_MODULE_PATH", m.InstallDirPath().ToMakePath().String())
 				entries.SetString("LOCAL_INSTALLED_MODULE_STEM", m.OutputFile().Base())
 			},
-		},
+		),
 	}}
 }
 
@@ -96,12 +98,12 @@ func (m *PrebuiltTestcase) AndroidMkEntries() []android.AndroidMkEntries {
 		Class:      "DATA",
 		OutputFile: android.OptionalPathForPath(m.OutputFile()),
 		Include:    "$(BUILD_PREBUILT)",
-		ExtraEntries: []android.AndroidMkExtraEntriesFunc{
+		ExtraEntries: soong_compat.ConvertAndroidMkExtraEntriesFunc(
 			func(entries *android.AndroidMkEntries) {
 				entries.SetString("LOCAL_MODULE_PATH", m.InstallDirPath().ToMakePath().String())
 				entries.SetString("LOCAL_INSTALLED_MODULE_STEM", m.OutputFile().Base())
 			},
-		},
+		),
 	}}
 }
 


### PR DESCRIPTION
A recent change in Soong (`0b0e1b980 AndroidMkEntries() returns multiple
AndroidMkEntries structs`) broke the build of Bob's Soong plugins.

The fix itself is simple - it's just another argument to a callback
function. However, we need compatibility with multiple Android versions
so cannot just make the obvious change.

Instead, add a new `soong_compat` module, which compiles different
helper functions, returning the correct types, depending on the Soong
commit. Infrastructure is added to allow adding more layers in future,
although it is hoped that this will not be necessary.

Detection of the Android version first will do a simple comparison on
ANDROID_PLATFORM_VERSION, which in most cases is enough to uniquely
identify the required source file. If that fails, it will try and do a
comparison using Soong's git SHA, before reverting to the most recent
compatibility file for that particular Android version and printing a
warning.

Change-Id: Ibfa76641deb20b7e9d5ff68a380cf2d7f3aecfba
Signed-off-by: Chris Diamand <chris.diamand@arm.com>