### PR TITLE
Match lines in the Soong source instead of git SHAs

### DIFF
--- a/core/androidbp_backend.go
+++ b/core/androidbp_backend.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -248,22 +247,68 @@ func (s *androidBpSingleton) generateBuildbpCheck(ctx blueprint.SingletonContext
 		})
 }
 
+// A line to match in a specific source file, to identify a particular Soong version.
+type codeMatcher struct {
+	filename string
+	text     string
+	result   *bool
+}
+
+func (cm *codeMatcher) match() bool {
+	if cm.result != nil {
+		return *cm.result
+	}
+
+	matched := false
+	contents, err := ioutil.ReadFile(cm.filename)
+	if err == nil {
+		matched = strings.Contains(string(contents), cm.text)
+	} else {
+		fmt.Fprintf(os.Stderr,
+			"WARNING: Could not open file %s to determine Soong "+
+				"compatibility layer: %s\n"+
+				"Compilation of Bob plugins may fail!\n",
+			err.Error(), cm.filename)
+	}
+
+	cm.result = &matched
+	return matched
+}
+
 func getSoongCompatFile(config *bobConfig) string {
 	type compatVersion struct {
-		sha              string
+		matches          []codeMatcher
 		android_versions []int
 		src              string
 	}
 
-	// List of compatibility layers, ordered from oldest Soong SHA to newest.
+	listOfAndroidMkEntriesMatcher := codeMatcher{
+		filename: "build/soong/android/androidmk.go",
+		text:     "\n\tAndroidMkEntries() []AndroidMkEntries\n",
+	}
+
+	androidMkExtraEntriesContextMatcher := codeMatcher{
+		filename: "build/soong/android/androidmk.go",
+		text:     "\ntype AndroidMkExtraEntriesContext interface {\n",
+	}
+
+	// List of compatibility layers, ordered from oldest Soong version
+	// support to newest.
 	allSoongCompats := []compatVersion{
+		// AndroidMkEntries() was made to return an array in 0b0e1b9
 		{
-			"0b0e1b98048a6d7a5efb699447253202f1d1d52a",
+			[]codeMatcher{
+				listOfAndroidMkEntriesMatcher,
+			},
 			[]int{9, 10, 11, 12},
 			"soong_compat_00_pqr.go",
 		},
+		// AndroidMkExtraEntriesContext was added in aa25553
 		{
-			"aa2555387d214fc0292406d10714558054d794f3",
+			[]codeMatcher{
+				listOfAndroidMkEntriesMatcher,
+				androidMkExtraEntriesContextMatcher,
+			},
 			[]int{12},
 			"soong_compat_01_AndroidMkExtraEntries_ctx.go",
 		},
@@ -273,7 +318,8 @@ func getSoongCompatFile(config *bobConfig) string {
 
 	soongCompats := []compatVersion{}
 
-	// See if we can uniquely identify the required compatibility code based on the Android version
+	// See if we can uniquely identify the required compatibility code based
+	// on the Android version
 	for _, soongCompat := range allSoongCompats {
 		android_versions := soongCompat.android_versions
 
@@ -284,56 +330,38 @@ func getSoongCompatFile(config *bobConfig) string {
 		}
 	}
 
-	if len(soongCompats) == 0 {
-		fmt.Fprintf(os.Stderr, "WARNING: Could not find an appropriate Soong "+
-			"compatibility layer for ANDROID_PLATFORM_VERSION = %d. Falling back to "+
-			"default. Compilation of Bob plugins may fail!\n", android_platform_version)
-		return allSoongCompats[len(soongCompats)-1].src
-	} else if len(soongCompats) == 1 {
+	if len(soongCompats) == 1 {
 		return soongCompats[0].src
+	} else if len(soongCompats) == 0 {
+		fmt.Fprintf(os.Stderr, "WARNING: No available Soong compatibility "+
+			"layers found for ANDROID_PLATFORM_VERSION = %d.\n"+
+			"Attempting text-based detection.\n",
+			android_platform_version)
+		soongCompats = allSoongCompats
 	}
 
-	// If there are multiple potential options for this Android version, try to differentiate
-	// using Soong's git SHA. Search from newest to oldest - newer Soong versions will contain
-	// the older commits too, so going the other way would mean always incorrectly choosing the
-	// earliest version.
+	// If there are multiple potential options for this Android version, try
+	// to differentiate by matching specific lines in Soong's source. Search
+	// from newest to oldest - newer Soong versions may contain older code
+	// fragments too, so going the other way could mean incorrectly choosing
+	// an earlier version.
 	for i := len(soongCompats) - 1; i >= 0; i-- {
-		sha := soongCompats[i].sha
-		src := soongCompats[i].src
-
-		// See if Soong contains the current SHA. Bob should be executing in
-		// ANDROID_BUILD_TOP (see e.g. `tests/bootstrap_androidbp`), so the Soong code can
-		// be accessed trivially using its relative path within the Android source tree.
-		cmd := exec.Command("git", "-C", "build/soong", "merge-base", "--is-ancestor", sha, "HEAD")
-		out, err := cmd.CombinedOutput()
-
-		if err == nil {
-			// HEAD contains the commit; stop searching and use the most recent
-			// compatibility layer.
-			return src
-		} else if _, ok := err.(*exec.ExitError); ok {
-			// The command started running and completed, but exited with a non-zero
-			// exist status. Git returns 1 when it recognises the SHA but it isn't an
-			// ancestor, and 128 for most other stuff - even for valid git directories
-			// without that commit. Either way, just keep iterating until we find a
-			// match. On the last time (oldest supported Soong SHA), print the error, in
-			// case there is a git repo issue.
-
-			if i == 0 {
-				fmt.Fprintf(os.Stderr, "Command '%s' failed: stderr is:\n",
-					strings.Join(cmd.Args, " "))
-				os.Stderr.Write(out)
+		allMatchesPassed := true
+		for _, m := range soongCompats[i].matches {
+			if !m.match() {
+				allMatchesPassed = false
+				break
 			}
-		} else { // Invoking git failed for some other reason - don't bother trying again
-			fmt.Fprintf(os.Stderr, "Command '%s' failed: %s\n",
-				strings.Join(cmd.Args, " "), err)
-			break
+		}
+		if allMatchesPassed {
+			return soongCompats[i].src
 		}
 	}
 
-	fmt.Fprintf(os.Stderr, "WARNING: Could not find an appropriate Soong compatibility layer "+
-		"based on git SHA in build/soong.\nWARNING: Falling back to default for this "+
-		"Android version. Compilation of Bob plugins may fail!\n")
+	fmt.Fprintf(os.Stderr, "WARNING: Could not find an appropriate Soong "+
+		"compatibility layer based on code in build/soong.\n"+
+		"WARNING: Falling back to default for this Android version. "+
+		"Compilation of Bob plugins may fail!\n")
 	return soongCompats[len(soongCompats)-1].src
 }
 


### PR DESCRIPTION
Handle Android checkouts without complete commit history by matching
specific lines in Soong source files. The fragility of this approach is
significantly reduced by the fact that Go code is always formatted by
`gofmt`, so any changes to the relevant lines are highly likely to be
interface changes that would need accounting for anyway.

Remove the git-SHA-based implementation, because the new approach turns
out to be simpler anyway and will work in the scenarios handling by SHA
detection as well.

Change-Id: I70ba67e037475ac771dfeb57d4cabf388e99fb3c
Signed-off-by: Chris Diamand <chris.diamand@arm.com>