### PR TITLE
Remove ${(mod)_dir} support

### DIFF
--- a/core/androidbp_kernel_module.go
+++ b/core/androidbp_kernel_module.go
@@ -63,7 +63,7 @@ func (g *androidBpGenerator) kernelModuleActions(l *kernelModule, mctx blueprint
 	for _, mod := range l.extraSymbolsModules(mctx) {
 		generated_deps = append(generated_deps, mod.Name())
 		// reference all dependent modules outputs, needed for related symvers files
-		sources_param += " ${" + mod.Name() + "_dir}/Module.symvers"
+		sources_param += " $$(dirname ${" + mod.Name() + "_out})/Module.symvers"
 	}
 
 	kdir := l.Properties.Kernel_dir

--- a/core/generated.go
+++ b/core/generated.go
@@ -88,7 +88,7 @@ type GenerateProps struct {
 	 * $args       - the value of "args" - space-delimited
 	 * $tool       - the path to the tool
 	 * $host_bin   - the path to the binary that is produced by the host_bin module
-	 * $(name)_dir - the build directory for each dep in generated_dep
+	 * $(dep)_out  - the outputs of the generated_dep `dep`
 	 * $src_dir    - the path to the project source directory - this will be different than the build source directory
 	 *               for Android.
 	 * $module_dir - the path to the module directory */
@@ -468,11 +468,10 @@ func getDependentArgsAndFiles(ctx blueprint.ModuleContext, args map[string]strin
 			}
 
 			depName := ctx.OtherModuleName(m)
-			// When the dependent module is another Bob generated module, provide
-			// the location of its output dir so the using module can pick and
-			// choose what it uses.
+			// When the dependent module is another Bob generated
+			// module, provide all its outputs so the using module can
+			// pick and choose what it uses.
 			if gc, ok := getGenerateCommon(m); ok {
-				args[depName+"_dir"] = gc.outputDir()
 				args[depName+"_out"] = strings.Join(gc.outputs(), " ")
 			} else {
 				args[depName+"_out"] = strings.Join(gen.outputs(), " ")

--- a/docs/module_types/common_generate_module_properties.md
+++ b/docs/module_types/common_generate_module_properties.md
@@ -26,7 +26,6 @@ available substitutions are:
 - `${host_bin}` - the path to the binary specified by `host_bin`
 - `${module_dir}` - the path this module's source directory
 - `${gen_dir}` - the path to the output directory for this module
-- `${(name)_dir}` - the output directory for the `generated_deps` dependency with `name`
 - `${(name)_out}` - the outputs of the `generated_deps` dependency with `name`
 - `${src_dir}` - the path to the project source directory - this will be different
   than the build source directory for Android.
@@ -56,8 +55,8 @@ be built before the `bob_generated`.
 ----
 ### **bob_generated.generated_deps** (optional)
 A list of other modules that this generator depends on. The dependencies can be
-used in the command through `${(name_of_dependency)_dir}` (that is, the variable's
-name is the name of the dependency, with the `_dir` suffix).
+used in the command through `${(name_of_dependency)_out}` (that is, the variable's
+name is the name of the dependency, with the `_out` suffix).
 
 ----
 ### **bob_generated.generated_sources** (optional)

--- a/docs/user_guide/code_generation.md
+++ b/docs/user_guide/code_generation.md
@@ -354,11 +354,13 @@ bob_static_library {
 }
 ```
 
-The next example shows how `generated_deps` might be used. Note that for
-each module named in `generated_deps` there are variables to get the
-intermediate directory as well as all the outputs for that module. The
-variables are `${mod_dir}` and `${mod_outs}` where `mod` is the module
-name.
+The next example shows how `generated_deps` might be used. For each
+module named in `generated_deps` there is a variable to get the
+outputs for that module. The variable is `${mod_outs}` where `mod` is
+the module name. For compatibility with Soong, it is not possible to
+get the intermediate output directory for the module, to prevent
+modules using undeclared outputs. This forces the script to do some
+filtering to find the desired input.
 
 ```
 bob_generate_source {
@@ -388,7 +390,7 @@ bob_generate_source {
     ],
 
     tool: "x_generator.py",
-    cmd: "${tool} -c ${gen_dir}/src/x.cpp -h ${gen_dir}/src/x.h ${templates_dir}/x.in",
+    cmd: "${tool} -c ${gen_dir}/src/x.cpp -h ${gen_dir}/src/x.h ${templates_out} --use x.in",
 }
 
 bob_generate_source {
@@ -400,7 +402,7 @@ bob_generate_source {
     ],
 
     tool: "y_generator.py",
-    cmd: "${tool} -c ${gen_dir}/src/y.cpp -h ${gen_dir}/src/y.h ${templates_dir}/y.in",
+    cmd: "${tool} -c ${gen_dir}/src/y.cpp -h ${gen_dir}/src/y.h ${templates_out} --use y.in",
 }
 
 bob_static_library {

--- a/plugins/genrulebob/genrule.go
+++ b/plugins/genrulebob/genrule.go
@@ -325,7 +325,7 @@ func (m *genrulebobCommon) getArgs(ctx android.ModuleContext) (args map[string]s
 	}
 
 	// Add arguments providing information about other modules the current
-	// one depends on, accessible via ${module}_out and ${module}_dir.
+	// one depends on, accessible via ${module}_out.
 	ctx.VisitDirectDepsWithTag(generatedDepTag, func(dep android.Module) {
 		// If a generated module depends on a library/binary which was split
 		// into host/target variants by the Android.bp generator, they will
@@ -336,14 +336,11 @@ func (m *genrulebobCommon) getArgs(ctx android.ModuleContext) (args map[string]s
 		if gdep, ok := dep.(genruleInterface); ok {
 			dependents = append(dependents, gdep.outputs().Paths()...)
 			dependents = append(dependents, gdep.implicitOutputs().Paths()...)
-			args[varName+"_dir"] = gdep.outputPath().String()
 			args[varName+"_out"] = utils.Join(gdep.outputs().Strings(), gdep.getEncapsulatedOuts().Strings())
 
 		} else if ccmod, ok := dep.(cc.LinkableInterface); ok {
 			out := ccmod.OutputFile()
 			dependents = append(dependents, out.Path())
-			// We only expect to use the output from static/shared libraries
-			// and binaries, so `_dir' is not supported on these.
 			args[varName+"_out"] = out.String()
 		}
 	})

--- a/tests/command_vars/build.bp
+++ b/tests/command_vars/build.bp
@@ -1,24 +1,23 @@
 bob_generate_source {
     name: "bob_test_generate_source_single",
     out: [
-        "dir_and_outs.c",
-        "dir_and_outs.h",
+        "single.c",
+        "single.h",
     ],
     tool: "generate_trivial_function.py",
-    cmd: "${tool} module_dir_and_outs ${srcs_generated} ${headers_generated}",
+    cmd: "${tool} testfn ${srcs_generated} ${headers_generated}",
     build_by_default: true,
 }
 
 bob_generate_source {
-    name: "bob_test_module_dep_dir_and_outs",
+    name: "bob_test_module_dep_outs",
     generated_deps: ["bob_test_generate_source_single"],
     out: [
-        "dir_and_outs.c",
-        "dir_and_outs.h",
+        "single.c",
+        "single.h",
     ],
     tool: "test_vars.py",
-    cmd: "${tool} --check-in-dir ${bob_test_generate_source_single_dir} ${bob_test_generate_source_single_out} " +
-        "--check-basename ${bob_test_generate_source_single_out} dir_and_outs.c dir_and_outs.h " +
+    cmd: "${tool} --check-basename ${bob_test_generate_source_single_out} single.c single.h " +
         "--copy ${bob_test_generate_source_single_out} ${gen_dir}",
     export_gen_include_dirs: ["."],
     build_by_default: true,
@@ -28,6 +27,6 @@ bob_alias {
     name: "bob_test_command_vars",
     srcs: [
         "bob_test_generate_source_single",
-        "bob_test_module_dep_dir_and_outs",
+        "bob_test_module_dep_outs",
     ]
 }

--- a/tests/command_vars/test_vars.py
+++ b/tests/command_vars/test_vars.py
@@ -9,7 +9,6 @@ def parse_args():
     ap = argparse.ArgumentParser()
 
     ap.add_argument("--check-basename", nargs="+", action="append", metavar=("PATH ...", "BASE"))
-    ap.add_argument("--check-in-dir", nargs="+", action="append", metavar=("DIR", "PATH"))
     ap.add_argument("--copy", nargs="+", action="append", metavar=("SRC", "DEST"))
 
     return ap.parse_args()
@@ -17,14 +16,6 @@ def parse_args():
 
 def main():
     args = parse_args()
-
-    for check in args.check_in_dir:
-        assert len(check) >= 2, "Path and directory required"
-        check_dir = os.path.normpath(check[0])
-        for path in check[1:]:
-            path = os.path.normpath(path)
-            assert path.startswith(check_dir), \
-                "'%s' is not inside directory '%s'" % (path, check_dir)
 
     for check in args.check_basename:
         # The first half of the arguments are paths, the second are basenames


### PR DESCRIPTION
We would like to use Soong's genrule to support the functionality
provided by bob_generate_source and bob_transform_source. In order to
do this, we need to remove some of the functionality currently present
in these modules.

${(mod)_dir} allows access to the intermediate directories of
dependencies. This would allow an undeclared output to be referenced.
It's preferable to avoid this. This affects:

* modules that only want to use particular outputs of a given
  dependency. Workaround: script needs to handle input filtering

* modules that want to pass the intermediate directory to their script
  as an extra include path. This is the use case of wrapping a call to
  a compiler. Workaround: script needs to calculate include paths from
  all outputs

Change-Id: Ie7d0b6d4b6c192d2b4cdb031d7585ffeaf5819d8
Signed-off-by: David Kilroy <david.kilroy@arm.com>