### PR TITLE
Fix dependency issue caused by bob_resource in Android bp builds

### DIFF
--- a/core/androidbp_generated.go
+++ b/core/androidbp_generated.go
@@ -89,7 +89,11 @@ func populateCommonProps(gc *generateCommon, mctx blueprint.ModuleContext, m bpw
 		m.AddString("rsp_content", *gc.Properties.Rsp_content)
 	}
 	if gc.Properties.Host_bin != nil {
-		m.AddString("host_bin", ccModuleName(mctx, gc.hostBinName(mctx)))
+		hostBin := bpModuleNamesForDep(mctx, gc.hostBinName(mctx))
+		if len(hostBin) != 1 {
+			panic(fmt.Errorf("%s must have one host_bin entry (have %d)", gc.Name(), len(hostBin)))
+		}
+		m.AddString("host_bin", hostBin[0])
 	}
 	m.AddBool("depfile", proptools.Bool(gc.Properties.Depfile))
 

--- a/core/androidbp_resource.go
+++ b/core/androidbp_resource.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Arm Limited.
+ * Copyright 2020-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,6 +39,10 @@ func writeCodeResourceModule(m bpwriter.Module, src, installRel string) {
 	m.AddStringList("srcs", []string{src})
 	m.AddString("stem", filepath.Base(src))
 	m.AddString("relative_install_path", installRel)
+}
+
+func (m *resource) getAndroidbpResourceName(src string) string {
+	return m.shortName() + "__" + strings.Replace(src, "/", "_", -1)
 }
 
 func (g *androidBpGenerator) resourceActions(r *resource, mctx blueprint.ModuleContext) {
@@ -86,8 +90,7 @@ func (g *androidBpGenerator) resourceActions(r *resource, mctx blueprint.ModuleC
 	// as prebuilt_etc module supports only single src, we have to split into N modules
 	for _, src := range r.Properties.getSources(mctx) {
 		// keep module name unique, remove slashes
-		modName := r.shortName() + "__" + strings.Replace(src, "/", "_", -1)
-		m, err := AndroidBpFile().NewModule(modType, modName)
+		m, err := AndroidBpFile().NewModule(modType, r.getAndroidbpResourceName(src))
 		if err != nil {
 			panic(err.Error())
 		}


### PR DESCRIPTION
A bob_resource creates a Blueprint module for each element
in its sources. The name of these modules is generated
using the name of the bob_resource and the path of the source.
This is causing somes issues because other modules are refering
to these modules using the bob_resource name instead of the
generated modules names.

The solution consists in modifying ccModuleName which converts
bob module names to Blueprint module names. This function
returns a list of names instead of a single name because a
bob_resource can generate multiple Blueprint modules.
Blueprint modules that depends on a bob_resource now contains
the list of generated module names instead of the bob_resource
name.