### PR TITLE
Fix include and cflag ordering for defaults

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -252,10 +252,11 @@ type SourceProps struct {
 // by the module.
 type IncludeDirsProps struct {
 	// The list of include dirs to use that is relative to the source directory
-	Include_dirs []string
+	Include_dirs []string `bob:"first_overrides"`
 
 	// The list of include dirs to use that is relative to the build.bp file
-	Local_include_dirs []string // These use relative instead of absolute paths
+	// These use relative instead of absolute paths
+	Local_include_dirs []string `bob:"first_overrides"`
 }
 
 // Get a list of sources to compile.
@@ -460,7 +461,7 @@ func targetMutator(mctx blueprint.TopDownMutatorContext) {
 		src := t.getTargetSpecific(tgt).getTargetSpecificProps()
 
 		// Copy the target-specific variables to the core set
-		err := proptools.AppendMatchingProperties(dst, src, nil)
+		err := AppendMatchingProperties(dst, src)
 		if err != nil {
 			if propertyErr, ok := err.(*proptools.ExtendPropertyError); ok {
 				mctx.PropertyErrorf(propertyErr.Property, "%s", propertyErr.Err.Error())

--- a/core/feature.go
+++ b/core/feature.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Arm Limited.
+ * Copyright 2018-2019, 2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-
-	"github.com/google/blueprint/proptools"
 )
 
 // featurePropertyName returns name of feature. Name needs to start from capital letter because
@@ -183,7 +181,7 @@ func (f *Features) AppendProps(dst []interface{}, properties *configProperties) 
 			// If featureProps is nil then we've determined that we can skip this,
 			// so avoid calling AppendProperties
 			if featureStructPointer != nil {
-				err := proptools.AppendMatchingProperties(dst, featureStructPointer, nil)
+				err := AppendMatchingProperties(dst, featureStructPointer)
 				if err != nil {
 					return err
 				}

--- a/core/library.go
+++ b/core/library.go
@@ -85,7 +85,7 @@ type BuildProps struct {
 	// These are propagated to the closest linking object when specified on static libraries.
 	// shared_libs is an indication that this module is using a shared library, and
 	// users of this module need to link against it.
-	Shared_libs []string
+	Shared_libs []string `bob:"first_overrides"`
 	// The libraries mentioned here will be appended to shared_libs of the modules that use
 	// this library (via static_libs, whole_static_libs or shared_libs).
 	ExtraSharedLibs []string `blueprint:"mutated"`
@@ -94,11 +94,11 @@ type BuildProps struct {
 	// These are propagated to the closest linking object when specified on static libraries.
 	// static_libs is an indication that this module is using a static library, and
 	// users of this module need to link against it.
-	Static_libs []string
+	Static_libs []string `bob:"first_overrides"`
 
 	// This list of dependencies that exported cflags and exported include dirs
 	// should be propagated 1-level higher
-	Reexport_libs []string
+	Reexport_libs []string `bob:"first_overrides"`
 	// Internal property for collecting libraries with reexported flags and include paths
 	ResolvedReexportedLibs []string `blueprint:"mutated"`
 
@@ -108,25 +108,25 @@ type BuildProps struct {
 	// This will include all the objects in the library (as opposed to normal static linking)
 	// If this is set for a static library, any shared library will also include objects
 	// from dependent libraries
-	Whole_static_libs []string
+	Whole_static_libs []string `bob:"first_overrides"`
 
 	// List of libraries to import headers from, but not link to
-	Header_libs []string
+	Header_libs []string `bob:"first_overrides"`
 
 	// List of libraries that users of the current library should import
 	// headers from, but not link to
-	Export_header_libs []string
+	Export_header_libs []string `bob:"first_overrides"`
 
 	// Linker flags required to link to the necessary system libraries
 	// These are propagated to the closest linking object when specified on static libraries.
-	Ldlibs []string
+	Ldlibs []string `bob:"first_overrides"`
 
 	// The list of modules that generate extra headers for this module
-	Generated_headers []string
+	Generated_headers []string `bob:"first_overrides"`
 
 	// The list of modules that generate extra headers for this module,
 	// which should be made available to linking modules
-	Export_generated_headers []string
+	Export_generated_headers []string `bob:"first_overrides"`
 
 	// The list of modules that generate extra source files for this module
 	Generated_sources []string
@@ -135,10 +135,10 @@ type BuildProps struct {
 	Generated_deps []string
 
 	// Include local dirs to be exported into dependent
-	Export_local_include_dirs []string
+	Export_local_include_dirs []string `bob:"first_overrides"`
 
 	// Include dirs (path relative to root) to be exported into dependent
-	Export_include_dirs []string // TODO: Hide this in Android-specific properties
+	Export_include_dirs []string `bob:"first_overrides"`
 
 	// Wrapper for all build commands (object file compilation *and* linking)
 	Build_wrapper *string

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -168,16 +168,17 @@ func Main() {
 	// The depender mutator adds the dependencies between binaries and libraries.
 	//
 	// The generated depender mutator add dependencies to generated source modules.
-	ctx.RegisterBottomUpMutator("default_deps", defaultDepsMutator).Parallel()
+	ctx.RegisterBottomUpMutator("default_deps1", defaultDepsStage1Mutator).Parallel()
+	ctx.RegisterBottomUpMutator("default_deps2", defaultDepsStage2Mutator).Parallel()
 	ctx.RegisterTopDownMutator("features_applier", featureApplierMutator).Parallel()
 	ctx.RegisterTopDownMutator("template_applier", templateApplierMutator).Parallel()
 	ctx.RegisterBottomUpMutator("check_lib_fields", checkLibraryFieldsMutator).Parallel()
 	ctx.RegisterBottomUpMutator("strip_empty_components", stripEmptyComponentsMutator).Parallel()
-	ctx.RegisterTopDownMutator("supported_variants", supportedVariantsMutator).Parallel()
+	ctx.RegisterBottomUpMutator("supported_variants", supportedVariantsMutator).Parallel()
 	ctx.RegisterBottomUpMutator(splitterMutatorName, splitterMutator).Parallel()
 	ctx.RegisterTopDownMutator("target", targetMutator).Parallel()
 	ctx.RegisterBottomUpMutator("process_paths", pathMutator).Parallel()
-	ctx.RegisterTopDownMutator("default_applier", defaultApplierMutator).Parallel()
+	ctx.RegisterBottomUpMutator("default_applier", defaultApplierMutator).Parallel()
 	ctx.RegisterBottomUpMutator("depender", dependerMutator).Parallel()
 	ctx.RegisterBottomUpMutator("alias", aliasMutator).Parallel()
 	ctx.RegisterBottomUpMutator("generated", generatedDependerMutator).Parallel()

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,9 +4,10 @@ Features
 The feature system allows for the possibility of changing aspects of the build
 depending on the configuration.
 
-It provides a way to select flags, source files, includes and others
-by indicating that they should only be included when a certain
-configuration option is enabled.
+It provides a way to select flags, source files, includes and other
+settings by indicating that they should only be included when a
+certain configuration option is enabled. In most cases, the settings
+apply cumulatively.
 
 ## Connection to config system
 
@@ -15,6 +16,7 @@ with the output of the config system. Each config option (e.g. `DEBUG`)
 generates a matching feature (`debug`).
 
 ## How a feature is set and referred to
+
 A feature added to [Mconfig](config_system.md) (e.g. `FOO`)
 becomes `CONFIG_xxx=value` (e.g. `CONFIG_FOO=value`) in
 `$OUT/bob.config`. We can refer to it in Bob modules as follows:
@@ -30,8 +32,14 @@ bob_module_type {
 }
 ```
 
-Where the properties inside `feature_name` are only set if `CONFIG_FOO` is
-enabled in the current configuration.
+Where the properties inside `feature_name` are only set if
+`CONFIG_FOO` is enabled in the current configuration. Feature-specific
+properties have priority over non-feature-specific properties. Note
+that where the same property is specified in multiple feature blocks,
+there is no priority between the blocks. If the property is
+single-valued (like `enabled`) the result is undefined. If the
+property is a list then all elements will be present, but the order is
+undefined.
 
 Here's a more concrete example, with a `DEBUG` option:
 

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -36,8 +36,30 @@ Shared library names must begin with `lib`.
 ----
 ### **bob_module.defaults** (optional)
 
-The list of default properties that should prepended
-to all configuration.
+A list of [`bob_defaults`](bob_defaults.md) modules containing
+configuration required by this module.
+
+The configuration specified by a listed `bob_defaults` module is
+allowed to conflict with another listed module, though this should
+generally be avoided. A conflict can be for a single-valued property
+like `enabled` or `build_wrapper`, or in a list property where a
+particular element may have an opposite meaning (in `cflags`) or
+modify search behaviour (in `include_dirs`).
+
+Configuration in later `bob_defaults` will take priority over
+configuration in earlier ones. In the following example, any conflicts
+between the `generic` and `specific` modules will end up following
+what is set by `specific`.
+
+    defaults: [
+        "generic",
+        "specific",
+    ],
+
+Configuration in the current module will override configuration set
+within a `bob_defaults`. A consequence of this is that where
+`bob_defaults` are nested, the leaf modules have least priority and
+get overriden.
 
 #### Examples:
 
@@ -63,12 +85,8 @@ bob_binary {
 }
 ```
 
-In this example, the `bob_binary` will
-have the flags `-DGLOBAL_FLAG=1 -DMYFLAG=2 -DBINARY_FLAG=3`. The ordering is
-from least to most-specific: Bob will traverse the graph of defaults which a
-module (like `my_binary`) depends on, and prepend flags in breadth-first order.
-This means that flags specified in the actual module can override options set
-in defaults, because later flags usually take precedence.
+In this example, `my_binary` will have the flags `-DGLOBAL_FLAG=1
+-DMYFLAG=2 -DBINARY_FLAG=3`.
 
 ----
 ### **bob_module.srcs** (optional)

--- a/tests/arg_order/build.bp
+++ b/tests/arg_order/build.bp
@@ -1,0 +1,189 @@
+// Test property ordering
+// Check cflag and local_include_path
+// Use a build wrapper
+
+bob_defaults {
+    name: "aa_defaults",
+
+    cflags: [
+        "-aa_flag1",
+        "-aa_flag2",
+    ],
+    local_include_dirs: [
+        "aa_include1",
+        "aa_include2",
+    ],
+}
+
+bob_defaults {
+    name: "ab_defaults",
+
+    cflags: [
+        "-ab_flag1",
+        "-ab_flag2",
+    ],
+    local_include_dirs: [
+        "ab_include1",
+        "ab_include2",
+    ],
+}
+
+bob_defaults {
+    name: "ba_defaults",
+
+    target: {
+        always_enabled_feature: {
+            cflags: [
+                "-batf1_flag",
+                "-batf2_flag",
+            ],
+            local_include_dirs: [
+                "batf1_include",
+                "batf2_include",
+            ],
+        },
+        cflags: [
+            "-batarg1_flag",
+            "-batarg2_flag",
+        ],
+        local_include_dirs: [
+            "batarg1_include",
+            "batarg2_include",
+        ],
+    },
+
+    cflags: [
+        "-ba_flag1",
+        "-ba_flag2",
+    ],
+    local_include_dirs: [
+        "ba_include1",
+        "ba_include2",
+    ],
+}
+
+bob_defaults {
+    name: "bb_defaults",
+
+    target: {
+        always_enabled_feature: {
+            cflags: [
+                "-bbtf1_flag",
+                "-bbtf2_flag",
+            ],
+            local_include_dirs: [
+                "bbtf1_include",
+                "bbtf2_include",
+            ],
+        },
+        cflags: [
+            "-bbtarg1_flag",
+            "-bbtarg2_flag",
+        ],
+        local_include_dirs: [
+            "bbtarg1_include",
+            "bbtarg2_include",
+        ],
+    },
+
+    cflags: [
+        "-bb_flag1",
+        "-bb_flag2",
+    ],
+    local_include_dirs: [
+        "bb_include1",
+        "bb_include2",
+    ],
+}
+
+bob_defaults {
+    name: "a_defaults",
+    defaults: [
+        "aa_defaults",
+        "ab_defaults",
+    ],
+
+    cflags: [
+        "-a_flag1",
+        "-a_flag2",
+    ],
+    local_include_dirs: [
+        "a_include1",
+        "a_include2",
+    ],
+}
+
+bob_defaults {
+    name: "b_defaults",
+    defaults: [
+        "ba_defaults",
+        "bb_defaults",
+    ],
+
+    cflags: [
+        "-b_flag1",
+        "-b_flag2",
+    ],
+    local_include_dirs: [
+        "b_include1",
+        "b_include2",
+    ],
+}
+
+bob_binary {
+    name: "bob_test_arg_order",
+    srcs: ["main.c"],
+    build_wrapper: "arg_order/check_flags.py",
+
+    defaults: [
+        "a_defaults",
+        "b_defaults",
+    ],
+
+    always_enabled_feature: {
+        cflags: [
+            "-binfeat1_flag",
+            "-binfeat2_flag",
+        ],
+        local_include_dirs: [
+            "binfeat1_include",
+            "binfeat2_include",
+        ],
+    },
+
+    target: {
+        always_enabled_feature: {
+            cflags: [
+                "-bintf1_flag",
+                "-bintf2_flag",
+            ],
+            local_include_dirs: [
+                "bintf1_include",
+                "bintf2_include",
+            ],
+        },
+        cflags: [
+            "-bintarg1_flag",
+            "-bintarg2_flag",
+        ],
+        local_include_dirs: [
+            "bintarg1_include",
+            "bintarg2_include",
+        ],
+    },
+
+    cflags: [
+        "-bin_flag1",
+        "-bin_flag2",
+    ],
+    local_include_dirs: [
+        "bin_include1",
+        "bin_include2",
+    ],
+    android: {
+        // Soong checks that all the local_include_dirs exist, so
+        // disable this test on Android. The logic is in generic
+        // code, so testing on Linux should be sufficient.
+        enabled: false,
+    },
+}

--- a/tests/arg_order/check_flags.py
+++ b/tests/arg_order/check_flags.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python
+
+# Copyright 2021 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import sys
+
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args():
+    # Dump all args into a dictionary returning the position of the
+    # last copy of that arg.
+    #
+    # For include arguments, strip any intermediate directories (all
+    # our local includes directories are leaves)
+    #
+    # Return information on whether this command is link, and also
+    # what the output file is.
+
+    args = dict()
+    link = True
+    output = None
+
+    skiparg = False
+    for i, arg in enumerate(sys.argv[1:]):
+        if skiparg:
+            skiparg = False
+            continue
+
+        if arg == "-c":
+            link = False
+        elif arg == "-o":
+            output = sys.argv[i+2]
+        elif arg.startswith("-I"):
+            if len(arg) > 2:
+                includedir = arg[2:]
+            else:
+                # Handle "-I includedir", merging to a single arg
+                includedir = sys.argv[i+2]
+                skiparg = True
+
+            arg = "-I{}".format(os.path.basename(includedir))
+        args[arg] = i
+
+    return (link, output, args)
+
+
+def find_range(args, subset):
+    """
+    Return inclusive range, (first, last), of the elements of `subset` in
+    the dictionary `args`.
+    """
+    first = 65536
+    last = -1
+    for a in subset:
+        if a in args:
+            if args[a] < first:
+                first = args[a]
+            if args[a] > last:
+                last = args[a]
+        else:
+            logger.error("%s not in args", a)
+    return (first, last)
+
+
+def check_set1_before_set2(args, set1, set2):
+    """
+    Check all set1 arguments occur before set2 in args
+    """
+    _, s1_last = find_range(args, set1)
+    s2_first, _ = find_range(args, set2)
+    return s1_last < s2_first
+
+
+class mod:
+
+    def __init__(self, name, cflags, includes, defaults, **kwargs):
+        self.name = name
+        self.cflags = cflags
+        self.includes = ['-I'+inc for inc in includes]
+        self.defaults = defaults
+        self.feature_cflags = []
+        self.feature_includes = []
+        self.target_cflags = []
+        self.target_includes = []
+        self.target_feature_cflags = []
+        self.target_feature_includes = []
+
+        if 'feature_cflags' in kwargs:
+            self.feature_cflags = kwargs['feature_cflags']
+        if 'target_cflags' in kwargs:
+            self.target_cflags = kwargs['target_cflags']
+        if 'target_feature_cflags' in kwargs:
+            self.target_feature_cflags = kwargs['target_feature_cflags']
+        if 'feature_includes' in kwargs:
+            self.feature_includes = ['-I'+inc for inc in kwargs['feature_includes']]
+        if 'target_includes' in kwargs:
+            self.target_includes = ['-I'+inc for inc in kwargs['target_includes']]
+        if 'target_feature_includes' in kwargs:
+            self.target_feature_includes = ['-I'+inc for inc in kwargs['target_feature_includes']]
+
+    def find_flags(self, args):
+        """
+        Return the range (inclusive) for this module's cflags
+        """
+        return find_range(args, self.cflags + self.feature_cflags +
+                          self.target_cflags + self.target_feature_cflags)
+
+    def find_includes(self, args):
+        """
+        Return the range (inclusive) for this module's includes
+        """
+        return find_range(args, self.includes + self.feature_includes +
+                          self.target_includes + self.target_feature_includes)
+
+    def find_flags_recursive(self, args):
+        """
+        Return the range (inclusive) for this module's cflags, and all its
+        dependencies
+        """
+        first, last = self.find_flags(args)
+        for sub in self.defaults:
+            (sub_first, sub_last) = sub.find_flags_recursive(args)
+            if sub_first < first:
+                first = sub_first
+            if sub_last > last:
+                last = sub_last
+
+        return (first, last)
+
+    def find_includes_recursive(self, args):
+        """
+        Return the range (inclusive) for this module's includes and all
+        its dependencies
+        """
+        (first, last) = self.find_includes(args)
+        for sub in self.defaults:
+            (sub_first, sub_last) = sub.find_includes_recursive(args)
+            if sub_first < first:
+                first = sub_first
+            if sub_last > last:
+                last = sub_last
+
+        return (first, last)
+
+    def check_order_maintained(self, all_args, args):
+        """
+        Check that args occur in the same order in all_args.
+        """
+        result = True
+        for i, f1 in enumerate(args):
+            if f1 not in all_args:
+                logger.error("%s not in args", f1)
+                result = False
+                continue
+
+            for f2 in args[i+1:]:
+                if f2 not in all_args:
+                    logger.error("%s not in args", f2)
+                    result = False
+                    continue
+
+                if all_args[f1] >= all_args[f2]:
+                    logger.error("Module %s arguments out of order %s vs %s", self.name, f1, f2)
+                    result = False
+
+        return result
+
+    def check_flags(self, args):
+        """
+        Check this module's flags are in the expected order, then check
+        that the child modules' flags are in order. Finally check the
+        child modules' flags relative to each other.
+        """
+        result = True
+
+        # Flags for just this module are in the same order
+        if not self.check_order_maintained(args, self.cflags):
+            result = False
+
+        # Feature-specific cflags
+        if not self.check_order_maintained(args, self.feature_cflags):
+            logger.error("Module %s feature-specific flag order not maintained",
+                         self.name)
+            result = False
+        if not check_set1_before_set2(args, self.cflags, self.feature_cflags):
+            logger.error("Module %s feature-specific flags not overriding normal flags",
+                         self.name)
+            result = False
+
+        # Target-specific cflags
+        if not self.check_order_maintained(args, self.target_cflags):
+            logger.error("Module %s target-specific flag order not maintained",
+                         self.name)
+            result = False
+        if not check_set1_before_set2(args, self.cflags, self.target_cflags):
+            logger.error("Module %s target-specific flags not overriding normal flags",
+                         self.name)
+            result = False
+
+        # Target-and-feature-specific cflags
+        if not self.check_order_maintained(args, self.target_feature_cflags):
+            logger.error("Module %s target-and-feature-specific flag order not maintained",
+                         self.name)
+            result = False
+        if not check_set1_before_set2(args, self.cflags, self.target_feature_cflags):
+            logger.error(
+                "Module %s flags target-and-feature-specific not overriding normal",
+                self.name)
+            result = False
+        if not check_set1_before_set2(args, self.feature_cflags, self.target_feature_cflags):
+            logger.error(
+                "Module %s flags target-and-feature-specific not overriding feature-specific",
+                self.name)
+            result = False
+        if not check_set1_before_set2(args, self.target_cflags, self.target_feature_cflags):
+            logger.error(
+                "Module %s flags target-and-feature-specific not overriding target-specific",
+                self.name)
+            result = False
+
+        # Check each child module's flags
+        for sub in self.defaults:
+            if sub.check_flags(args) != 0:
+                result = False
+
+        # Check child module flag ordering
+        last_sub_flag = -1
+        for i, sub1 in enumerate(self.defaults):
+            (sub1_first, sub1_last) = sub1.find_flags_recursive(args)
+            if sub1_last > last_sub_flag:
+                last_sub_flag = sub1_last
+            for sub2 in self.defaults[i+1:]:
+                (sub2_first, sub2_last) = sub2.find_flags_recursive(args)
+                if sub1_last >= sub2_first:
+                    logger.error("Module %s submodules %s and %s flags out of order",
+                                 self.name, sub1.name, sub2.name)
+                    result = False
+
+        # Check this module's flags are after all submodule flags
+        first_flag, _ = self.find_flags(args)
+        if first_flag <= last_sub_flag:
+            logger.error("Module %s module flags not overriding submodule flags",
+                         self.name)
+            result = False
+
+        return result
+
+    def check_includes(self, args):
+        """
+        Check this module's includes are in the expected order, then check
+        that the child modules' includes are in order. Finally check
+        the child modules' includes relative to each other.
+        """
+        result = True
+
+        # Includes for just this module are in the same order
+        if not self.check_order_maintained(args, self.includes):
+            result = False
+
+        # Feature-specific includes
+        if not self.check_order_maintained(args, self.feature_includes):
+            logger.error("Module %s feature-specific include order not maintained",
+                         self.name)
+            result = False
+        if not check_set1_before_set2(args, self.feature_includes, self.includes):
+            logger.error("Module %s feature-specific includes not overriding normal includes",
+                         self.name)
+            result = False
+
+        # Target-specific includes
+        if not self.check_order_maintained(args, self.target_includes):
+            logger.error("Module %s target-specific include order not maintained",
+                         self.name)
+            result = False
+        if not check_set1_before_set2(args, self.target_includes, self.includes):
+            logger.error("Module %s target-specific includes not overriding normal includes",
+                         self.name)
+            result = False
+
+        # Target-and-feature-specific includes
+        if not self.check_order_maintained(args, self.target_feature_includes):
+            logger.error("Module %s target-and-feature-specific include order not maintained",
+                         self.name)
+            result = False
+        if not check_set1_before_set2(args, self.target_feature_includes, self.includes):
+            logger.error(
+                "Module %s includes target-and-feature-specific not overriding normal",
+                self.name)
+            result = False
+        if not check_set1_before_set2(args, self.target_feature_includes, self.feature_includes):
+            logger.error(
+                "Module %s includes target-and-feature-specific not overriding feature-specific",
+                self.name)
+            result = False
+        if not check_set1_before_set2(args, self.target_feature_includes, self.target_includes):
+            logger.error(
+                "Module %s includes target-and-feature-specific not overriding target-specific",
+                self.name)
+            result = False
+
+        # Check each child module's includes
+        for sub in self.defaults:
+            if sub.check_includes(args) != 0:
+                result = False
+
+        # Check child module include ordering
+        first_sub_include = 65536
+        for i, sub1 in enumerate(self.defaults):
+            (sub1_first, sub1_last) = sub1.find_includes_recursive(args)
+            if sub1_first < first_sub_include:
+                first_sub_include = sub1_first
+            for sub2 in self.defaults[i+1:]:
+                (sub2_first, sub2_last) = sub2.find_includes_recursive(args)
+                # sub2 includes must be before sub1 includes
+                if sub1_first <= sub2_last:
+                    logger.error("Module %s submodules %s and %s includes out of order",
+                                 self.name, sub1.name, sub2.name)
+                    result = False
+
+        # Check this module's includes are before all submodule includes
+        last_include, _ = self.find_includes(args)
+        if last_include >= first_sub_include:
+            logger.error("Module %s module includes not overriding submodule includes",
+                         self.name)
+            result = False
+
+        return result
+
+
+def check_args(args):
+    # The default structure looks like:
+    #
+    #         bin
+    #       /     \
+    #     a         b
+    #   /   \     /   \
+    # aa     ab ba     bb
+    #
+    # arguments specified in a single cflags [] should not be reordered.
+    #
+    # cflags in defaults at the same level should be in the order of
+    # the defaults. i.e. a's cflags first, then b's cflags.
+    #
+    # defaults higher in the hierarchy have precedence, so bin's
+    # cflags must come last, and a's cflags before aa and ab's.
+    #
+    aa = mod("aa",
+             ["-aa_flag1", "-aa_flag2"],
+             ["aa_include1", "aa_include2"],
+             [])
+    ab = mod("ab",
+             ["-ab_flag1", "-ab_flag2"],
+             ["ab_include1", "ab_include2"],
+             [])
+    ba = mod("ba",
+             ["-ba_flag1", "-ba_flag2"],
+             ["ba_include1", "ba_include2"],
+             [],
+             target_flags=["-batarg1_flag", "-batarg2_flag"],
+             target_feature_flags=["-batf1_flag", "batf2_flag"],
+             target_includes=["batarg1_include", "batarg2_include"],
+             target_feature_includes=["batf1_include", "batf2_include"])
+    bb = mod("bb",
+             ["-bb_flag1", "-bb_flag2"],
+             ["bb_include1", "bb_include2"],
+             [],
+             target_flags=["-bbtarg1_flag", "-bbtarg2_flag"],
+             target_feature_flags=["-bbtf1_flag", "bbtf2_flag"],
+             target_includes=["bbtarg1_include", "bbtarg2_include"],
+             target_feature_includes=["bbtf1_include", "bbtf2_include"])
+    a = mod("a",
+            ["-a_flag1", "-a_flag2"],
+            ["a_include1", "a_include2"],
+            [aa, ab])
+    b = mod("b",
+            ["-b_flag1", "-b_flag2"],
+            ["b_include1", "b_include2"],
+            [ba, bb])
+    bin = mod("bin",
+              ["-bin_flag1", "-bin_flag2"],
+              ["bin_include1", "bin_include2"],
+              [a, b],
+              feature_flags=["-binfeat1_flag", "-binfeat2_flag"],
+              target_flags=["-bintarg1_flag", "-bintarg2_flag"],
+              target_feature_flags=["-bintf1_flag", "bintf2_flag"],
+              feature_includes=["binfeat1_include", "binfeat2_include"],
+              target_includes=["bintarg1_include", "bintarg2_include"],
+              target_feature_includes=["bintf1_include", "bintf2_include"])
+    r1 = bin.check_flags(args)
+    r2 = bin.check_includes(args)
+    return r1 and r2
+
+
+def main():
+    link, output, args = parse_args()
+    result = 0
+    if not link:
+        if check_args(args):
+            result = 0
+        else:
+            result = 1
+
+    if not output:
+        logging.error("No output specified")
+        result = 1
+
+    if result == 0:
+        # Ensure we update the write time on the output file
+        # No need to actually call the compiler
+        try:
+            os.utime(output, None)
+        except OSError:
+            open(output, 'a').close()
+    return result
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARNING)
+
+    sys.exit(main())

--- a/tests/arg_order/main.c
+++ b/tests/arg_order/main.c
@@ -1,0 +1,4 @@
+int main()
+{
+	return 0;
+}

--- a/tests/bplist
+++ b/tests/bplist
@@ -1,4 +1,5 @@
 ./aliases/build.bp
+./arg_order/build.bp
 ./binary/build.bp
 ./bob/Blueprints
 ./bob/blueprint/Blueprints

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,6 +61,7 @@ bob_alias {
     srcs: [
         "bob_test_aliases",
         "bob_test_aliases_all_variants",
+        "bob_test_arg_order",
         "bob_test_command_vars",
         "bob_test_cxx11simple",
         "bob_test_encapsulates",


### PR DESCRIPTION
cflag and include ordering in defaults is currently inconsistent. This
commit attempts to fix this.

In a hierarchy of defaults, a->b->c, the fields set in leaf nodes (c)
have the lowest priority. Therefore cflags from b must follow cflags
from c (which is currently the case). Include paths from b must come
before include paths from c (this is not currently the case).

In sibling defaults, ["a", "b", "c"], the last element overrides
earlier elements. Therefore cflags from b must follow cflags from a
(this is not currently the case). Include paths from b must come
before include paths from a (which is currently the case).

Address the fact that cflag and include properties have different
ordering requirements by adding field tags to fields read by
Blueprint. The common case for properties is cflag orderring (later
elements override earlier elements), so use the tag
`bob:"first_overrides"` to identify where include orderring is needed.
Note that where libraries are specified through defaults, these also
want include ordering - as the linker is searching for symbols in
libraries in the specified order. For static libraries this will be
overriden if library dependency information is available.

Define functions to select orderring based on the field tag.

Modify the DefaultApplierMutator to separate hierarchical and sibling
propagation.

It's possible that a defaults module occurs more than once within a
defaults hierarchy. When this happens we want to avoid repeating
includes/cflags etc more than once on the command line.

In order to accomplish this, expand the defaults used by each module
into a flat list (maintaining priority order), and tell Blueprint
about this list instead of the full hierarchy.

When expanding properties, we don't need to expand properties on
defaults modules - as the proper modules will always go directly to
each defaults modules to get the required property.

Add a new test to check cflag and include orderring.

Features and Targets are updated to use the same Append functions.

The SupportedVariants mutator is updated to use the same algorithm as
the DefaultApplierMutator. This required updating
defaults.getSplittableProps() to return the right properties instead
of a zero initialised structure.

Change-Id: I396738ede096cad45117cb9a35d794ad237b840c
Signed-off-by: David Kilroy <david.kilroy@arm.com>