### PR TITLE
Remove "specials" support

### DIFF
--- a/core/android_make.go
+++ b/core/android_make.go
@@ -234,7 +234,7 @@ func androidLibraryBuildAction(sb *strings.Builder, mod blueprint.Module, ctx bl
 	} else {
 		sb.WriteString("LOCAL_CLANG := false\n")
 	}
-	srcs := utils.NewStringSlice(m.Properties.getSources(ctx), m.Properties.Build.SourceProps.Specials)
+	srcs := m.Properties.getSources(ctx)
 
 	// Remove sources which are not compiled
 	nonCompiledDeps := utils.Filter(utils.IsNotCompilableSource, srcs)
@@ -364,8 +364,6 @@ func androidLibraryBuildAction(sb *strings.Builder, mod blueprint.Module, ctx bl
 		if m.Properties.Post_install_cmd != nil {
 			// Setup args like we do for bob_generated_*
 			args := map[string]string{}
-			args["bob_config"] = configFile
-			args["bob_config_json"] = configJSONFile
 			if m.Properties.Post_install_tool != nil {
 				args["tool"] = *m.Properties.Post_install_tool
 			}

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -243,9 +243,6 @@ type SourceProps struct {
 	Srcs []string
 	// The list of source files that should not be included. Use with care.
 	Exclude_srcs []string
-
-	// Sources that we need to treat specially
-	Specials []string `blueprint:"mutated"`
 }
 
 // IncludeDirsProps defines a set of properties for including directories
@@ -270,27 +267,7 @@ func (s *SourceProps) getSources(ctx blueprint.BaseModuleContext) []string {
 
 func (s *SourceProps) processPaths(ctx blueprint.BaseModuleContext, g generatorBackend) {
 	prefix := projectModuleDir(ctx)
-	var special = map[string]string{
-		"${bob_config}":      configFile,
-		"${bob_config_json}": configJSONFile,
-	}
-
-	// Look for special items. Remove from Srcs and add to Specials
-	srcs := []string{}
-	for _, src := range s.Srcs {
-		if value, ok := special[src]; !ok {
-			srcs = append(srcs, src)
-		} else {
-			// Only append if not in Excluded.
-			// Users shouldn't rely on how any special is expanded, so
-			// no need to check the expanded case.
-			if !utils.Contains(s.Exclude_srcs, src) {
-				s.Specials = append(s.Specials, value)
-			}
-		}
-	}
-
-	s.Srcs = utils.PrefixDirs(srcs, prefix)
+	s.Srcs = utils.PrefixDirs(s.Srcs, prefix)
 	s.Exclude_srcs = utils.PrefixDirs(s.Exclude_srcs, prefix)
 }
 

--- a/core/linux_backend.go
+++ b/core/linux_backend.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -252,8 +252,6 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 		// Expand args immediately
 		cmd = strings.Replace(cmd, "${args}", strings.Join(props.Post_install_args, " "), -1)
 
-		args["bob_config"] = configFile
-		args["bob_config_json"] = configJSONFile
 		if props.Post_install_tool != nil {
 			args["tool"] = *props.Post_install_tool
 			deps = append(deps, *props.Post_install_tool)

--- a/core/linux_cclibs.go
+++ b/core/linux_cclibs.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -160,7 +160,6 @@ func (l *library) CompileObjs(ctx blueprint.ModuleContext) ([]string, []string) 
 // Returns all the source files for a C/C++ library. This includes any sources that are generated.
 func (l *library) GetSrcs(ctx blueprint.ModuleContext) []string {
 	srcs := l.Properties.getSources(ctx)
-	srcs = append(srcs, l.Properties.Build.SourceProps.Specials...)
 
 	ctx.VisitDirectDepsIf(
 		func(m blueprint.Module) bool { return ctx.OtherModuleDependencyTag(m) == generatedSourceTag },

--- a/core/linux_kernel_module.go
+++ b/core/linux_kernel_module.go
@@ -59,7 +59,6 @@ func (g *linuxGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.Modu
 	delete(args, "kmod_build")
 	sources := utils.NewStringSlice(
 		getBackendPathsInSourceDir(g, m.Properties.getSources(ctx)),
-		m.Properties.SourceProps.Specials,
 		m.extraSymbolsFiles(ctx))
 
 	ctx.Build(pctx,

--- a/docs/module_types/common_generate_module_properties.md
+++ b/docs/module_types/common_generate_module_properties.md
@@ -29,6 +29,14 @@ available substitutions are:
 - `${(name)_out}` - the outputs of the `generated_deps` dependency with `name`
 - `${src_dir}` - the path to the project source directory - this will be different
   than the build source directory for Android.
+- `${bob_config}` - the Bob configuration file. When used, a depfile must be
+  generated naming the config file as a dependency to ensure the rule is
+  correctly rerun when the configuration changes.
+- `${bob_config_json}` - the Bob configuration JSON file, intended for use
+  by tools that just need to read configuration values without having to know
+  about the config system. When used, a depfile must be generated naming the
+  config file as a dependency to ensure the rule is correctly rerun when the
+  configuration changes.
 
 The value in `cmd` is executed by the shell. Compound shell
 expressions and expansions can be used, though we recommend keeping

--- a/docs/module_types/common_module_properties.md
+++ b/docs/module_types/common_module_properties.md
@@ -368,10 +368,6 @@ are substituted into the command:
 
 - `${tool}` - the tool specified in `bob_module.post_install_tool`.
 - `${out}` - the output file(s) of the current module.
-- `${bob_config}` - the Bob configuration file.
-- `${bob_config_json}` - the Bob configuration JSON file, intended for use
-  by tools that just need to read configuration values without having to
-  know about the config system.
 - `${args}` - arguments from `post_install_args`
 
 Not supported on Android.bp.

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -208,13 +208,22 @@ func Reversed(in []string) []string {
 	return out
 }
 
+// `cmd` is the command that will be executed
+// Return true if it contains a reference to the argument expansion `arg`
+func ContainsArg(cmd string, k string) bool {
+	// argument ref can be done as ${arg} or $arg
+	if strings.Contains(cmd, "${"+k+"}") || strings.Contains(cmd, "$"+k) {
+		return true
+	}
+	return false
+}
+
 // cmd is the command that will be executed
 // args contains potential argument that may occur in ${}
 // This function will remove unused arguments from the map
 func StripUnusedArgs(args map[string]string, cmd string) {
 	for k := range args {
-		// argument ref can be done as ${arg} or $arg
-		if !strings.Contains(cmd, "${"+k+"}") && !strings.Contains(cmd, "$"+k) {
+		if !ContainsArg(cmd, k) {
 			delete(args, k)
 		}
 	}


### PR DESCRIPTION
Remove support for the `${bob_config}` and `${bob_config_json}`
expansions when used in `srcs`. This is required because Soong does not
accept `srcs` entries that are outside of the source directory, and
therefore this functionality cannot be implemented on `Android.bp`.

The expansions may still be used in `cmd`. However, a depfile must
always be used so that dependencies are tracked correctly. Enforce this
with a new check on all three backends.

Also remove the use of the same expansions in `post_install_cmd`,
because post install commands are also not supported on Soong, and in
any case do not support depfiles.

Change-Id: I9c9f8b77f5881a2c5cc15f6b40a35aa4bbb99486
Signed-off-by: Chris Diamand <chris.diamand@arm.com>