### PR TITLE
Move `getTarget` into `splittable`

### DIFF
--- a/core/external_library.go
+++ b/core/external_library.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 Arm Limited.
+ * Copyright 2019-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,8 @@ type ExternalLibProps struct {
 	Export_cflags  []string
 	Export_ldflags []string
 	Ldlibs         []string
+
+	TargetType tgtType `blueprint:"mutated"`
 }
 
 type externalLib struct {
@@ -55,7 +57,8 @@ func (m *externalLib) implicitOutputs() []string { return []string{} }
 // Implement the splittable interface so "normal" libraries can depend on external ones.
 func (m *externalLib) supportedVariants() []tgtType         { return []tgtType{tgtTypeHost, tgtTypeTarget} }
 func (m *externalLib) disable()                             {}
-func (m *externalLib) setVariant(tgtType)                   {}
+func (m *externalLib) setVariant(tgt tgtType)               { m.Properties.TargetType = tgt }
+func (m *externalLib) getTarget() tgtType                   { return m.Properties.TargetType }
 func (m *externalLib) getSplittableProps() *SplittableProps { return &SplittableProps{} }
 
 // Implement the propertyExporter interface so that external libraries can pass
@@ -69,6 +72,7 @@ func (m *externalLib) exportLdlibs() []string           { return m.Properties.Ld
 func (m *externalLib) exportSharedLibs() []string       { return []string{} }
 
 var _ propertyExporter = (*externalLib)(nil)
+var _ splittable = (*externalLib)(nil)
 
 // External libraries have no actions - they are already built.
 func (m *externalLib) GenerateBuildActions(ctx blueprint.ModuleContext) {}

--- a/core/gen_binary.go
+++ b/core/gen_binary.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,7 @@ type generateBinary struct {
 // Verify that the following interfaces are implemented
 var _ generateLibraryInterface = (*generateBinary)(nil)
 var _ singleOutputModule = (*generateBinary)(nil)
+var _ splittable = (*generateBinary)(nil)
 var _ blueprint.Module = (*generateBinary)(nil)
 
 func (m *generateBinary) generateInouts(ctx blueprint.ModuleContext, g generatorBackend) []inout {

--- a/core/gen_shared.go
+++ b/core/gen_shared.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,7 @@ type generateSharedLibrary struct {
 var _ generateLibraryInterface = (*generateSharedLibrary)(nil)
 var _ singleOutputModule = (*generateSharedLibrary)(nil)
 var _ sharedLibProducer = (*generateSharedLibrary)(nil)
+var _ splittable = (*generateSharedLibrary)(nil)
 var _ blueprint.Module = (*generateSharedLibrary)(nil)
 
 func (m *generateSharedLibrary) generateInouts(ctx blueprint.ModuleContext, g generatorBackend) []inout {

--- a/core/gen_static.go
+++ b/core/gen_static.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2021 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,7 @@ type generateStaticLibrary struct {
 // Verify that the following interfaces are implemented
 var _ generateLibraryInterface = (*generateStaticLibrary)(nil)
 var _ singleOutputModule = (*generateStaticLibrary)(nil)
+var _ splittable = (*generateStaticLibrary)(nil)
 var _ blueprint.Module = (*generateStaticLibrary)(nil)
 
 func (m *generateStaticLibrary) generateInouts(ctx blueprint.ModuleContext, g generatorBackend) []inout {

--- a/core/library.go
+++ b/core/library.go
@@ -310,6 +310,7 @@ var _ enableable = (*library)(nil)
 var _ propertyExporter = (*library)(nil)
 var _ matchSourceInterface = (*library)(nil)
 var _ propertyEscapeInterface = (*library)(nil)
+var _ splittable = (*library)(nil)
 var _ aliasable = (*library)(nil)
 
 func (l *library) defaults() []string {

--- a/core/splitter.go
+++ b/core/splitter.go
@@ -43,6 +43,9 @@ type splittable interface {
 	// Set the particular variant
 	setVariant(tgtType)
 
+	// Retrieve the module target type variant as set by setVariant
+	getTarget() tgtType
+
 	// Get the properties related to which variants are available
 	getSplittableProps() *SplittableProps
 }
@@ -51,9 +54,6 @@ type splittable interface {
 // for host and target.
 type targetSpecificLibrary interface {
 	splittable
-
-	// Get module target type
-	getTarget() tgtType
 
 	// Get the target specific properties i.e. host:{} or target:{}
 	getTargetSpecific(tgtType) *TargetSpecific


### PR DESCRIPTION
Modules that can be split into target and host-specific variants must
also support a method to discover which variant they are, so move the
corresponding `getTarget` method into `splittable`.

Add a property to external libraries to allow them to remember which
variant they have been set to. The other splittable types (generated
libraries/binaries, and normal libraries/binaries) already support this,
so are unaffected.

Change-Id: Id89edc088386fbde32664ce6a4d5f9a94b4b6795
Signed-off-by: Chris Diamand <chris.diamand@arm.com>