### PR TITLE
Separate target-specific static lib processing

### DIFF
--- a/core/standalone.go
+++ b/core/standalone.go
@@ -190,7 +190,12 @@ func Main() {
 	} else {
 
 		ctx.RegisterTopDownMutator("export_lib_flags", exportLibFlagsMutator).Parallel()
-		dependencyGraphHandler := graphMutatorHandler{graph.NewGraph("All")}
+		dependencyGraphHandler := graphMutatorHandler{
+			map[tgtType]graph.Graph{
+				tgtTypeHost:   graph.NewGraph("All"),
+				tgtTypeTarget: graph.NewGraph("All"),
+			},
+		}
 		ctx.RegisterBottomUpMutator("sort_resolved_static_libs",
 			dependencyGraphHandler.ResolveDependencySortMutator) // This can't be parallel
 		ctx.RegisterTopDownMutator("find_required_modules",

--- a/tests/bplist
+++ b/tests/bplist
@@ -38,6 +38,7 @@
 ./shared_libs_toc/build.bp
 ./source_encapsulation/build.bp
 ./static_libs/build.bp
+./target_specific_static_libs/build.bp
 ./templates/build.bp
 ./transform_source/build.bp
 ./version_script/build.bp

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -90,6 +90,7 @@ bob_alias {
         "bob_test_simple_binary",
         "bob_test_source_encapsulation",
         "bob_test_static_libs",
+        "bob_test_target_specific_static_libs",
         "bob_test_templates",
         "bob_test_transform_source",
         "bob_test_version_script",

--- a/tests/target_specific_static_libs/build.bp
+++ b/tests/target_specific_static_libs/build.bp
@@ -1,0 +1,39 @@
+bob_static_library {
+    name: "libonly_works_on_target",
+    srcs: ["fail_when_FAIL_is_1.c"],
+    host_supported: true,
+    target_supported: true,
+    host: {
+        cflags: ["-DFAIL=1"],
+    },
+    target: {
+        cflags: ["-DFAIL=0"],
+    },
+}
+
+bob_static_library {
+    name: "libuses_target_specific_link",
+    srcs: ["dummy.c"],
+    host_supported: true,
+    target_supported: true,
+    target: {
+        static_libs: ["libonly_works_on_target"],
+    },
+}
+
+bob_binary {
+    name: "bob_test_target_specific_link",
+    srcs: ["main.c"],
+    static_libs: ["libuses_target_specific_link"],
+    host_supported: true,
+    target_supported: true,
+    build_by_default: true,
+}
+
+bob_alias {
+    name: "bob_test_target_specific_static_libs",
+    srcs: [
+        "bob_test_target_specific_link:host",
+        "bob_test_target_specific_link:target",
+    ],
+}

--- a/tests/target_specific_static_libs/fail_when_FAIL_is_1.c
+++ b/tests/target_specific_static_libs/fail_when_FAIL_is_1.c
@@ -1,0 +1,3 @@
+#if FAIL == 1
+#error "This must not be built"
+#endif

--- a/tests/target_specific_static_libs/main.c
+++ b/tests/target_specific_static_libs/main.c
@@ -1,0 +1,3 @@
+int main(void) {
+    return 0;
+}


### PR DESCRIPTION
The graph traversal algorithm for optimal static library ordering
currently uses the same `graph.Graph` instance instance for both target
and host libraries. This means that libraries which should only be
pulled in on one target type may end up incorrectly included on the
other.

This is obviously wrong - in particular on Android, where there are lots
of system libraries on the target which may not be present on the host.

Fix this by using two different `graph.Graph` instances to calculate the
static library ordering.

Add a test case.

Change-Id: Ib5c4b969b168d6a11f595b3c9369dee8d57a34f7
Signed-off-by: Chris Diamand <chris.diamand@arm.com>