### PR TITLE
Hash the whole bootstrap environment

### DIFF
--- a/scripts/env_hash.py
+++ b/scripts/env_hash.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2018-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,9 +46,19 @@ def hash_env():
 
         # bob-build
         "BOB_ALWAYS_LINK_SHARED_LIBS",
+        "BOB_BOOTSTRAP_VERSION",
+        "BOB_CONFIG_OPTS",
+        "BOB_CONFIG_PLUGIN_OPTS",
         "BOB_CPUPROFILE",
+        "BOB_DIR",
         "BOB_LINK_PARALLELISM",
         "BOB_VERSION",
+        "BUILDDIR",
+        "CONFIG_FILE",
+        "CONFIG_JSON",
+        "SRCDIR",
+        "TOPNAME",
+        "WORKDIR",
 
         # go
         "GO386",


### PR DESCRIPTION
Ensure that any change to the `.bob.bootstrap` file results in a
regeneration of the Ninja or Android.bp output, by including all the
relevant environment variables in `env_hash.py`'s allowlist.

Change-Id: I6873f7a083a5b8c29de7321d6c89995760840091
Signed-off-by: Chris Diamand <chris.diamand@arm.com>