### PR TITLE
Support MTE

### DIFF
--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/google/blueprint"
+	"github.com/google/blueprint/proptools"
 
 	"github.com/ARM-software/bob-build/internal/bpwriter"
 	"github.com/ARM-software/bob-build/internal/ccflags"
@@ -147,6 +148,23 @@ func addPGOProps(m bpwriter.Module, props AndroidPGOProps) {
 	g.AddOptionalBool("enable_profile_use", props.Pgo.Enable_profile_use)
 
 	g.AddStringList("cflags", props.Pgo.Cflags)
+}
+
+func addMTEProps(m bpwriter.Module, props AndroidMTEProps) {
+	memtagHeap := proptools.Bool(props.Mte.Memtag_heap)
+	diagMemtagHeap := proptools.Bool(props.Mte.Diag_memtag_heap)
+
+	if !memtagHeap {
+		return
+	}
+
+	g := m.NewGroup("sanitize")
+	g.AddBool("memtag_heap", true)
+
+	if diagMemtagHeap {
+		diag := g.NewGroup("diag")
+		diag.AddBool("memtag_heap", true)
+	}
 }
 
 func addRequiredModules(m bpwriter.Module, l library, mctx blueprint.ModuleContext) {
@@ -280,6 +298,8 @@ func addBinaryProps(m bpwriter.Module, l binary, mctx blueprint.ModuleContext) {
 			g.NewGroup("lib64").AddString("relative_install_path", installRel+"64")
 		}
 	}
+
+	addMTEProps(m, l.Properties.Build.AndroidMTEProps)
 }
 
 func addStaticOrSharedLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContext) {

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -151,6 +151,14 @@ type AndroidPGOProps struct {
 	}
 }
 
+// AndroidMTEProps defines properties used to enable the Arm Memory Tagging Extension
+type AndroidMTEProps struct {
+	Mte struct {
+		Memtag_heap      *bool
+		Diag_memtag_heap *bool
+	}
+}
+
 func getBobScriptsDir() string {
 	return filepath.Join(getBobDir(), "scripts")
 }

--- a/core/library.go
+++ b/core/library.go
@@ -162,6 +162,7 @@ type BuildProps struct {
 
 	StripProps
 	AndroidPGOProps
+	AndroidMTEProps
 
 	TargetType tgtType `blueprint:"mutated"`
 }
@@ -843,10 +844,14 @@ func checkLibraryFieldsMutator(mctx blueprint.BottomUpMutatorContext) {
 	} else if sl, ok := m.(*sharedLibrary); ok {
 		props := sl.Properties
 		sl.checkField(len(props.Export_ldflags) == 0, "export_ldflags")
+		sl.checkField(props.Mte.Memtag_heap == nil, "memtag_heap")
+		sl.checkField(props.Mte.Diag_memtag_heap == nil, "memtag_heap")
 	} else if sl, ok := m.(*staticLibrary); ok {
 		props := sl.Properties
 		sl.checkField(props.Forwarding_shlib == nil, "forwarding_shlib")
 		sl.checkField(props.Version_script == nil, "version_script")
+		sl.checkField(props.Mte.Memtag_heap == nil, "memtag_heap")
+		sl.checkField(props.Mte.Diag_memtag_heap == nil, "memtag_heap")
 	}
 }
 


### PR DESCRIPTION
Add support for setting the Android.bp options that enable the Memory
Tagging Extension (MTE) on ARMv9 builds.

This is only applicable to binaries, so ignore the option on other
module types, and error when it is set directly on e.g. a library.

Signed-off-by: Chris Diamand <chris.diamand@arm.com>
Change-Id: I445a28f6943f639f79902eeef2b9f17357e31245