### PR TITLE
Make test for $NINJA in bob.bootstrap.in safer

### DIFF
--- a/bob.bootstrap.in
+++ b/bob.bootstrap.in
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2019, 2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 # to `ninja`. Do this in the bootstrap template so that it can be easily
 # accessed from multiple places - most scripts will already need to source this
 # file.
-[[ -z $NINJA ]] && export NINJA=ninja
+[[ -z "${NINJA-}" ]] && export NINJA=ninja
 
 export WORKDIR="@@WorkDir@@"
 export SRCDIR="@@SrcDir@@"


### PR DESCRIPTION
Check by using ${NINJA-} which expands to empty if unset, and does not trigger
unbound variable warnings under `set -u`, unlike the existing test.

Change-Id: Id12e8e72d283bb557cb4b637fd8192c5d0ebd049
Signed-off-by: Chris Diamand <chris.diamand@arm.com>
Signed-off-by: Mihail Atanassov <mihail.atanassov@arm.com>