### PR TITLE
Use the first character of platform_version

### DIFF
--- a/scripts/android_version.py
+++ b/scripts/android_version.py
@@ -44,7 +44,7 @@ def get_platform_version():
 
     if platform_version.isalpha():
         # aosp master may have a single letter for PLATFORM_VERSION eg. 'Q' for Android 10
-        platform_version = ord(platform_version) - 71
+        platform_version = ord(platform_version[0]) - 71
     return int(platform_version)
 
 


### PR DESCRIPTION
Increase the robustness of the Android platform version detection by
only using the first character of the version string.

CC: Anders Pedersen <anders.pedersen@arm.com>
CC: Sidath Senanayake <sidaths@google.com>
Change-Id: I5ecf922bc0b191db002c5937ab0173c456c5787c
Signed-off-by: Chris Diamand <chris.diamand@arm.com>