### PR TITLE
Ignore config options marked as 'bob_ignore y'

### DIFF
--- a/config_system/config_system/config_json.py
+++ b/config_system/config_system/config_json.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2019, 2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,14 +32,16 @@ def config_to_json():
         datatype = c["datatype"]
         value = c["value"]
 
-        if datatype == "bool":
-            properties[key] = value
-        elif datatype == "int":
-            properties[key] = int(value)
-        elif datatype == "string":
-            properties[key] = value
-        else:
+        if datatype not in ["bool", "int", "string"]:
             logger.error("Invalid config type: %s (with value '%s')\n" % (datatype, str(value)))
+
+        if datatype == "int":
+            value = int(value)
+
+        properties[key] = {
+            "ignore": c["bob_ignore"] == 'y',
+            "value": value
+        }
 
     return properties
 

--- a/config_system/config_system/general.py
+++ b/config_system/config_system/general.py
@@ -354,6 +354,9 @@ def set_initial_values():
     for k in config_list:
         update_defaults(k)
 
+    for k in config_list:
+        update_bob_ignore(k)
+
 
 def update_choice_default(c):
     """Update a choice group to select the best default"""
@@ -406,6 +409,17 @@ def update_choice_default(c):
 
     if selection != choice_group.get("selected"):
         set_config_internal(selection, True)
+
+
+def update_bob_ignore(k):
+    """Checks whether an option should be ignored by bob"""
+    c = data.get_config(k)
+
+    if 'bob_ignore' not in c:
+        c['bob_ignore'] = 'n'
+
+    if c['bob_ignore'] not in ['y', 'n']:
+        logger.error("bob_ignore for %s needs to be boolean ('y' or 'n')" % k)
 
 
 def update_defaults(k):

--- a/config_system/config_system/lex.py
+++ b/config_system/config_system/lex.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2018-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@ class TokenizeError(Exception):
 
 tokens = (
     "ANDAND", "OROR", "NOT",
+    "BOB_IGNORE",
     "BOOL",
     "CHOICE", "ENDCHOICE",
     "CONFIG",
@@ -62,6 +63,7 @@ states = (
 )
 
 commands = (
+    "bob_ignore",
     "bool",
     "choice",
     "config",

--- a/config_system/config_system/syntax.py
+++ b/config_system/config_system/syntax.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Arm Limited.
+# Copyright 2018-2019, 2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -285,6 +285,7 @@ def p_config_options(p):
     """config_options : config_options config_type
                       | config_options config_select
                       | config_options config_default
+                      | config_options config_bob_ignore
                       | config_options config_depends
                       | config_options config_help
                       | config_options config_prompt
@@ -324,6 +325,13 @@ def p_config_default(p):
     p[0] = {"default": p[2]}
     if len(p) > 4:
         p[0] = {"default_cond": [{"cond": p[4], "expr": p[2]}]}
+
+
+def p_config_bob_ignore(p):
+    """config_bob_ignore : BOB_IGNORE YES EOL
+                         | BOB_IGNORE NO EOL
+    """
+    p[0] = {"bob_ignore": p[2]}
 
 
 def p_config_depends(p):

--- a/config_system/mconfigfmt.py
+++ b/config_system/mconfigfmt.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2019 Arm Limited.
+# Copyright 2019, 2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,7 +41,7 @@ def perform_formatting(file_path, output):
 # Sets grouping tokens into types
 set_config_props = {"BOOL", "INT", "STRING", "PROMPT",
                     "DEFAULT", "DEPENDS", "SELECT",
-                    "VISIBLE", "HELP", "WARNING"}
+                    "VISIBLE", "HELP", "WARNING", "BOB_IGNORE"}
 set_binary_ops = {"ANDAND", "OROR",
                   "EQUAL", "UNEQUAL", "LESS", "LESS_EQUAL", "GREATER", "GREATER_EQUAL",
                   "PLUS", "MINUS"}

--- a/docs/config_system.md
+++ b/docs/config_system.md
@@ -113,6 +113,7 @@ config OPTION_NAME
 	depends on (A && B) || C
 	default n|y|"hello"|1234 if D || E
 	default n
+	bob_ignore n|y
 	select ANOTHER_OPTION
 	warning "warning text when option enabled"
 	help
@@ -187,6 +188,52 @@ config OS_NAME
 	default "Android" if ANDROID
 	default "Linux" if LINUX
 	default "Unknown"
+```
+
+#### Ignore configuration options by bob
+
+There is a possibility to mark a config option as `bob_ignore y` to point
+Bob that it should ignore such option while gathering parameters for templates
+and features. This will prevent from accidentally exposing options by `cflags`.
+
+```
+config PLATFORM_VERBOSE_MODE
+	bool "Enable verbose mode"
+	default y
+	bob_ignore y
+
+config PLATFORM_VERBOSE_TYPE
+	string "verbose mode type"
+	default "all"
+	bob_ignore y
+```
+
+Options are stored in `.bob.config.json` as:
+```
+{
+	"platform_verbose_mode" : {
+		"ignore" : true,
+		"value" : true
+	},
+	"platform_verbose_type" : {
+		"ignore" : true,
+		"value" : "all"
+	}
+}
+```
+
+This way Bob will not be able to recognize at all of those options:
+
+```
+bob_defaults {
+	...
+	platform_verbose_mode: {
+        cflags: [
+			"-DVERBOSE_MODE=1",
+			"-DVERBOSE_TYPE={{.platform_verbose_type}}",
+		],
+	},
+}
 ```
 
 #### Negated values


### PR DESCRIPTION
Bob need to support ignoring some configuration options
for its templates and features to be not accidentally
exposed via cflags.

Add Mconfig support for 'bob_ignore' config option.

Now .bob.config.json stores configuration options in a new way:
{
    config_option_one : {
        "ignore" : true|false,
        "value" : config_option_one_value
    }
}

Change-Id: I57bfbf0d266f28dd8c9eeac9909d1c16e49b564d
Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>