### PR TITLE
Fix pylint check

### DIFF
--- a/.github/checks/check-pylint.sh
+++ b/.github/checks/check-pylint.sh
@@ -2,4 +2,4 @@
 
 BOB_ROOT=$(dirname ${0})/../..
 find "${BOB_ROOT}" -name "*.py" -print0 \
-    | xargs -0 pylint --py3k --errors-only
+    | xargs -0 pylint --errors-only

--- a/config_system/menuconfig.py
+++ b/config_system/menuconfig.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2018-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -65,6 +65,7 @@ def init_attr():
 class MenuBar(object):
     def __init__(self, options):
         self.options = options
+        self.selection_pos = (0, 0)
         self.selection = 0
 
     def left(self):


### PR DESCRIPTION
The github actions setup (`ci.yml`) requests Python 3.x for the pylint
checks, which means the `--py3k` option is not available, causing an
error.

Remove the use of that option.

Change-Id: If1ac89a96e1ce3c1f1252c53186f03ae198578d6
Signed-off-by: Chris Diamand <chris.diamand@arm.com>