### PR TITLE
Add error handling to bob

### DIFF
--- a/cmd/bob/main.go
+++ b/cmd/bob/main.go
@@ -23,6 +23,7 @@ import (
 	"runtime/pprof"
 
 	"github.com/ARM-software/bob-build/core"
+	"github.com/ARM-software/bob-build/internal/utils"
 )
 
 func main() {
@@ -34,7 +35,7 @@ func main() {
 	if present && cpuprofile != "" {
 		f, err := os.Create(cpuprofile)
 		if err != nil {
-			panic(err)
+			utils.Die("%v", err)
 		}
 		pprof.StartCPUProfile(f)
 		defer pprof.StopCPUProfile()

--- a/core/androidbp_backend.go
+++ b/core/androidbp_backend.go
@@ -157,7 +157,7 @@ func collectBuildBpFilesMutator(mctx blueprint.BottomUpMutatorContext) {
 func extractDeps(depfile string) []string {
 	file, err := os.Open(depfile)
 	if err != nil {
-		panic(fmt.Errorf("Could not open depfile %s: %v", depfile, err))
+		utils.Die("Could not open depfile %s: %v", depfile, err)
 	}
 	defer file.Close()
 
@@ -167,7 +167,7 @@ func extractDeps(depfile string) []string {
 		lines = append(lines, scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
-		panic(fmt.Errorf("Error reading depfile %s: %v", depfile, err))
+		utils.Die("Error reading depfile %s: %v", depfile, err)
 	}
 
 	if len(lines) == 0 {
@@ -185,7 +185,7 @@ func extractDeps(depfile string) []string {
 func hashFileAtPath(path string) []byte {
 	file, err := os.Open(path)
 	if err != nil {
-		panic(fmt.Errorf("Could not open %s for hashing: %v", path, err))
+		utils.Die("Could not open %s for hashing: %v", path, err)
 	}
 	defer file.Close()
 
@@ -374,7 +374,7 @@ func (s *androidBpSingleton) GenerateBuildActions(ctx blueprint.SingletonContext
 	ctx.AddNinjaFileDeps(pluginTemplate)
 	content, err := ioutil.ReadFile(pluginTemplate)
 	if err != nil {
-		utils.Exit(1, err.Error())
+		utils.Die("%v", err.Error())
 	}
 
 	// use source dir to get project-unique identifier,
@@ -401,7 +401,7 @@ func (s *androidBpSingleton) GenerateBuildActions(ctx blueprint.SingletonContext
 	androidbpFile := getPathInSourceDir("Android.bp")
 	err = fileutils.WriteIfChanged(androidbpFile, sb)
 	if err != nil {
-		utils.Exit(1, err.Error())
+		utils.Die("%v", err.Error())
 	}
 
 	// Blueprint does not output package context dependencies unless

--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -49,7 +49,7 @@ func bpModuleNamesForDep(mctx blueprint.BaseModuleContext, name string) []string
 	})
 
 	if dep == nil {
-		panic(fmt.Errorf("%s has no dependency '%s'", mctx.ModuleName(), name))
+		utils.Die("%s has no dependency '%s'", mctx.ModuleName(), name)
 	}
 
 	if r, ok := dep.(*resource); ok {
@@ -58,7 +58,7 @@ func bpModuleNamesForDep(mctx blueprint.BaseModuleContext, name string) []string
 			modNames = append(modNames, r.getAndroidbpResourceName(src))
 		}
 		if len(modNames) == 0 {
-			panic(fmt.Errorf("bob_resource %s has empty srcs", name))
+			utils.Die("bob_resource %s has empty srcs", name)
 		}
 		return modNames
 	}
@@ -208,8 +208,8 @@ func (g *androidBpGenerator) getVersionScript(l *library, ctx blueprint.ModuleCo
 
 func addCcLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContext) {
 	if len(l.Properties.Export_include_dirs) > 0 {
-		panic(fmt.Errorf("Module %s exports non-local include dirs %v - this is not supported",
-			mctx.ModuleName(), l.Properties.Export_include_dirs))
+		utils.Die("Module %s exports non-local include dirs %v - this is not supported",
+			mctx.ModuleName(), l.Properties.Export_include_dirs)
 	}
 
 	// Soong deals with exported include directories between library
@@ -249,7 +249,7 @@ func addCcLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContex
 	m.AddStringList("exclude_srcs", l.Properties.Exclude_srcs)
 	err := addCFlags(m, cflags, l.Properties.Conlyflags, l.Properties.Cxxflags)
 	if err != nil {
-		panic(fmt.Errorf("Module %s: %s", mctx.ModuleName(), err.Error()))
+		utils.Die("Module %s: %s", mctx.ModuleName(), err.Error())
 	}
 	m.AddStringList("include_dirs", l.Properties.Include_dirs)
 	m.AddStringList("local_include_dirs", l.Properties.Local_include_dirs)
@@ -274,8 +274,8 @@ func addCcLibraryProps(m bpwriter.Module, l library, mctx blueprint.ModuleContex
 	if l.Properties.Post_install_cmd != nil ||
 		l.Properties.Post_install_args != nil ||
 		l.Properties.Post_install_tool != nil {
-		panic(fmt.Errorf("Module %s has post install actions - this is not supported on Android.bp",
-			mctx.ModuleName()))
+		utils.Die("Module %s has post install actions - this is not supported on Android.bp",
+			mctx.ModuleName())
 	}
 }
 

--- a/core/androidbp_generated.go
+++ b/core/androidbp_generated.go
@@ -18,7 +18,6 @@
 package core
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -31,19 +30,19 @@ import (
 
 func (g *androidBpGenerator) genBinaryActions(m *generateBinary, mctx blueprint.ModuleContext) {
 	if enabledAndRequired(m) {
-		panic(fmt.Errorf("Generated binaries are not supported (%s)", m.Name()))
+		utils.Die("Generated binaries are not supported (%s)", m.Name())
 	}
 }
 
 func (g *androidBpGenerator) genSharedActions(m *generateSharedLibrary, mctx blueprint.ModuleContext) {
 	if enabledAndRequired(m) {
-		panic(fmt.Errorf("Generated shared libraries are not supported (%s)", m.Name()))
+		utils.Die("Generated shared libraries are not supported (%s)", m.Name())
 	}
 }
 
 func (g *androidBpGenerator) genStaticActions(m *generateStaticLibrary, mctx blueprint.ModuleContext) {
 	if enabledAndRequired(m) {
-		panic(fmt.Errorf("Generated static libraries are not supported (%s)", m.Name()))
+		utils.Die("Generated static libraries are not supported (%s)", m.Name())
 	}
 }
 
@@ -65,14 +64,14 @@ func expandCmd(gc *generateCommon, s string, moduleDir string) string {
 			return filepath.Join("${module_dir}", moduleDir)
 		case "bob_config":
 			if !proptools.Bool(gc.Properties.Depfile) {
-				panic(fmt.Errorf("%s references Bob config but depfile not enabled. "+
-					"Config dependencies must be declared via a depfile!", gc.Name()))
+				utils.Die("%s references Bob config but depfile not enabled. "+
+					"Config dependencies must be declared via a depfile!", gc.Name())
 			}
 			return configFile
 		case "bob_config_json":
 			if !proptools.Bool(gc.Properties.Depfile) {
-				panic(fmt.Errorf("%s references Bob config but depfile not enabled. "+
-					"Config dependencies must be declared via a depfile!", gc.Name()))
+				utils.Die("%s references Bob config but depfile not enabled. "+
+					"Config dependencies must be declared via a depfile!", gc.Name())
 			}
 			return configJSONFile
 		case "bob_config_opts":
@@ -99,12 +98,12 @@ func populateCommonProps(gc *generateCommon, mctx blueprint.ModuleContext, m bpw
 	if gc.Properties.Host_bin != nil {
 		hostBin := bpModuleNamesForDep(mctx, gc.hostBinName(mctx))
 		if len(hostBin) != 1 {
-			panic(fmt.Errorf("%s must have one host_bin entry (have %d)", gc.Name(), len(hostBin)))
+			utils.Die("%s must have one host_bin entry (have %d)", gc.Name(), len(hostBin))
 		}
 		m.AddString("host_bin", hostBin[0])
 	}
 	if proptools.Bool(gc.Properties.Depfile) && !utils.ContainsArg(cmd, "depfile") {
-		panic(fmt.Errorf("%s depfile is true, but ${depfile} not used in cmd", gc.Name()))
+		utils.Die("%s depfile is true, but ${depfile} not used in cmd", gc.Name())
 	}
 
 	m.AddBool("depfile", proptools.Bool(gc.Properties.Depfile))
@@ -127,7 +126,7 @@ func (g *androidBpGenerator) generateSourceActions(gs *generateSource, mctx blue
 
 	m, err := AndroidBpFile().NewModule("genrule_bob", gs.shortName())
 	if err != nil {
-		panic(err.Error())
+		utils.Die("%v", err.Error())
 	}
 
 	srcs := gs.generateCommon.Properties.getSources(mctx)
@@ -149,7 +148,7 @@ func (g *androidBpGenerator) transformSourceActions(ts *transformSource, mctx bl
 
 	m, err := AndroidBpFile().NewModule("gensrcs_bob", ts.shortName())
 	if err != nil {
-		panic(err.Error())
+		utils.Die(err.Error())
 	}
 
 	srcs := ts.generateCommon.Properties.getSources(mctx)

--- a/core/androidbp_resource.go
+++ b/core/androidbp_resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/blueprint"
 
 	"github.com/ARM-software/bob-build/internal/bpwriter"
+	"github.com/ARM-software/bob-build/internal/utils"
 )
 
 func writeDataResourceModule(m bpwriter.Module, src, installRel string) {
@@ -92,7 +93,7 @@ func (g *androidBpGenerator) resourceActions(r *resource, mctx blueprint.ModuleC
 		// keep module name unique, remove slashes
 		m, err := AndroidBpFile().NewModule(modType, r.getAndroidbpResourceName(src))
 		if err != nil {
-			panic(err.Error())
+			utils.Die(err.Error())
 		}
 
 		addProvenanceProps(m, r.Properties.AndroidProps)

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -18,7 +18,6 @@
 package core
 
 import (
-	"fmt"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -58,7 +57,7 @@ type TargetSpecific struct {
 // init initializes properties and features
 func (t *TargetSpecific) init(properties *configProperties, list ...interface{}) {
 	if len(list) == 0 {
-		panic("List can't be empty")
+		utils.Die("List can't be empty")
 	}
 
 	propsType := coalesceTypes(typesOf(list...)...)
@@ -368,7 +367,7 @@ func parseAndAddVariationDeps(mctx blueprint.BottomUpMutatorContext,
 				} else if vn == "target" {
 					variations = append(variations, targetVariation...)
 				} else {
-					panic("Invalid variation: " + vn + " in module name " + dep)
+					utils.Die("Invalid variation: %s in module name %s", vn, dep)
 				}
 			}
 
@@ -596,7 +595,7 @@ func checkDisabledMutator(mctx blueprint.BottomUpMutatorContext) {
 	// disable current module if dependency is disabled, or panic if it's required
 	if len(disabledDeps) > 0 {
 		if isRequired(ep) {
-			panic(fmt.Errorf("Module %s is required but depends on disabled modules %s", module.Name(), strings.Join(disabledDeps, ", ")))
+			utils.Die("Module %s is required but depends on disabled modules %s", module.Name(), strings.Join(disabledDeps, ", "))
 		} else {
 			ep.getEnableableProps().Enabled = proptools.BoolPtr(false)
 			return

--- a/core/config_props.go
+++ b/core/config_props.go
@@ -50,31 +50,34 @@ func (properties configProperties) getProp(name string) interface{} {
 	if elem, ok := properties.properties[name]; ok {
 		return elem
 	}
-	panic(fmt.Sprintf("No property found: %s", name))
+	utils.Die("No property found: %s", name)
+	return nil
 }
 
 func (properties configProperties) GetBool(name string) bool {
-	if ret, ok := properties.getProp(name).(bool); ok {
+	ret, ok := properties.getProp(name).(bool)
+	if ok {
 		return ret
 	}
-	panic(fmt.Sprintf("Property %s is not a bool", name))
+	utils.Die("Property %s is not a bool", name)
+	return !ret
 }
 
 func (properties configProperties) GetInt(name string) int {
 	number, ok := properties.getProp(name).(json.Number)
 	if !ok {
-		panic(fmt.Sprintf("Property %s with value '%v' is not an int",
-			name, properties.getProp(name)))
+		utils.Die("Property %s with value '%v' is not an int",
+			name, properties.getProp(name))
 	}
 
 	ret, err := number.Int64()
 	if err != nil {
-		panic(fmt.Sprintf("Property %s contains invalid int value '%s': %v",
-			name, number.String(), err))
+		utils.Die("Property %s contains invalid int value '%s': %v",
+			name, number.String(), err)
 	}
 
 	if int64(int(ret)) != ret {
-		panic(fmt.Sprintf("Property %s value out of `int` range: %d", name, ret))
+		utils.Die("Property %s value out of `int` range: %d", name, ret)
 	}
 
 	return int(ret)
@@ -84,7 +87,8 @@ func (properties configProperties) GetString(name string) string {
 	if ret, ok := properties.getProp(name).(string); ok {
 		return ret
 	}
-	panic(fmt.Sprintf("Property %s is not a string", name))
+	utils.Die("Property %s is not a string", name)
+	return ""
 }
 
 func (properties configProperties) StringMap() map[string]string {
@@ -98,7 +102,7 @@ func (properties configProperties) StringMap() map[string]string {
 //  - Slices of booleans,strings and ints are converted into a space-separated string
 //  - Pointers to booleans,strings and ints are converted into the referenced value
 //
-// Any other type might panic.
+// Any other type might Exit().
 func convertToString(thing interface{}) string {
 	field := reflect.ValueOf(thing)
 	var value string
@@ -133,7 +137,7 @@ func convertToString(thing interface{}) string {
 		value = strings.Join(values, " ")
 
 	default:
-		panic(fmt.Sprintf("Can't convert type %s to string!", field.Type().String()))
+		utils.Die("Can't convert type %s to string!", field.Type().String())
 	}
 	return value
 }

--- a/core/defaults.go
+++ b/core/defaults.go
@@ -18,7 +18,6 @@
 package core
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/google/blueprint"
@@ -201,8 +200,8 @@ func defaultDepsStage1Mutator(mctx blueprint.BottomUpMutatorContext) {
 		if len(gsc.Properties.Flag_defaults) > 0 {
 			tgt := gsc.Properties.Target
 			if !(tgt == tgtTypeHost || tgt == tgtTypeTarget) {
-				panic(fmt.Errorf("Module %s uses flag_defaults '%v' but has invalid target type '%s'",
-					mctx.ModuleName(), gsc.Properties.Flag_defaults, tgt))
+				utils.Die("Module %s uses flag_defaults '%v' but has invalid target type '%s'",
+					mctx.ModuleName(), gsc.Properties.Flag_defaults, tgt)
 			}
 		}
 	}
@@ -228,7 +227,7 @@ func expandDefault(d string, visited []string) []string {
 	if len(defaultsMap[d]) > 0 {
 		for _, def := range defaultsMap[d] {
 			if utils.Find(visited, def) >= 0 {
-				panic(fmt.Errorf("Defaults module %s depends upon itself", def))
+				utils.Die("Defaults module %s depends upon itself", def)
 			}
 			defaults = append(defaults, expandDefault(def, append(visited, def))...)
 			defaults = append(defaults, def)

--- a/core/feature.go
+++ b/core/feature.go
@@ -18,9 +18,10 @@
 package core
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
+
+	"github.com/ARM-software/bob-build/internal/utils"
 )
 
 // featurePropertyName returns name of feature. Name needs to start from capital letter because
@@ -75,7 +76,7 @@ func typesOf(list ...interface{}) []reflect.Type {
 // Only exported properties can be set so property name MUST start from capital letter.
 func (f *Features) Init(properties *configProperties, list ...interface{}) {
 	if len(list) == 0 {
-		panic("List can't be empty")
+		utils.Die("List can't be empty")
 	}
 
 	propsType := coalesceTypes(typesOf(list...)...)
@@ -135,7 +136,7 @@ func (f *Features) Init(properties *configProperties, list ...interface{}) {
 // }
 func coalesceTypes(list ...reflect.Type) reflect.Type {
 	if len(list) == 0 {
-		panic("List can't be empty")
+		utils.Die("List can't be empty")
 	}
 	if len(list) == 1 {
 		return list[0]
@@ -149,7 +150,7 @@ func coalesceTypes(list ...reflect.Type) reflect.Type {
 			field := elementType.Field(i)
 			fieldName := field.Name
 			if _, ok := fieldsKeys[fieldName]; ok {
-				panic(fmt.Sprintf("Name collision: '%v'\n", fieldName))
+				utils.Die("Name collision: '%v'\n", fieldName)
 			} else {
 				fieldsKeys[fieldName] = true
 				fields = append(fields, field)
@@ -173,7 +174,7 @@ func (f *Features) AppendProps(dst []interface{}, properties *configProperties) 
 			featureFieldName := featurePropertyName(featureKey)
 			featureStruct := featuresData.FieldByName(featureFieldName)
 			if !featureStruct.IsValid() {
-				panic(fmt.Sprintf("Field returned for property %s isn't valid\n", featureFieldName))
+				utils.Die("Field returned for property %s isn't valid\n", featureFieldName)
 			}
 			// AppendProperties expects a pointer to a struct.
 			featureStructPointer := featureStruct.FieldByName("BlueprintEmbed").Interface()

--- a/core/filepath.go
+++ b/core/filepath.go
@@ -18,11 +18,11 @@
 package core
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/ARM-software/bob-build/internal/utils"
 	"github.com/google/blueprint"
 )
 
@@ -105,7 +105,7 @@ func newGeneratedFilePath(path string) filePath {
 	// Module dir is everything up to and including m.Name().
 	pathElems := strings.Split(path, string(os.PathSeparator))
 	if len(pathElems) < 4 {
-		panic(fmt.Errorf("Path doesn't have as many elements as expected. %s", path))
+		utils.Die("Path doesn't have as many elements as expected. %s", path)
 	}
 	lclPath := filepath.Join(pathElems[2:]...)
 	modDir := filepath.Join(pathElems[:3]...)

--- a/core/generated.go
+++ b/core/generated.go
@@ -18,8 +18,6 @@
 package core
 
 import (
-	"errors"
-	"fmt"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -178,7 +176,7 @@ func splitGeneratedComponent(comp string) (module string, lib string) {
 	split := strings.Split(comp, "/")
 
 	if len(split) < 2 {
-		panic(errors.New("Generated component " + comp + " does not specify module and lib"))
+		utils.Die("Generated component %s does not specify module and lib", comp)
 	}
 
 	return split[0], strings.Join(split[1:], "/")
@@ -238,7 +236,7 @@ func (m *generateCommon) disable() {
 
 func (m *generateCommon) setVariant(variant tgtType) {
 	if variant != m.Properties.Target {
-		panic(fmt.Errorf("Variant mismatch: %s != %s", variant, m.Properties.Target))
+		utils.Die("Variant mismatch: %s != %s", variant, m.Properties.Target)
 	}
 }
 
@@ -463,7 +461,7 @@ func getDependentArgsAndFiles(ctx blueprint.ModuleContext, args map[string]strin
 		func(m blueprint.Module) {
 			gen, ok := m.(dependentInterface)
 			if !ok {
-				panic(errors.New(reflect.TypeOf(m).String() + " is not a valid dependent interface"))
+				utils.Die("%s is not a valid dependent interface", reflect.TypeOf(m).String())
 			}
 
 			depName := ctx.OtherModuleName(m)
@@ -539,12 +537,12 @@ func (m *generateCommon) getArgs(ctx blueprint.ModuleContext) (string, map[strin
 	cmd := strings.Replace(proptools.String(m.Properties.Cmd), "${args}", strings.Join(m.Properties.Args, " "), -1)
 
 	if proptools.Bool(m.Properties.Depfile) && !utils.ContainsArg(cmd, "depfile") {
-		panic(fmt.Errorf("%s depfile is true, but ${depfile} not used in cmd", m.Name()))
+		utils.Die("%s depfile is true, but ${depfile} not used in cmd", m.Name())
 	}
 	if utils.ContainsArg(cmd, "bob_config") || utils.ContainsArg(cmd, "bob_config_json") {
 		if !proptools.Bool(m.Properties.Depfile) {
-			panic(fmt.Errorf("%s references Bob config but depfile not enabled. "+
-				"Config dependencies must be declared via a depfile!", m.Name()))
+			utils.Die("%s references Bob config but depfile not enabled. "+
+				"Config dependencies must be declared via a depfile!", m.Name())
 		}
 	}
 
@@ -761,7 +759,7 @@ func getGeneratedFiles(ctx blueprint.ModuleContext) []string {
 				srcs = append(srcs, gs.outputs()...)
 				srcs = append(srcs, gs.implicitOutputs()...)
 			} else {
-				panic(errors.New(ctx.OtherModuleName(m) + " does not have outputs"))
+				utils.Die("%s does not have outputs", ctx.OtherModuleName(m))
 			}
 		})
 	return srcs

--- a/core/install.go
+++ b/core/install.go
@@ -18,10 +18,11 @@
 package core
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/google/blueprint"
+
+	"github.com/ARM-software/bob-build/internal/utils"
 )
 
 // EnableableProps allow a module to be disabled or only built when explicitly requested
@@ -126,7 +127,7 @@ func getShortNamesForDirectDepsIf(ctx blueprint.ModuleContext,
 					ret = append(ret, dep.shortName())
 				}
 			} else {
-				panic(fmt.Errorf("install_dep on non-dependendable module %s", m.Name()))
+				utils.Die("install_dep on non-dependendable module %s", m.Name())
 			}
 			visited[m.Name()] = true
 		})
@@ -289,12 +290,12 @@ func getInstallGroupPathFromTag(mctx blueprint.TopDownMutatorContext, tag depend
 		func(m blueprint.Module) {
 			insg, ok := m.(*installGroup)
 			if !ok {
-				panic(fmt.Sprintf("%s dependency of %s not an install group",
-					tag.name, mctx.ModuleName()))
+				utils.Die("%s dependency of %s not an install group",
+					tag.name, mctx.ModuleName())
 			}
 			if installGroupPath != nil {
-				panic(fmt.Sprintf("Multiple %s dependencies for %s",
-					tag.name, mctx.ModuleName()))
+				utils.Die("Multiple %s dependencies for %s",
+					tag.name, mctx.ModuleName())
 			}
 			installGroupPath = insg.Properties.Install_path
 		})
@@ -307,7 +308,7 @@ func installGroupMutator(mctx blueprint.TopDownMutatorContext) {
 		path := getInstallGroupPathFromTag(mctx, installGroupTag)
 		if path != nil {
 			if *path == "" {
-				panic(fmt.Sprintf("Module %s has empty install path", mctx.ModuleName()))
+				utils.Die("Module %s has empty install path", mctx.ModuleName())
 			}
 
 			props := ins.getInstallableProps()

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -18,12 +18,13 @@
 package core
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/google/blueprint"
 	"github.com/google/blueprint/proptools"
+
+	"github.com/ARM-software/bob-build/internal/utils"
 )
 
 type KernelProps struct {
@@ -146,7 +147,7 @@ func (m *kernelModule) extraSymbolsModules(ctx blueprint.BaseModuleContext) (mod
 			if km, ok := m.(*kernelModule); ok {
 				modules = append(modules, km)
 			} else {
-				panic(fmt.Errorf("invalid extra_symbols, %s not a kernel module", ctx.OtherModuleName(m)))
+				utils.Die("invalid extra_symbols, %s not a kernel module", ctx.OtherModuleName(m))
 			}
 		})
 

--- a/core/late_template.go
+++ b/core/late_template.go
@@ -18,7 +18,6 @@
 package core
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 	"text/template"
@@ -160,7 +159,7 @@ func (s *SourceProps) matchSources(ctx blueprint.BaseModuleContext, arg string,
 	for _, src := range s.getSources(ctx) {
 		matched, err := pathtools.Match("**/"+arg, src)
 		if err != nil {
-			panic("Error during matching filepath pattern")
+			utils.Die("Error during matching filepath pattern")
 		}
 		if matched {
 			matchedNonCompiledSources[src] = true
@@ -168,7 +167,7 @@ func (s *SourceProps) matchSources(ctx blueprint.BaseModuleContext, arg string,
 		}
 	}
 	if len(matchedSources) == 0 {
-		panic(fmt.Errorf("Could not match '%s' for module '%s'", arg, ctx.ModuleName()))
+		utils.Die("Could not match '%s' for module '%s'", arg, ctx.ModuleName())
 	}
 
 	return strings.Join(matchedSources, " ")
@@ -179,7 +178,7 @@ func (s *SourceProps) matchSources(ctx blueprint.BaseModuleContext, arg string,
 func verifyMatchSources(matchedNonCompiledSources map[string]bool) {
 	for src, matched := range matchedNonCompiledSources {
 		if !matched {
-			panic(fmt.Errorf("Non-compiled source %s is not used by match_srcs.", src))
+			utils.Die("Non-compiled source %s is not used by match_srcs.", src)
 		}
 	}
 }

--- a/core/linux_generated.go
+++ b/core/linux_generated.go
@@ -18,8 +18,6 @@
 package core
 
 import (
-	"fmt"
-
 	"github.com/google/blueprint"
 	"github.com/google/blueprint/proptools"
 
@@ -82,7 +80,7 @@ func (g *linuxGenerator) generateCommonActions(m *generateCommon, ctx blueprint.
 
 	for _, inout := range inouts {
 		if inout.depfile != "" && len(inout.out) > 1 {
-			panic(fmt.Errorf("Module %s uses a depfile with multiple outputs", ctx.ModuleName()))
+			utils.Die("Module %s uses a depfile with multiple outputs", ctx.ModuleName())
 		}
 
 		if inout.rspfile != "" {

--- a/core/properties.go
+++ b/core/properties.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/google/blueprint"
 	"github.com/google/blueprint/proptools"
+
+	"github.com/ARM-software/bob-build/internal/utils"
 )
 
 // Property concatenation.
@@ -112,8 +114,8 @@ func defaultApplierMutator(mctx blueprint.BottomUpMutatorContext) {
 		if mctx.OtherModuleDependencyTag(dep) == defaultDepTag {
 			def, ok := dep.(*defaults)
 			if !ok {
-				panic(fmt.Errorf("module %s in %s's defaults is not a default",
-					dep.Name(), mctx.ModuleName()))
+				utils.Die("module %s in %s's defaults is not a default",
+					dep.Name(), mctx.ModuleName())
 			}
 
 			// Append defaults at the same level to maintain cflag order
@@ -122,7 +124,7 @@ func defaultApplierMutator(mctx blueprint.BottomUpMutatorContext) {
 				if propertyErr, ok := err.(*proptools.ExtendPropertyError); ok {
 					mctx.PropertyErrorf(propertyErr.Property, "%s", propertyErr.Err.Error())
 				} else {
-					panic(err)
+					utils.Die("%s", err)
 				}
 			}
 		}
@@ -140,7 +142,7 @@ func defaultApplierMutator(mctx blueprint.BottomUpMutatorContext) {
 		if propertyErr, ok := err.(*proptools.ExtendPropertyError); ok {
 			mctx.PropertyErrorf(propertyErr.Property, "%s", propertyErr.Err.Error())
 		} else {
-			panic(err)
+			utils.Die("%s", err)
 		}
 	}
 }
@@ -276,7 +278,7 @@ func featureApplierMutator(mctx blueprint.TopDownMutatorContext) {
 				if propertyErr, ok := err.(*proptools.ExtendPropertyError); ok {
 					mctx.PropertyErrorf(propertyErr.Property, "%s", propertyErr.Err.Error())
 				} else {
-					panic(err)
+					utils.Die("%s", err)
 				}
 			}
 		}

--- a/core/splitter.go
+++ b/core/splitter.go
@@ -19,10 +19,11 @@ package core
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/google/blueprint"
 	"github.com/google/blueprint/proptools"
+
+	"github.com/ARM-software/bob-build/internal/utils"
 )
 
 // SplittableProps are embedded by modules which can be split into multiple variants
@@ -84,8 +85,8 @@ func supportedVariantsMutator(mctx blueprint.BottomUpMutatorContext) {
 		if mctx.OtherModuleDependencyTag(dep) == defaultDepTag {
 			def, ok := dep.(*defaults)
 			if !ok {
-				panic(fmt.Errorf("module %s in %s's defaults is not a default",
-					dep.Name(), mctx.ModuleName()))
+				utils.Die("module %s in %s's defaults is not a default",
+					dep.Name(), mctx.ModuleName())
 			}
 
 			// Append at the same level, so later siblings take precedence
@@ -94,7 +95,7 @@ func supportedVariantsMutator(mctx blueprint.BottomUpMutatorContext) {
 				if propertyErr, ok := err.(*proptools.ExtendPropertyError); ok {
 					mctx.PropertyErrorf(propertyErr.Property, "%s", propertyErr.Err.Error())
 				} else {
-					panic(err)
+					utils.Die("%v", err)
 				}
 			}
 		}
@@ -106,7 +107,7 @@ func supportedVariantsMutator(mctx blueprint.BottomUpMutatorContext) {
 		if propertyErr, ok := err.(*proptools.ExtendPropertyError); ok {
 			mctx.PropertyErrorf(propertyErr.Property, "%s", propertyErr.Err.Error())
 		} else {
-			panic(err)
+			utils.Die("%v", err)
 		}
 	}
 }

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -23,13 +23,13 @@
 package core
 
 import (
-	"errors"
 	"os"
 
 	"github.com/google/blueprint"
 	"github.com/google/blueprint/bootstrap"
 
 	"github.com/ARM-software/bob-build/internal/graph"
+	"github.com/ARM-software/bob-build/internal/utils"
 )
 
 var (
@@ -83,7 +83,7 @@ func Main() {
 	config := &bobConfig{}
 	err := config.Properties.LoadConfig(configJSONFile)
 	if err != nil {
-		panic(err)
+		utils.Die("%v", err)
 	}
 
 	builder_ninja := config.Properties.GetBool("builder_ninja")
@@ -225,7 +225,7 @@ func Main() {
 	} else if builder_android_make {
 		config.Generator = &androidMkGenerator{}
 	} else {
-		panic(errors.New("unknown builder backend"))
+		utils.Die("Unknown builder backend")
 	}
 
 	config.Generator.init(ctx, config)

--- a/core/template.go
+++ b/core/template.go
@@ -23,11 +23,13 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
+
+	"github.com/ARM-software/bob-build/internal/utils"
 )
 
 func applyTemplateString(elem reflect.Value, stringvalues map[string]string, funcmap map[string]interface{}) {
 	if elem.Kind() != reflect.String {
-		panic("elem is not a string")
+		utils.Die("elem is not a string")
 	}
 
 	t := template.New("TemplateProps")
@@ -36,12 +38,12 @@ func applyTemplateString(elem reflect.Value, stringvalues map[string]string, fun
 
 	tmpl, err := t.Parse(elem.String())
 	if err != nil {
-		panic("Error parsing string '" + elem.String() + "': " + err.Error())
+		utils.Die("Error parsing string '%s': %s", elem.String(), err.Error())
 	}
 	buf := new(bytes.Buffer)
 	err = tmpl.Execute(buf, stringvalues)
 	if err != nil {
-		panic("Error executing string '" + elem.String() + "': " + err.Error())
+		utils.Die("Error executing string '%s': %s", elem.String(), err.Error())
 	}
 	elem.SetString(buf.String())
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -288,9 +288,13 @@ func NewStringSlice(lists ...[]string) []string {
 
 // Exit the program, printing a message to stderr.
 // Deferred functions will not execute.
-func Exit(exitCode int, err string) {
-	fmt.Fprintf(os.Stderr, err+"\n")
+func Exit(exitCode int, err string, a ...interface{}) {
+	fmt.Fprintf(os.Stderr, err+"\n", a...)
 	os.Exit(exitCode)
+}
+
+func Die(err string, a ...interface{}) {
+	Exit(1, err, a...)
 }
 
 // FlattenPath produces a filename containing no slashes from a path.


### PR DESCRIPTION
Modified the utils.Exit() function to be variadic and take format strings.
Change the panic calls for external errors to utils.Exit() calls.

Signed-off-by: Samuel Percival <samuel.percival@arm.com>
Change-Id: I0f0fe6107a075cee55fe8a4e4e4571b0173aacb0