### PR TITLE
Clarify [generate|transform]_source documentation

### DIFF
--- a/docs/module_types/bob_generate_source.md
+++ b/docs/module_types/bob_generate_source.md
@@ -1,9 +1,10 @@
 Module: bob_generate_source
 ===========================
 
-This target generates source code (headers or C files). A single
-module can generate multiple outputs from common inputs, by running a
-custom command.
+This target generates files via a custom shell command. This is usually source
+code (headers or C files), but it could be anything. A single module will
+generate multiple outputs from common inputs, and the command is run exactly
+once.
 
 The command will be run once - with `$in` being the paths in
 `srcs` and `$out` being the paths in `out`.

--- a/docs/module_types/bob_transform_source.md
+++ b/docs/module_types/bob_transform_source.md
@@ -1,9 +1,10 @@
 Module: bob_transform_source
 ============================
 
-This target generates source code (headers or C files). A single
-module generates output from each input (i.e. it runs the command
-separately on each input file).
+This target generates files via a custom shell command. This is usually source
+code (headers or C files), but it could be anything. A single module generates
+an output from each input (i.e. it runs the command separately on each input
+file).
 
 The command will be run once per source file with `$in` being the
 path in `srcs` and `$out` being the path transformed


### PR DESCRIPTION
Update the documentation for `bob_generate_source` and
`bob_transform_source` to clarify that they can generate any kind of
file.

Change-Id: I7aaa8926f63404010e1cf89287eca49ae78b22c4
Signed-off-by: Chris Diamand <chris.diamand@arm.com>