### PR TITLE
Delimit BOB_CONFIG_PLUGINS plugins with a colon ':'

### DIFF
--- a/bootstrap/utils.bash
+++ b/bootstrap/utils.bash
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2018-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,8 +18,10 @@ function write_bootstrap() {
     local BOB_CONFIG_PLUGIN_OPTS="-p ${BOB_DIR}/scripts/host_explore"
 
     # Add any other plugins requested by the caller
-    for i in ${BOB_CONFIG_PLUGINS}; do
-        BOB_CONFIG_PLUGIN_OPTS="${BOB_CONFIG_PLUGIN_OPTS} -p ${i}"
+    # Split ':' separated paths and store them in a PLUGINS array
+    IFS=':' read -ra PLUGINS <<< "$BOB_CONFIG_PLUGINS"
+    for i in "${PLUGINS[@]}"; do
+        BOB_CONFIG_PLUGIN_OPTS="${BOB_CONFIG_PLUGIN_OPTS} -p \'${i}\'"
     done
 
     source "${BOB_DIR}/bob.bootstrap.version"

--- a/config.bash
+++ b/config.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2018-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +45,7 @@ done
 # Move to the working directory
 cd -P "${WORKDIR}"
 
-"${BOB_DIR}/config_system/update_config.py" --new -d "${SRCDIR}/Mconfig" \
+eval "${BOB_DIR}/config_system/update_config.py" --new -d "${SRCDIR}/Mconfig" \
     ${BOB_CONFIG_OPTS} ${BOB_CONFIG_PLUGIN_OPTS} \
     -j "${CONFIG_JSON}" \
     -c "${CONFIG_FILE}" \

--- a/docs/config_system.md
+++ b/docs/config_system.md
@@ -393,7 +393,7 @@ Config plugins are included in the build system by adding them to the
 `BOB_CONFIG_PLUGINS` variable during bootstrap:
 
 ```bash
-export BOB_CONFIG_PLUGINS="path/to/config_plugin" # No .py extension
+export BOB_CONFIG_PLUGINS="path/to/config_plugin:path/to/other_config_plugin" # No .py extension
 ... # Other exports for Bob bootstrap
 bob/bootstrap_linux.bash # or bootstrap_androidmk.bash
 ```

--- a/docs/project_setup.md
+++ b/docs/project_setup.md
@@ -78,7 +78,7 @@ expected. This is expected to be relative to the working directory
 `BOB_CONFIG_OPTS` is a list of options passed to the configuration
 system. This can usually be left empty.
 
-`BOB_CONFIG_PLUGINS` is a space separated list of plugins that the
+`BOB_CONFIG_PLUGINS` is a ':' separated list of plugins that the
 configuration system should run before saving the configuration file.
 
 ### Linux bootstrap

--- a/menuconfig.bash
+++ b/menuconfig.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2018-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@ source ".bob.bootstrap"
 # Move to the working directory
 cd -P "${WORKDIR}"
 
-"${BOB_DIR}/config_system/menuconfig.py" -d "${SRCDIR}/Mconfig" \
+eval "${BOB_DIR}/config_system/menuconfig.py" -d "${SRCDIR}/Mconfig" \
     ${BOB_CONFIG_OPTS} ${BOB_CONFIG_PLUGIN_OPTS} \
     -j "${CONFIG_JSON}" \
     --depfile "${CONFIG_FILE}.d" \

--- a/reconfig.bash
+++ b/reconfig.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Arm Limited.
+# Copyright 2020-2021 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +28,7 @@ source ".bob.bootstrap"
 # Move to the working directory
 cd -P "${WORKDIR}"
 
-"${BOB_DIR}/config_system/update_config.py" -d "${SRCDIR}/Mconfig" \
+eval "${BOB_DIR}/config_system/update_config.py" -d "${SRCDIR}/Mconfig" \
     ${BOB_CONFIG_OPTS} ${BOB_CONFIG_PLUGIN_OPTS} \
     -j "${CONFIG_JSON}" \
     -c "${CONFIG_FILE}" \


### PR DESCRIPTION
Plugins in a BOB_CONFIG_PLUGINS variable are delimited
with a space but it may happen that plugin names will
also contain the space within it. This will lead to
incorrect tokenisation of the plugin paths.

Change the delimiter character from space to ':' to
avoid possible errors in case plugin name will contain
a space.

Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>
Change-Id: Ida2281f00c0d43e0c265b53bfb3cd569a08a5f3e