### PR TITLE
Add explicit quotes for config variables

### DIFF
--- a/config.bash
+++ b/config.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2021 Arm Limited.
+# Copyright 2018-2022 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,7 @@ for arg in "$@"
 do
 
     if [[ $arg =~ "=" ]];then
-        ARG_TARGET+=("${arg}")
+        ARG_TARGET+=(\'${arg}\')
     elif [ "${arg:0:1}" == "/" ];then
         ARG_TARGET+=("${arg}")
     else


### PR DESCRIPTION
When a config variable is passed with possible multiple params
e.g. CFLAGS=-g -O0 -DTEST
there are passed to next update_config.py script as separate ones
  1. CFLAGS=-g
  2. -O0
  3. -DTEST

Add explicit quotes for such variables to parse them as single
input parameter.

Change-Id: Id10f7edfb25f72a26c77ba032535cd0ba5089d34
Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>