### PR TITLE
Add support for A13 Soong

### DIFF
--- a/core/androidbp_backend.go
+++ b/core/androidbp_backend.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Arm Limited.
+ * Copyright 2020-2022 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -293,6 +293,11 @@ func getSoongCompatFile(config *bobConfig) string {
 		text:     "\ntype AndroidMkExtraEntriesContext interface {\n",
 	}
 
+	androidMkSoongInstallTargetsMatcher := codeMatcher{
+		filename: "build/soong/android/androidmk.go",
+		text:     "a.SetPath(\"LOCAL_SOONG_INSTALLED_MODULE\", base.katiInstalls[len(base.katiInstalls)-1].to)\n",
+	}
+
 	// List of compatibility layers, ordered from oldest Soong version
 	// support to newest.
 	allSoongCompats := []compatVersion{
@@ -312,6 +317,16 @@ func getSoongCompatFile(config *bobConfig) string {
 			},
 			[]int{12},
 			"soong_compat_01_AndroidMkExtraEntries_ctx.go",
+		},
+		// Soong install Mk targets have been added in 6301c3c
+		{
+			[]codeMatcher{
+				listOfAndroidMkEntriesMatcher,
+				androidMkExtraEntriesContextMatcher,
+				androidMkSoongInstallTargetsMatcher,
+			},
+			[]int{13},
+			"soong_compat_02_AndroidMkSoongInstallTargets.go",
 		},
 	}
 

--- a/internal/soong_compat/soong_compat_01_AndroidMkExtraEntries_ctx.go
+++ b/internal/soong_compat/soong_compat_01_AndroidMkExtraEntries_ctx.go
@@ -1,7 +1,7 @@
 // +build soong
 
 /*
- * Copyright 2021 Arm Limited.
+ * Copyright 2021-2022 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,4 +31,8 @@ func ConvertAndroidMkExtraEntriesFunc(f AndroidMkExtraEntriesFunc) []android.And
 			f(entries)
 		},
 	}
+}
+
+func SoongSupportsMkInstallTargets() bool {
+	return false
 }

--- a/internal/soong_compat/soong_compat_02_AndroidMkSoongInstallTargets.go
+++ b/internal/soong_compat/soong_compat_02_AndroidMkSoongInstallTargets.go
@@ -1,7 +1,7 @@
 // +build soong
 
 /*
- * Copyright 2021-2022 Arm Limited.
+ * Copyright 2022 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,17 +23,16 @@ import (
 	"android/soong/android"
 )
 
-// This definition is compatible with Soong SHAs _before_ `aa2555387 Add ctx to
-// AndroidMkExtraEntriesFunc` It requires Soong SHA `0b0e1b980 AndroidMkEntries()
-// returns multiple AndroidMkEntries structs` or later.
+// This definition is compatible with Soong SHAs after `aa2555387 Add ctx to
+// AndroidMkExtraEntriesFunc`
 func ConvertAndroidMkExtraEntriesFunc(f AndroidMkExtraEntriesFunc) []android.AndroidMkExtraEntriesFunc {
 	return []android.AndroidMkExtraEntriesFunc{
-		func(entries *android.AndroidMkEntries) {
+		func(ctx android.AndroidMkExtraEntriesContext, entries *android.AndroidMkEntries) {
 			f(entries)
 		},
 	}
 }
 
 func SoongSupportsMkInstallTargets() bool {
-	return false
+	return true
 }


### PR DESCRIPTION
Since 6301c3c, Soong now generates install
targets for Make. This clashed with genrulebob
targets and caused cyclic dependencies for install.

The module output will now be correctly set to the
intermediate file and the install rules will be
generated automatically by Soong.

Change-Id: Ibd789c0ac716b33e62b4fc778d03367f1cc558de