### PR TITLE
Extend tools for source generation modules

### DIFF
--- a/core/androidbp_kernel_module.go
+++ b/core/androidbp_kernel_module.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Arm Limited.
+ * Copyright 2020-2022 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -77,7 +77,7 @@ func (g *androidBpGenerator) kernelModuleActions(l *kernelModule, mctx blueprint
 	bpmod.AddStringList("generated_deps", generated_deps)
 	bpmod.AddStringList("out", l.outs)
 	bpmod.AddStringList("implicit_outs", []string{"Module.symvers"})
-	bpmod.AddString("tool", kmod_build)
+	bpmod.AddStringList("tools", []string{kmod_build})
 	bpmod.AddBool("depfile", true)
 
 	// Generate the build command. Use the `stringParam` helper for options which

--- a/docs/module_types/bob_generate_library.md
+++ b/docs/module_types/bob_generate_library.md
@@ -47,7 +47,7 @@ bob_generate_shared_library {
     add_to_alias: ["bob_alias.name"],
 
     cmd: "python ${tool} ${args} ${in}",
-    tool: "my_script.py",
+    tools: ["my_script.py"],
 
     host_bin: "name_of_host_binary",
     tags: ["optional"],

--- a/docs/module_types/bob_generate_source.md
+++ b/docs/module_types/bob_generate_source.md
@@ -35,7 +35,7 @@ bob_generate_source {
     add_to_alias: ["bob_alias.name"],
 
     cmd: "python ${tool} ${args} ${in} -d ${depfile}",
-    tool: "my_script.py",
+    tools: ["my_script.py"],
 
     host_bin: "clang-tblgen",
     tags: ["optional"],

--- a/docs/module_types/bob_transform_source.md
+++ b/docs/module_types/bob_transform_source.md
@@ -42,7 +42,7 @@ bob_transform_source {
     add_to_alias: ["bob_alias.name"],
 
     cmd: "python ${tool} ${args} ${in} -d ${depfile}",
-    tool: "my_script.py",
+    tools: ["my_script.py"],
 
     host_bin: "clang-tblgen",
     tags: ["optional"],

--- a/docs/module_types/common_generate_module_properties.md
+++ b/docs/module_types/common_generate_module_properties.md
@@ -22,7 +22,8 @@ available substitutions are:
 - `${depfile}` - the path for the generated dependency file
 - `${rspfile}` - the path to the RSP file, if `rsp_content` is set
 - `${args}` - the value of `args` - space-delimited
-- `${tool}` - the path to the script specified by `tool`
+- `${tool}` - the path to the first script specified in `tools`
+- `${tool <label>}` - the path to the script with name `<label>` specified in `tools`
 - `${host_bin}` - the path to the binary specified by `host_bin`
 - `${module_dir}` - the path this module's source directory
 - `${gen_dir}` - the path to the output directory for this module
@@ -49,10 +50,11 @@ The [`match_srcs`](../strings.md#match_srcs) function can be used in
 this property to reference files listed in `srcs`.
 
 ----
-### **bob_generated.tool** (required)
-A path to the tool that is to be used in `cmd`. If `${tool}` is in
+### **bob_generated.tools** (required)
+A path to the tools that are to be used in `cmd`. If `${tool}` is in
 the command variable, then this will be replaced with the path to
-this tool.
+the first tool on the list. To refer to the other tools provide its name
+as `${tool example.sh}` for the `example.sh` specified in the list.
 
 ----
 ### **bob_generated.host_bin** (optional)

--- a/docs/user_guide/code_generation.md
+++ b/docs/user_guide/code_generation.md
@@ -38,7 +38,7 @@ Note that the above module does not create a dependency on
 on the compilers and linkers used in C compilation.
 
 When scripts within the project are used to generate code, use the
-`tool` property to add a dependency on the script.
+`tools` property to add a dependency on the script.
 
 ```
 bob_generate_source {
@@ -46,7 +46,7 @@ bob_generate_source {
     srcs: ["custom_protocol.xml"],
     outs: ["code/wayland_server_custom_protocol.c"],
 
-    tool: "gen_wayland.py",
+    tools: ["gen_wayland.py"],
     args: ["code"],
     cmd: ["${tool} ${args} ${in} ${out}"],
 }
@@ -170,7 +170,7 @@ bob_transform_source {
 
     export_gen_include_dirs: ["inc"],
 
-    tool: "obfuscate.py",
+    tools: ["obfuscate.py"],
     cmd: "${tool} -o ${out} ${in}",
 }
 
@@ -256,7 +256,7 @@ bob_generate_source {
     outs: ["code/wayland_server_custom_protocol.c"],
     depfile: true,
 
-    tool: "gen_wayland.py",
+    tools: ["gen_wayland.py"],
     args: [
         "code",
         "-d",
@@ -289,7 +289,7 @@ bob_transform_source {
     depfile: true,
     export_gen_include_dirs: ["inc"],
 
-    tool: "obfuscate.py",
+    tools: ["obfuscate.py"],
     cmd: "${tool} -d ${depfile} -o ${out} ${in}",
 }
 
@@ -341,7 +341,7 @@ bob_transform_source {
     depfile: true,
     export_gen_include_dirs: ["inc"],
 
-    tool: "obfuscate.py",
+    tools: ["obfuscate.py"],
     cmd: "${tool} -d ${depfile} -o ${out} ${in}",
 }
 
@@ -386,7 +386,7 @@ bob_generate_source {
         "inc/x.h",
     ],
 
-    tool: "x_generator.py",
+    tools: ["x_generator.py"],
     cmd: "${tool} -c ${gen_dir}/src/x.cpp -h ${gen_dir}/src/x.h ${templates_out} --use x.in",
 }
 
@@ -398,7 +398,7 @@ bob_generate_source {
         "inc/y.h",
     ],
 
-    tool: "y_generator.py",
+    tools: ["y_generator.py"],
     cmd: "${tool} -c ${gen_dir}/src/y.cpp -h ${gen_dir}/src/y.h ${templates_out} --use y.in",
 }
 
@@ -558,7 +558,7 @@ bob_generate_source {
     srcs: ["file1.in", ..., "file999.in"],
     generated_sources: ["module_generating_many_files"],
     out: ["combined.c"],
-    tool: "combine.sh",
+    tools: ["combine.sh"],
     rsp_content: "${in}",
     cmd: "${tool} --input_list ${rspfile} --out ${out}",
 }

--- a/docs/user_guide/wrappers.md
+++ b/docs/user_guide/wrappers.md
@@ -42,7 +42,7 @@ bob_generate_source {
     name: "wrapcc_config",
     outs: ["wrapcc_config.json"],
 
-    tool: "wrapcc_config.py",
+    tools: ["wrapcc_config.py"],
     cmd: "${tool}",
 }
 

--- a/tests/bplist
+++ b/tests/bplist
@@ -26,6 +26,7 @@
 ./kernel_module/module1/build.bp
 ./kernel_module/module2/build.bp
 ./match_source/build.bp
+./multiple_tools/build.bp
 ./output/build.bp
 ./pgo/build.bp
 ./properties/build.bp

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -78,6 +78,7 @@ bob_alias {
         "bob_test_install_deps",
         "bob_test_kernel_module",
         "bob_test_match_source",
+        "bob_test_multiple_tools",
         "bob_test_output",
         "bob_test_pgo",
         "bob_test_properties",

--- a/tests/build_tests.sh
+++ b/tests/build_tests.sh
@@ -250,6 +250,12 @@ SRC=tests/resources/main.c
 UPDATE=(${build_dir}/install/testcases/y/main.c)
 check_dep_updated "resources" "${build_dir}" "${SRC}" "${UPDATE[@]}"
 
+# using multiple tools for source generation
+SRC=tests/multiple_tools/template.in
+UPDATE=(${build_dir}/gen/multiple_tools_generate_sources/tool_first_out.c
+        ${build_dir}/gen/multiple_tools_generate_sources/tool_second_out.c)
+check_dep_updated "generate source with multiple tools" "${build_dir}" "${SRC}" "${UPDATE[@]}"
+
 if [ "$OS" != "OSX" ] ; then
     # simple version script
     SRC=tests/version_script/exports0.map

--- a/tests/command_vars/build.bp
+++ b/tests/command_vars/build.bp
@@ -1,10 +1,27 @@
+/*
+ * Copyright 2019-2022 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 bob_generate_source {
     name: "bob_test_generate_source_single",
     out: [
         "single.c",
         "single.h",
     ],
-    tool: "generate_trivial_function.py",
+    tools: ["generate_trivial_function.py"],
     cmd: "${tool} testfn ${out}",
     build_by_default: true,
 }
@@ -16,7 +33,7 @@ bob_generate_source {
         "single.c",
         "single.h",
     ],
-    tool: "test_vars.py",
+    tools: ["test_vars.py"],
     cmd: "${tool} --check-basename ${bob_test_generate_source_single_out} single.c single.h " +
         "--copy ${bob_test_generate_source_single_out} ${gen_dir}",
     export_gen_include_dirs: ["."],

--- a/tests/flag_defaults/build.bp
+++ b/tests/flag_defaults/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018,2020 Arm Limited.
+ * Copyright 2018,2020,2022 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,7 +44,7 @@ bob_generate_source {
     name: "bob_test_flag_defaults_host",
     flag_defaults: ["bob_test_flag_defaults_second"],
     cmd: check_cmd,
-    tool: "check_cflags.py",
+    tools: ["check_cflags.py"],
     args: ["--check-host"],
     out: ["flags.txt"],
     target: "host",
@@ -55,7 +55,7 @@ bob_generate_source {
     name: "bob_test_flag_defaults_target",
     flag_defaults: ["bob_test_flag_defaults_second"],
     cmd: check_cmd,
-    tool: "check_cflags.py",
+    tools: ["check_cflags.py"],
     args: ["--check-target"],
     out: ["flags.txt"],
     target: "target",

--- a/tests/generate_libs/build.bp
+++ b/tests/generate_libs/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Arm Limited.
+ * Copyright 2018-2022 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -178,7 +178,7 @@ bob_generate_source {
     name: "check_renamed_gen_library",
     out: ["success.txt"],
     generated_sources: ["binary_linked_to_gen_shared_rename"],
-    tool: "check_library_link.py",
+    tools: ["check_library_link.py"],
     cmd: "${tool} --links-to libblah_shared2 ${args} ${in} && touch ${out}",
     osx: {
         args: ["--read-deps-method otool"],

--- a/tests/generate_source/build.bp
+++ b/tests/generate_source/build.bp
@@ -28,7 +28,7 @@ bob_generate_source {
     ],
     out: ["single.cpp"],
 
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in",
 }
 
@@ -41,7 +41,7 @@ bob_generate_source {
     ],
     out: ["multiple_in.cpp"],
 
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in before_generate2.in before_generate3.in",
 }
 
@@ -55,7 +55,7 @@ bob_generate_source {
         "multiple_out2.cpp",
     ],
 
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in",
 }
 
@@ -71,7 +71,7 @@ bob_generate_source {
         out: ["multiple_in_out2.cpp"],
     },
 
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in before_generate2.in before_generate3.in",
 }
 
@@ -87,7 +87,7 @@ bob_generate_source {
 
     out: ["level_1_single.cpp"],
 
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} --out ${out} --expect-in single.cpp",
 }
 
@@ -97,7 +97,7 @@ bob_generate_source {
 
     out: ["level_2_single.cpp"],
 
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} --out ${out} --expect-in level_1_single.cpp",
 }
 
@@ -107,7 +107,7 @@ bob_generate_source {
 
     out: ["level_3_single.cpp"],
 
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} --out ${out} --expect-in level_2_single.cpp",
 }
 
@@ -120,7 +120,7 @@ bob_generate_source {
     ],
     out: ["extra_single.cpp"],
 
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in level_2_single.cpp",
 }
 
@@ -139,7 +139,7 @@ bob_generate_source {
     ],
     out: ["deps.cpp"],
 
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} ${generate_source_single_out} --out ${out} --expect-in before_generate.in single.cpp",
 }
 
@@ -152,7 +152,7 @@ bob_generate_source {
     ],
     out: ["deps2.cpp"],
 
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in deps.cpp",
 }
 
@@ -186,7 +186,7 @@ bob_generate_source {
     srcs: ["depgen1.in"],
     out: ["output.txt"],
     depfile: true,
-    tool: "gen_with_dep.py",
+    tools: ["gen_with_dep.py"],
     cmd: "${tool} -o ${out} -d ${depfile} ${in}",
     build_by_default: true,
 }
@@ -199,7 +199,7 @@ bob_generate_source {
         "out.h"
     ],
     depfile: true,
-    tool: "gen_with_dep.py",
+    tools: ["gen_with_dep.py"],
     cmd: "${tool} --gen-implicit-out -o ${gen_dir}/output.txt -d ${depfile} ${in}",
     build_by_default: true,
 }
@@ -216,7 +216,7 @@ bob_generate_source {
     name: "gen_source_globbed_implicit_sources",
     implicit_srcs: ["*.implicit.src"],
     out: ["validate_globbed_implicit_dependency.c"],
-    tool: "join_srcs.py",
+    tools: ["join_srcs.py"],
     cmd: "python ${tool} --src-dir ${module_dir} --use-a --out ${out}",
     build_by_default: true,
 }
@@ -229,7 +229,7 @@ bob_generate_source {
         "bn.src",
     ],
     out: ["validate_globbed_exclude_implicit_dependency.c"],
-    tool: "join_srcs.py",
+    tools: ["join_srcs.py"],
     cmd: "python ${tool} --src-dir ${module_dir} --use-c --out ${out}",
     build_by_default: true,
 }

--- a/tests/multiple_tools/build.bp
+++ b/tests/multiple_tools/build.bp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+bob_generate_source {
+    name: "multiple_tools_generate_sources",
+    srcs: [
+        "template.in",
+    ],
+    out: [
+        "tool_first_out.c",
+        "tool_second_out.c",
+    ],
+
+    tools: [
+        "subtool/verify.py",
+        "generate.py",
+    ],
+    cmd: "python ${tool generate.py} --in ${in} --out ${out} && python ${tool subtool/verify.py} --in ${out}",
+    build_by_default: true,
+}
+
+bob_alias {
+    name: "bob_test_multiple_tools",
+    srcs: [
+        "multiple_tools_generate_sources",
+    ],
+}

--- a/tests/multiple_tools/generate.py
+++ b/tests/multiple_tools/generate.py
@@ -1,0 +1,39 @@
+#!/bin/python
+
+# Copyright 2022 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+
+
+parser = argparse.ArgumentParser(description='Test generator.')
+parser.add_argument('--in', dest='input', action='store', help='Input file')
+parser.add_argument('--out', nargs='*', dest='output', action='store', help='Output file')
+
+
+def main():
+    args = parser.parse_args()
+
+    with open(args.input, 'r') as f_in:
+        for out in args.output:
+            with open(out, 'w') as f_out:
+                f_out.write(f_in.read().replace("%%template%%", out))
+                f_in.seek(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/multiple_tools/subtool/verify.py
+++ b/tests/multiple_tools/subtool/verify.py
@@ -1,0 +1,38 @@
+#!/bin/python
+
+# Copyright 2022 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+import errno
+import os
+
+
+parser = argparse.ArgumentParser(description='Test generator.')
+parser.add_argument('--in', nargs='*', dest='input', action='store', help='Input file')
+
+
+def main():
+    args = parser.parse_args()
+
+    for in_f in args.input:
+        if not (os.path.exists(in_f) and os.path.isfile(in_f)):
+            raise OSError(errno.ENOENT, os.strerror(errno.ENOENT), in_f)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/multiple_tools/template.in
+++ b/tests/multiple_tools/template.in
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("\'%s\' created!\n", "%%template%%");
+    return 0;
+}

--- a/tests/output/build.bp
+++ b/tests/output/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 Arm Limited.
+ * Copyright 2019-2022 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,7 +43,7 @@ bob_generate_source {
         "lib_st_output",
     ],
     out: ["generated_output"],
-    tool: "verify.py",
+    tools: ["verify.py"],
     args: [
         "python ${tool} --out='${binary_output_out}' --expected='bob_output'",
         "&& python ${tool} --out='${lib_sh_output_out}' --expected='libshared_output' --shared",

--- a/tests/rsp/build.bp
+++ b/tests/rsp/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Arm Limited.
+ * Copyright 2020-2022 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,7 +32,7 @@ bob_transform_source {
         replace: ["out$1.txt"],
     },
     rsp_content: "${out}",
-    tool: "rspcat.py",
+    tools: ["rspcat.py"],
     cmd: "${tool} --input ${in} --output_list ${rspfile}",
 }
 
@@ -42,7 +42,7 @@ bob_generate_source {
     generated_sources: ["generate_multiple_sources"],
     out: ["merged.c"],
     rsp_content: "${in}",
-    tool: "rspcat.py",
+    tools: ["rspcat.py"],
     cmd: "${tool} --input_list ${rspfile} --output ${out}",
 }
 

--- a/tests/shared_libs_toc/build.bp
+++ b/tests/shared_libs_toc/build.bp
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2020,2022 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 bob_shared_library {
     name: "libsharedtest",
     srcs: ["srcs/lib.c"],
@@ -28,7 +45,7 @@ bob_transform_source {
     },
     host_bin: "utility",
     cmd: "${tool} -u ${host_bin} -i ${in} -o ${out}",
-    tool: "transform.py",
+    tools: ["transform.py"],
     target: "host",
 }
 

--- a/tests/transform_source/build.bp
+++ b/tests/transform_source/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Arm Limited.
+ * Copyright 2018-2022 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ bob_transform_source {
         ],
     },
     export_gen_include_dirs: ["single/transform_source"],
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} --gen ${out} --gen-implicit-header",
 }
 
@@ -50,7 +50,7 @@ bob_transform_source {
         },
     },
     export_gen_include_dirs: ["transform_source"],
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} --gen ${out} --gen-implicit-header",
 }
 
@@ -78,14 +78,14 @@ bob_transform_source {
         "generate_source_to_transform",
         "transform_source",
     ],
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} --gen ${out} --gen-implicit-header",
 }
 
 bob_generate_source {
     name: "generate_template_source_used_by_transform",
     out: ["test_src.tmpl"],
-    tool: "write_tmpl.py",
+    tools: ["write_tmpl.py"],
     cmd: "python ${tool} ${out}",
 }
 
@@ -103,7 +103,7 @@ bob_transform_source {
         ],
     },
     export_gen_include_dirs: ["."],
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} --gen ${out} --src-template ${generate_template_source_used_by_transform_out}",
 }
 
@@ -123,7 +123,7 @@ bob_transform_source {
             "$1.h",
         ],
     },
-    tool: "generator.py",
+    tools: ["generator.py"],
     cmd: "python ${tool} --in ${in} --gen ${out} --gen-implicit-header",
     build_by_default: true,
 }
@@ -141,7 +141,7 @@ bob_generate_source {
         "transform_source_generated_sources_only",
     ],
     out: ["combined_source.cpp"],
-    tool: "combine_sources.py",
+    tools: ["combine_sources.py"],
     cmd: "${tool} --out ${out} ${in}",
 }
 


### PR DESCRIPTION
Currently bob_generate_source and bob_transform_source support only
one tool which may be used in `cmd`. This is only single tool provided
with `tool` property. However some source generation need to refer to
two or more separate tools.

This change extends `tool` property to be a list. Referencing particular
tool is done by `${tool <label>}` syntax, where `<label>` is a tool name
specified on the list, e.g. `${tool sub/gen.py}` refers to `gen.py` tool
located in `sub` sub-directory:
```
bob_generate_source {
    name: "generate_source",
    tools: [
        "first_tool.py",
        "second_tool.py",
        "sub/gen.py",
    ],
    cmd: "python ${tool sub/gen.py}",
}
```
Change-Id: Idc3388c697512b412d7ff26aea2c92c8379a9eac
Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>