### PR TITLE
OSX workaround for empty static libs

### DIFF
--- a/tests/bplist
+++ b/tests/bplist
@@ -1,8 +1,8 @@
 ./aliases/build.bp
 ./arg_order/build.bp
 ./binary/build.bp
-./bob/Blueprints
 ./bob/blueprint/Blueprints
+./bob/Blueprints
 ./build.bp
 ./command_vars/build.bp
 ./cxx11_simple/build.bp
@@ -14,13 +14,14 @@
 ./external_libs/build.bp
 ./flag_defaults/build.bp
 ./flag_supported/build.bp
-./forwarding_libs/forwarding/build.bp
 ./forwarding_libs/forwarding_impl/build.bp
 ./forwarding_libs/forwarding_user/build.bp
+./forwarding_libs/forwarding/build.bp
 ./generate_libs/build.bp
 ./generate_source/build.bp
 ./generated_headers/build.bp
 ./globs/build.bp
+./header_libs/build.bp
 ./install_deps/build.bp
 ./kernel_module/build.bp
 ./kernel_module/module1/build.bp
@@ -33,8 +34,8 @@
 ./reexport_libs/build.bp
 ./resources/build.bp
 ./rsp/build.bp
-./shared_libs/build.bp
 ./shared_libs_toc/build.bp
+./shared_libs/build.bp
 ./static_libs/build.bp
 ./target_specific_static_libs/build.bp
 ./templates/build.bp

--- a/tests/build.bp
+++ b/tests/build.bp
@@ -59,8 +59,8 @@ bob_install_group {
 bob_alias {
     name: "bob_tests",
     srcs: [
-        "bob_test_aliases",
         "bob_test_aliases_all_variants",
+        "bob_test_aliases",
         "bob_test_arg_order",
         "bob_test_command_vars",
         "bob_test_cxx11simple",
@@ -75,6 +75,7 @@ bob_alias {
         "bob_test_generate_source",
         "bob_test_generated_headers",
         "bob_test_globs",
+        "bob_test_header_libs",
         "bob_test_install_deps",
         "bob_test_kernel_module",
         "bob_test_match_source",
@@ -84,8 +85,8 @@ bob_alias {
         "bob_test_properties",
         "bob_test_reexport_libs",
         "bob_test_resources",
-        "bob_test_shared_libs",
         "bob_test_shared_libs_toc",
+        "bob_test_shared_libs",
         "bob_test_simple_binary",
         "bob_test_static_libs",
         "bob_test_target_specific_static_libs",

--- a/tests/header_libs/build.bp
+++ b/tests/header_libs/build.bp
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+bob_alias {
+    name: "bob_test_header_libs",
+    srcs: [
+        "hl_main",
+    ],
+}
+
+bob_static_library {
+    name: "hl_a",
+    export_local_include_dirs: ["include"],
+}
+
+bob_static_library {
+    name: "hl_b",
+    export_local_include_dirs: ["include"],
+    static_libs: ["hl_a"]
+}
+
+bob_binary {
+    name: "hl_main",
+    srcs: ["main.c"],
+    static_libs: ["hl_b"],
+}
+
+
+

--- a/tests/header_libs/include/a/a.h
+++ b/tests/header_libs/include/a/a.h
@@ -1,0 +1,6 @@
+#ifndef A_H
+#define A_H
+
+#define A_VAL 1
+
+#endif /* A_H */

--- a/tests/header_libs/include/b/b.h
+++ b/tests/header_libs/include/b/b.h
@@ -1,0 +1,8 @@
+#ifndef B_H
+#define B_H
+
+#include "a/a.h"
+
+#define B_VAL 2
+
+#endif /* B_H */

--- a/tests/header_libs/main.c
+++ b/tests/header_libs/main.c
@@ -1,0 +1,16 @@
+
+#include "a/a.h"
+#include "b/b.h"
+
+#ifndef A_VAL
+#error "A_VAL not defined."
+#endif
+
+#ifndef B_VAL
+#error "B_VAL not defined."
+#endif
+
+int main(void)
+{
+    return A_VAL + B_VAL;
+}


### PR DESCRIPTION
Change-Id: Ide7bc548e725f0e53ad809f46109879948142b09