### PR TITLE
Loosen Android.bp permissions

### DIFF
--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Arm Limited.
+ * Copyright 2020, 2022 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +45,7 @@ func WriteIfChanged(filename string, sb *strings.Builder) error {
 	}
 
 	if mustWrite {
-		file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+		file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Make the generate `Android.bp` and `Android.mk` more widely readable,
matching the permissions of other generated files e.g. `config.json`.

Signed-off-by: Chris Diamand <chris.diamand@arm.com>
Change-Id: I678a54f6645e48609f0f64e58378174b0d66a94b