### PR TITLE
Refactor `phonyInterface`

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -30,10 +30,6 @@ import (
 
 // Types implementing phonyInterface support the creation of phony targets.
 type phonyInterface interface {
-	// A list of the outputs to be built when shortName is specified as the target
-	outputs() []string
-	implicitOutputs() []string
-
 	// The name of the target that can be used
 	shortName() string
 }
@@ -74,6 +70,9 @@ func (t *TargetSpecific) getTargetSpecificProps() interface{} {
 // A type implementing dependentInterface can be depended upon by other modules.
 type dependentInterface interface {
 	phonyInterface
+
+	outputs() []string
+	implicitOutputs() []string
 	outputDir() string
 }
 

--- a/core/install.go
+++ b/core/install.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Arm Limited.
+ * Copyright 2018-2022 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -235,17 +235,6 @@ func (m *resource) altShortName() string {
 
 func (m *resource) getEnableableProps() *EnableableProps {
 	return &m.Properties.EnableableProps
-}
-
-// Resources don't have any outputs (i.e. stuff generated in the build
-// directory) - they only copy source files to the installation dir. This
-// method exists to implement PhonyInterface.
-func (m *resource) outputs() []string {
-	return []string{}
-}
-
-func (m *resource) implicitOutputs() []string {
-	return []string{}
 }
 
 func (m *resource) filesToInstall(ctx blueprint.BaseModuleContext) []string {

--- a/core/linux_backend.go
+++ b/core/linux_backend.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Arm Limited.
+ * Copyright 2018-2022 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -76,15 +76,17 @@ func getTocUsageFromEnvironment() bool {
 func addPhony(p phonyInterface, ctx blueprint.ModuleContext,
 	installDeps []string, optional bool) {
 
-	deps := utils.NewStringSlice(p.outputs(), p.implicitOutputs(), installDeps)
-
 	ctx.Build(pctx,
 		blueprint.BuildParams{
 			Rule:     blueprint.Phony,
-			Inputs:   deps,
+			Inputs:   installDeps,
 			Outputs:  []string{p.shortName()},
 			Optional: optional,
 		})
+}
+
+func (g *linuxGenerator) getPhonyFiles(p dependentInterface) []string {
+	return utils.NewStringSlice(p.outputs(), p.implicitOutputs())
 }
 
 func (g *linuxGenerator) escapeFlag(s string) string {

--- a/core/linux_cclibs.go
+++ b/core/linux_cclibs.go
@@ -290,7 +290,7 @@ func (g *linuxGenerator) staticActions(m *staticLibrary, ctx blueprint.ModuleCon
 			Args:      args,
 		})
 
-	installDeps := g.install(m, ctx)
+	installDeps := append(g.install(m, ctx), g.getPhonyFiles(m)...)
 	addPhony(m, ctx, installDeps, !isBuiltByDefault(m))
 }
 
@@ -568,6 +568,7 @@ func (g *linuxGenerator) sharedActions(m *sharedLibrary, ctx blueprint.ModuleCon
 	tocFile := g.getSharedLibTocPath(m)
 	g.addSharedLibToc(ctx, soFile, tocFile, m.getTarget())
 
+	installDeps = append(installDeps, g.getPhonyFiles(m)...)
 	addPhony(m, ctx, installDeps, !isBuiltByDefault(m))
 }
 
@@ -609,6 +610,7 @@ func (g *linuxGenerator) binaryActions(m *binary, ctx blueprint.ModuleContext) {
 			Optional:  true,
 			Args:      g.getBinaryArgs(m, ctx),
 		})
-	installDeps := g.install(m, ctx)
+
+	installDeps := append(g.install(m, ctx), g.getPhonyFiles(m)...)
 	addPhony(m, ctx, installDeps, optional)
 }

--- a/core/linux_generated.go
+++ b/core/linux_generated.go
@@ -170,7 +170,7 @@ func (g *linuxGenerator) generateSourceActions(m *generateSource, ctx blueprint.
 	inouts := m.generateInouts(ctx, g)
 	g.generateCommonActions(&m.generateCommon, ctx, inouts)
 
-	installDeps := g.install(m, ctx)
+	installDeps := append(g.install(m, ctx), g.getPhonyFiles(m)...)
 	addPhony(m, ctx, installDeps, !isBuiltByDefault(m))
 }
 
@@ -178,7 +178,7 @@ func (g *linuxGenerator) transformSourceActions(m *transformSource, ctx blueprin
 	inouts := m.generateInouts(ctx, g)
 	g.generateCommonActions(&m.generateCommon, ctx, inouts)
 
-	installDeps := g.install(m, ctx)
+	installDeps := append(g.install(m, ctx), g.getPhonyFiles(m)...)
 	addPhony(m, ctx, installDeps, !isBuiltByDefault(m))
 }
 
@@ -186,7 +186,7 @@ func (g *linuxGenerator) genStaticActions(m *generateStaticLibrary, ctx blueprin
 	inouts := m.generateInouts(ctx, g)
 	g.generateCommonActions(&m.generateCommon, ctx, inouts)
 
-	installDeps := g.install(m, ctx)
+	installDeps := append(g.install(m, ctx), g.getPhonyFiles(m)...)
 	addPhony(m, ctx, installDeps, !isBuiltByDefault(m))
 }
 
@@ -208,7 +208,7 @@ func (g *linuxGenerator) genSharedActions(m *generateSharedLibrary, ctx blueprin
 	tocFile := g.getSharedLibTocPath(m)
 	g.addSharedLibToc(ctx, soFile, tocFile, m.getTarget())
 
-	installDeps := g.install(m, ctx)
+	installDeps := append(g.install(m, ctx), g.getPhonyFiles(m)...)
 	addPhony(m, ctx, installDeps, !isBuiltByDefault(m))
 }
 
@@ -226,6 +226,6 @@ func (g *linuxGenerator) genBinaryActions(m *generateBinary, ctx blueprint.Modul
 			Optional: true,
 		})
 
-	installDeps := g.install(m, ctx)
+	installDeps := append(g.install(m, ctx), g.getPhonyFiles(m)...)
 	addPhony(m, ctx, installDeps, !isBuiltByDefault(m))
 }

--- a/core/linux_kernel_module.go
+++ b/core/linux_kernel_module.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Arm Limited.
+ * Copyright 2018-2022 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -81,6 +81,6 @@ func (g *linuxGenerator) kernelModuleActions(m *kernelModule, ctx blueprint.Modu
 			Optional: true,
 		})
 
-	installDeps := g.install(m, ctx)
+	installDeps := append(g.install(m, ctx), g.getPhonyFiles(m)...)
 	addPhony(m, ctx, installDeps, optional)
 }


### PR DESCRIPTION
As `bob_resource` module implements `phonyInterface` it has to define `outputs()` and `implicitOutputs` even though it doesn't have any. Both methods need to be moved to `dependentInterface`.

Change-Id: Iad188d6cc3f0a0fa472f4a8868e1620cafc2d680
Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>