### PR TITLE
Add Warning logger

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -36,6 +36,7 @@ bootstrap_go_package {
         "bob-fileutils",
         "bob-graph",
         "bob-utils",
+        "bob-warnings",
     ],
     srcs: [
         "core/android.go",
@@ -148,4 +149,15 @@ bootstrap_go_package {
         "internal/utils/utils_test.go",
     ],
     pkgPath: "github.com/ARM-software/bob-build/internal/utils",
+}
+
+bootstrap_go_package {
+    name: "bob-warnings",
+    srcs: [
+        "internal/warnings/warnings.go",
+    ],
+    testSrcs: [
+        "internal/warnings/warnings_test.go",
+    ],
+    pkgPath: "github.com/ARM-software/bob-build/internal/warnings",
 }

--- a/bob.bootstrap.in
+++ b/bob.bootstrap.in
@@ -1,4 +1,4 @@
-# Copyright 2018-2019, 2021 Arm Limited.
+# Copyright 2018-2019, 2021-2022 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,3 +30,5 @@ export CONFIG_JSON="@@ConfigJson@@"
 export BOB_CONFIG_OPTS="@@BobConfigOpts@@"
 export BOB_CONFIG_PLUGIN_OPTS="@@BobConfigPluginOpts@@"
 export BOB_BOOTSTRAP_VERSION="@@BobBootstrapVersion@@"
+export BOB_LOG_WARNINGS_FILE="@@BobLogWarningsFile@@"
+export BOB_LOG_WARNINGS="@@BobLogWarnings@@"

--- a/bob.bootstrap.version
+++ b/bob.bootstrap.version
@@ -1,2 +1,2 @@
 # Version number used to identify whether the user needs to re-boostrap their build directory.
-BOB_VERSION="8"
+BOB_VERSION="9"

--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018-2021 Arm Limited.
+# Copyright 2018-2022 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -93,6 +93,12 @@ fi
 BOB_DIR="$(relative_path $(pwd) "${SCRIPT_DIR}")"
 CONFIG_FILE="${CONFIGDIR}/${CONFIGNAME}"
 CONFIG_JSON="${CONFIGDIR}/.bob.config.json"
+
+# Bob warnings log file
+BOB_LOG_WARNINGS_FILE="${BUILDDIR}/.bob.warnings.csv"
+
+# space separated values, e.g. "*:W RelativeUpLinkWarning:E"
+BOB_LOG_WARNINGS=""
 
 export TOPNAME="build.bp"
 export BOOTSTRAP="${BOB_DIR}/bootstrap.bash"

--- a/bootstrap/utils.bash
+++ b/bootstrap/utils.bash
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 Arm Limited.
+# Copyright 2018-2022 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +37,8 @@ function write_bootstrap() {
         -e "s|@@BobConfigOpts@@|${BOB_CONFIG_OPTS}|" \
         -e "s|@@BobConfigPluginOpts@@|${BOB_CONFIG_PLUGIN_OPTS}|" \
         -e "s|@@BobBootstrapVersion@@|${BOB_VERSION}|" \
+        -e "s|@@BobLogWarningsFile@@|${BOB_LOG_WARNINGS_FILE}|" \
+        -e "s|@@BobLogWarnings@@|${BOB_LOG_WARNINGS}|" \
         "${BOB_DIR}/bob.bootstrap.in" > "${BUILDDIR}/.bob.bootstrap.tmp"
     rsync -c "${BUILDDIR}/.bob.bootstrap.tmp" "${BUILDDIR}/.bob.bootstrap"
 }

--- a/core/androidbp_backend.go
+++ b/core/androidbp_backend.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ARM-software/bob-build/internal/bpwriter"
 	"github.com/ARM-software/bob-build/internal/fileutils"
 	"github.com/ARM-software/bob-build/internal/utils"
+	"github.com/ARM-software/bob-build/internal/warnings"
 )
 
 var (
@@ -43,6 +44,7 @@ var (
 
 type androidBpGenerator struct {
 	toolchainSet
+	logger *warnings.WarningLogger
 }
 
 /* Compile time checks for interfaces that must be implemented by androidBpGenerator */
@@ -480,6 +482,10 @@ func (s *androidBpSingleton) GenerateBuildActions(ctx blueprint.SingletonContext
 			Outputs:  []string{androidbpFile},
 			Optional: true,
 		})
+}
+
+func (g *androidBpGenerator) getLogger() *warnings.WarningLogger {
+	return g.logger
 }
 
 func (g *androidBpGenerator) init(ctx *blueprint.Context, config *bobConfig) {

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/blueprint/proptools"
 
 	"github.com/ARM-software/bob-build/internal/utils"
+	"github.com/ARM-software/bob-build/internal/warnings"
 )
 
 // Types implementing phonyInterface support the creation of phony targets.
@@ -121,6 +122,8 @@ type generatorBackend interface {
 
 	// Access to backend configuration
 	getToolchain(tgt tgtType) toolchain
+
+	getLogger() *warnings.WarningLogger
 }
 
 // The bobConfig type is stored against the Blueprint context, and allows us to
@@ -283,6 +286,7 @@ func (s *SourceProps) getSources(ctx blueprint.BaseModuleContext) []string {
 
 func (s *SourceProps) processPaths(ctx blueprint.BaseModuleContext, g generatorBackend) {
 	prefix := projectModuleDir(ctx)
+
 	s.Srcs = utils.PrefixDirs(s.Srcs, prefix)
 	s.Exclude_srcs = utils.PrefixDirs(s.Exclude_srcs, prefix)
 }

--- a/core/linux_backend.go
+++ b/core/linux_backend.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/blueprint/proptools"
 
 	"github.com/ARM-software/bob-build/internal/utils"
+	"github.com/ARM-software/bob-build/internal/warnings"
 )
 
 var (
@@ -46,6 +47,7 @@ var (
 
 type linuxGenerator struct {
 	toolchainSet
+	logger *warnings.WarningLogger
 }
 
 /* Compile time checks for interfaces that must be implemented by linuxGenerator */
@@ -363,6 +365,10 @@ func (g *linuxGenerator) resourceActions(m *resource, ctx blueprint.ModuleContex
 
 func (g *linuxGenerator) filegroupActions(m *filegroup, ctx blueprint.ModuleContext) {
 
+}
+
+func (g *linuxGenerator) getLogger() *warnings.WarningLogger {
+	return g.logger
 }
 
 func (g *linuxGenerator) init(ctx *blueprint.Context, config *bobConfig) {

--- a/internal/warnings/warnings.go
+++ b/internal/warnings/warnings.go
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package warnings
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+)
+
+type Category string
+
+const (
+	DeprecationWarning    Category = "DeprecationWarning"
+	DirectPathsWarning    Category = "DirectPathsWarning"
+	GenerateRuleWarning   Category = "GenerateRuleWarning"
+	PropertyWarning       Category = "PropertyWarning"
+	RelativeUpLinkWarning Category = "RelativeUpLinkWarning"
+	UserWarning           Category = "UserWarning"
+)
+
+var categoriesMap = map[string]Category{
+	string(DeprecationWarning):    DeprecationWarning,
+	string(DirectPathsWarning):    DirectPathsWarning,
+	string(GenerateRuleWarning):   GenerateRuleWarning,
+	string(PropertyWarning):       PropertyWarning,
+	string(RelativeUpLinkWarning): RelativeUpLinkWarning,
+	string(UserWarning):           UserWarning,
+}
+
+type Action string
+
+const (
+	IgnoreAction  Action = "ignore"
+	WarningAction Action = "warning"
+	ErrorAction   Action = "error"
+)
+
+var actionsMap = map[string]Action{
+	"I": IgnoreAction,
+	"W": WarningAction,
+	"E": ErrorAction,
+}
+
+type WarningLogger struct {
+	out          *csv.Writer
+	mu           sync.Mutex
+	filters      map[Category]Action
+	globalAction Action
+	errors       int
+}
+
+func New(out io.Writer, filters string) *WarningLogger {
+	w := csv.NewWriter(out)
+	w.Write([]string{"BpFile", "BpModule", "WarningAction", "WarningMessage", "WarningCategory"})
+	w.Flush()
+
+	f, g := parseFilters(filters)
+
+	return &WarningLogger{out: w, filters: f, globalAction: g}
+}
+
+func parseFilters(f string) (filters map[Category]Action, globalAction Action) {
+
+	filters = make(map[Category]Action)
+
+	fn := func(c rune) bool {
+		return c == ' '
+	}
+
+	if f != "" {
+		for _, subFilter := range strings.FieldsFunc(f, fn) {
+			parts := strings.SplitN(subFilter, ":", 2)
+
+			if len(parts) != 2 {
+				fmt.Fprintf(os.Stderr, "Wrong warnings filter expression '%s'\n", subFilter)
+				continue
+			}
+
+			c, a := parts[0], parts[1]
+
+			if _, ok := actionsMap[a]; !ok {
+				fmt.Fprintf(os.Stderr, "Wrong filter action '%s'\n", subFilter)
+				continue
+			}
+
+			if c == "*" {
+				if globalAction != "" {
+					fmt.Fprintf(os.Stderr, "Overriding wildcard (*) not allowed: '%s'\n", subFilter)
+				} else {
+					globalAction = actionsMap[a]
+				}
+
+				continue
+			}
+
+			if category, ok := categoriesMap[c]; ok {
+				if _, ok := filters[category]; ok {
+					fmt.Fprintf(os.Stderr, "Overriding warning category not allowed: '%s'\n", subFilter)
+					continue
+				}
+
+				filters[category] = actionsMap[a]
+			} else {
+				fmt.Fprintf(os.Stderr, "Wrong filter category '%s'\n", subFilter)
+			}
+		}
+	}
+
+	if globalAction == "" {
+		globalAction = IgnoreAction
+	}
+
+	return
+}
+
+func (w *WarningLogger) ErrorWarnings() int {
+	return w.errors
+}
+
+func (w *WarningLogger) Warn(category Category, bpFile string, bpModule string, message string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	action, ok := w.filters[category]
+
+	if !ok {
+		action = w.globalAction
+	}
+
+	if action == ErrorAction {
+		w.errors++
+	}
+
+	if action != IgnoreAction {
+		io.WriteString(os.Stderr, fmt.Sprintf("%s:%s: %s: %s [%s]\n", bpFile, bpModule, action, message, category))
+	}
+
+	w.out.Write([]string{bpFile, bpModule, string(action), message, string(category)})
+	w.out.Flush()
+
+	return w.out.Error()
+}

--- a/internal/warnings/warnings.md
+++ b/internal/warnings/warnings.md
@@ -1,0 +1,75 @@
+WarningLogger
+==================
+
+`WarningLogger` allows to write out the warnings to any `io.Writer`
+with the CSV format of:
+```
+BpFile,BpModule,WarningAction,WarningMessage,WarningCategory
+```
+Additionally warnings set with `WarningAction` or `ErrorAction`
+action will be printed to `os.Stderr`.
+
+
+## Warnings categories
+
+There are few types to categorize a warning:
+
+- `DirectPathsWarning`
+- `GenerateRuleWarning`
+- `PropertyWarning`
+- `RelativeUpLinkWarning`
+- `UserWarning`
+
+
+## Warning actions
+
+`WarningLogger` has a three actions to deal with warnings:
+- `I` (ignore)
+- `W` (warning)
+- `E` (error)
+
+By default all raised warnings are ignored coupled with action ignore (I).
+It means all the issues will be written just to provided `io.Writer`
+but not to `io.Stderr`.
+
+
+## Warning filtering
+
+_Filter expression_ allows to change the default behavior and change
+the action for particular warning categories. It is a space separated
+string with the format:
+```
+"WarningCategory:WarningAction"
+```
+E.g. to warn (`W`) all `RelativeUpLinkWarning`, _filter expression_ will be:
+```
+"RelativeUpLinkWarning:W"
+```
+
+It is possible to combine all warning categories with specific action using
+a wildcard (`*`). E.g. to mark all warning categories as errors (`E`),
+_filter expression_ will be:
+```
+"*:E"
+```
+
+Wildcard can be combined also with the other filters. In that case wildcard
+will take an effect only with those categories which were not specified, e.g.
+all but `RelativeUpLinkWarning` and `PropertyWarning` will be set as errors:
+```
+"PropertyWarning:I *:E RelativeUpLinkWarning:W"
+```
+
+**IMPORTANT:** Overriding category or a wildcard (`*`) is not possible.
+Only the first occurrence will give an effect:
+- `"*:W *:E"` - all as warning
+- `"RelativeUpLinkWarning:E RelativeUpLinkWarning:W"` - RelativeUpLinkWarning as error
+
+---
+
+Current behavior of the logger is to emit all warnings before raising
+an error. `WarningLogger` counts the number of errors occurred for
+later processing:
+```go
+func (w *WarningLogger) ErrorWarnings() int
+```

--- a/internal/warnings/warnings_test.go
+++ b/internal/warnings/warnings_test.go
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2022 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package warnings
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func captureStderr(f func()) string {
+	r, w, err := os.Pipe()
+
+	if err != nil {
+		panic(err)
+	}
+
+	stderr := os.Stderr
+	os.Stderr = w
+	defer func() {
+		os.Stderr = stderr
+	}()
+
+	f()
+	w.Close()
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+
+	return buf.String()
+
+}
+
+func TestWarningDefault(t *testing.T) {
+	const expected string = `BpFile,BpModule,WarningAction,WarningMessage,WarningCategory
+A/build.bp,gen_table,ignore,"Warning ocurred, will warn!",UserWarning
+`
+	var msg strings.Builder
+
+	wr := New(&msg, "")
+	wr.Warn(UserWarning, "A/build.bp", "gen_table", "Warning ocurred, will warn!")
+
+	assert.Equal(t, expected, msg.String())
+}
+
+func TestWarning(t *testing.T) {
+	const expected string = `BpFile,BpModule,WarningAction,WarningMessage,WarningCategory
+A/build.bp,gen_table,warning,Warning ocurred!,UserWarning
+B/build.bp,gen_binary,ignore,Warning ocurred!,RelativeUpLinkWarning
+`
+	const expectedStderr string = "A/build.bp:gen_table: warning: Warning ocurred! [UserWarning]\n"
+	var msg strings.Builder
+
+	wr := New(&msg, "UserWarning:W")
+
+	stderrOutput := captureStderr(func() {
+		wr.Warn(UserWarning, "A/build.bp", "gen_table", "Warning ocurred!")
+		wr.Warn(RelativeUpLinkWarning, "B/build.bp", "gen_binary", "Warning ocurred!")
+	})
+
+	//assert.Equal(t, expected, msg.String())
+	assert.Equal(t, expectedStderr, stderrOutput)
+}
+
+func TestErrorWarning(t *testing.T) {
+	const expected string = `BpFile,BpModule,WarningAction,WarningMessage,WarningCategory
+A/build.bp,gen_table,error,Wrong target!,UserWarning
+B/build.bp,gen_binary,warning,Warning ocurred!,RelativeUpLinkWarning
+`
+	const expectedStderr string = `A/build.bp:gen_table: error: Wrong target! [UserWarning]
+B/build.bp:gen_binary: warning: Warning ocurred! [RelativeUpLinkWarning]
+`
+	var msg strings.Builder
+
+	wr := New(&msg, "UserWarning:E RelativeUpLinkWarning:W")
+	stderrOutput := captureStderr(func() {
+		wr.Warn(UserWarning, "A/build.bp", "gen_table", "Wrong target!")
+		wr.Warn(RelativeUpLinkWarning, "B/build.bp", "gen_binary", "Warning ocurred!")
+	})
+
+	assert.Equal(t, expected, msg.String())
+	assert.Equal(t, expectedStderr, stderrOutput)
+}
+
+func TestFilterOverwriteCategory(t *testing.T) {
+	const expected string = "Overriding warning category not allowed: 'UserWarning:W'\n"
+	var msg strings.Builder
+
+	stderrOutput := captureStderr(func() {
+		New(&msg, "UserWarning:E RelativeUpLinkWarning:W UserWarning:W")
+	})
+
+	assert.Equal(t, expected, stderrOutput)
+}
+
+func TestFilterOverwriteWildcard(t *testing.T) {
+	const expected string = "Overriding wildcard (*) not allowed: '*:W'\n"
+	var msg strings.Builder
+
+	stderrOutput := captureStderr(func() {
+		New(&msg, "*:E RelativeUpLinkWarning:W *:W")
+	})
+
+	assert.Equal(t, expected, stderrOutput)
+}
+
+func TestErrorAllWarnings(t *testing.T) {
+	const expectedStderr string = `A/build.bp:gen_table: error: Wrong target! [UserWarning]
+B/build.bp:gen_binary: warning: Warning ocurred! [RelativeUpLinkWarning]
+`
+	const expected string = `BpFile,BpModule,WarningAction,WarningMessage,WarningCategory
+A/build.bp,gen_table,error,Wrong target!,UserWarning
+B/build.bp,gen_binary,warning,Warning ocurred!,RelativeUpLinkWarning
+`
+	var msg strings.Builder
+
+	wr := New(&msg, "*:E RelativeUpLinkWarning:W")
+	stderrOutput := captureStderr(func() {
+		wr.Warn(UserWarning, "A/build.bp", "gen_table", "Wrong target!")
+		wr.Warn(RelativeUpLinkWarning, "B/build.bp", "gen_binary", "Warning ocurred!")
+	})
+
+	assert.Equal(t, expected, msg.String())
+	assert.Equal(t, expectedStderr, stderrOutput)
+}
+
+func TestWrongFilterCategory(t *testing.T) {
+	const expected string = "Wrong filter category 'Ridiculous:E'\n"
+	var msg strings.Builder
+
+	stderrOutput := captureStderr(func() {
+		New(&msg, "Ridiculous:E")
+	})
+
+	assert.Equal(t, expected, stderrOutput)
+}
+
+func TestWrongFilterAction(t *testing.T) {
+	const expected string = "Wrong filter action 'DirectPathsWarning:D'\n"
+	var msg strings.Builder
+
+	stderrOutput := captureStderr(func() {
+		New(&msg, "DirectPathsWarning:D")
+	})
+
+	assert.Equal(t, expected, stderrOutput)
+}
+
+func TestWrongFilter(t *testing.T) {
+	const expected string = "Wrong warnings filter expression 'DirectPathsWarning'\n"
+	var msg strings.Builder
+
+	stderrOutput := captureStderr(func() {
+		New(&msg, "DirectPathsWarning RelativeUpLinkWarning:W")
+	})
+
+	assert.Equal(t, expected, stderrOutput)
+}
+
+func TestCheckIfErrors(t *testing.T) {
+	var msg strings.Builder
+
+	wr := New(&msg, "UserWarning:E RelativeUpLinkWarning:W")
+	captureStderr(func() {
+		wr.Warn(UserWarning, "A/build.bp", "gen_table", "Wrong target!")
+		wr.Warn(RelativeUpLinkWarning, "B/build.bp", "gen_binary", "Warning ocurred!")
+		assert.Equal(t, 1, wr.ErrorWarnings())
+		wr.Warn(UserWarning, "ABC/build.bp", "gen_lib", "Another wrong target!")
+		wr.Warn(RelativeUpLinkWarning, "BCD/build.bp", "gen_binary_two", "Warning ocurred!")
+		assert.Equal(t, 2, wr.ErrorWarnings())
+	})
+}


### PR DESCRIPTION
Provide a warning logger which allow to issue
an alert of some condition where it doesn't
rise an exception and terminate the program.

WarningLogger is able to write to `io.Writer`.
By default Bob will write to `.bob.warnings.csv`
file located in the build directory. Output
file is of CSV format.

There is a BOB_LOG_WARNINGS variable to be
set on bootstrap which allows to set filters
for particular warning categories.
It is a space separated string of format:
"UserWarning:E *:W"

By default all warnings are ignored,
i.e. will be written to log file but not
printed to `io.Stderr`.

Change-Id: Ic28adcfe532248ded6725f3b601ee50cd53b9943
Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>