### PR TITLE
Log GenerateRuleWarning warnings

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -18,6 +18,7 @@
 package core
 
 import (
+	"fmt"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -286,6 +287,13 @@ func (s *SourceProps) getSources(ctx blueprint.BaseModuleContext) []string {
 
 func (s *SourceProps) processPaths(ctx blueprint.BaseModuleContext, g generatorBackend) {
 	prefix := projectModuleDir(ctx)
+
+	for _, s := range s.Srcs {
+		if strings.HasPrefix(filepath.Clean(s), "../") {
+			msg := fmt.Sprintf("Path '%s' contains relative up-links, this is not allowed. Please use `bob_filegroup` instead.", s)
+			g.getLogger().Warn(warnings.RelativeUpLinkWarning, ctx.BlueprintsFile(), ctx.ModuleName(), msg)
+		}
+	}
 
 	s.Srcs = utils.PrefixDirs(s.Srcs, prefix)
 	s.Exclude_srcs = utils.PrefixDirs(s.Exclude_srcs, prefix)

--- a/core/generated.go
+++ b/core/generated.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/blueprint/proptools"
 
 	"github.com/ARM-software/bob-build/internal/utils"
+	"github.com/ARM-software/bob-build/internal/warnings"
 )
 
 var (
@@ -902,6 +903,12 @@ func getGeneratedFiles(ctx blueprint.ModuleContext) []string {
 }
 
 func generatedDependerMutator(mctx blueprint.BottomUpMutatorContext) {
+
+	if _, ok := mctx.Module().(*generateSource); ok {
+		msg := "`bob_generate_source` is deprecated, use `bob_genrule` instead"
+		getBackend(mctx).getLogger().Warn(warnings.GenerateRuleWarning, mctx.BlueprintsFile(), mctx.ModuleName(), msg)
+	}
+
 	if e, ok := mctx.Module().(enableable); ok {
 		if !isEnabled(e) {
 			// Not enabled, so don't add dependencies


### PR DESCRIPTION
`bob_generate_source` should be replaced by `bob_genrule`
target thus Bob should warn whenever former is used.

Change-Id: If4353fcbed5ee28bf6b51f1cb57824ca7097dae5
Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>