### PR TITLE
Log DefaultSrcsWarning warnings

### DIFF
--- a/core/defaults.go
+++ b/core/defaults.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Arm Limited.
+ * Copyright 2018-2022 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,7 @@ import (
 	"github.com/google/blueprint"
 
 	"github.com/ARM-software/bob-build/internal/utils"
+	"github.com/ARM-software/bob-build/internal/warnings"
 )
 
 type defaults struct {
@@ -188,6 +189,16 @@ var (
 
 // Locally store defaults in defaultsMap
 func defaultDepsStage1Mutator(mctx blueprint.BottomUpMutatorContext) {
+
+	if d, ok := mctx.Module().(*defaults); ok {
+		srcs := d.getSourceProperties()
+
+		// forbid the use of `srcs` and `exclude_srcs` in `bob_defaults` altogether
+		if len(srcs.Srcs) > 0 || len(srcs.Exclude_srcs) > 0 {
+			msg := "`srcs`/`exclude_srcs` property should not be used in defaults. Specify target sources explicitly or use `bob_filegroup`"
+			getBackend(mctx).getLogger().Warn(warnings.DefaultSrcsWarning, mctx.BlueprintsFile(), mctx.ModuleName(), msg)
+		}
+	}
 
 	if l, ok := mctx.Module().(defaultable); ok {
 		defaultsMapLock.Lock()

--- a/internal/warnings/warnings.go
+++ b/internal/warnings/warnings.go
@@ -29,6 +29,7 @@ import (
 type Category string
 
 const (
+	DefaultSrcsWarning    Category = "DefaultSrcsWarning"
 	DeprecationWarning    Category = "DeprecationWarning"
 	DirectPathsWarning    Category = "DirectPathsWarning"
 	GenerateRuleWarning   Category = "GenerateRuleWarning"
@@ -38,6 +39,7 @@ const (
 )
 
 var categoriesMap = map[string]Category{
+	string(DefaultSrcsWarning):    DefaultSrcsWarning,
 	string(DeprecationWarning):    DeprecationWarning,
 	string(DirectPathsWarning):    DirectPathsWarning,
 	string(GenerateRuleWarning):   GenerateRuleWarning,


### PR DESCRIPTION
Srcs/include paths should not be used in `bob_default`. Shared srsc should use `bob_filegroup` instead.

Issue a `DefaultSrcsWarning` warning when
`srsc`/`exclude_srcs` is used in `bob_defaults`.

This warning has been set already to be ignored,
i.e. issue will be logged to file but not printed
to `os.Stderr`.

Change-Id: I7d5131e3a497cb90c972dc2473a3c9b8dd4ca938
Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>