### PR TITLE
Improve warning logger

### DIFF
--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 Arm Limited.
+ * Copyright 2018-2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,6 @@
 package core
 
 import (
-	"fmt"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -290,8 +289,7 @@ func (s *SourceProps) processPaths(ctx blueprint.BaseModuleContext, g generatorB
 
 	for _, s := range s.Srcs {
 		if strings.HasPrefix(filepath.Clean(s), "../") {
-			msg := fmt.Sprintf("Path '%s' contains relative up-links, this is not allowed. Please use `bob_filegroup` instead.", s)
-			g.getLogger().Warn(warnings.RelativeUpLinkWarning, ctx.BlueprintsFile(), ctx.ModuleName(), msg)
+			g.getLogger().Warn(warnings.RelativeUpLinkWarning, ctx.BlueprintsFile(), ctx.ModuleName())
 		}
 	}
 

--- a/core/defaults.go
+++ b/core/defaults.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 Arm Limited.
+ * Copyright 2018-2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -195,8 +195,7 @@ func defaultDepsStage1Mutator(mctx blueprint.BottomUpMutatorContext) {
 
 		// forbid the use of `srcs` and `exclude_srcs` in `bob_defaults` altogether
 		if len(srcs.Srcs) > 0 || len(srcs.Exclude_srcs) > 0 {
-			msg := "`srcs`/`exclude_srcs` property should not be used in defaults. Specify target sources explicitly or use `bob_filegroup`"
-			getBackend(mctx).getLogger().Warn(warnings.DefaultSrcsWarning, mctx.BlueprintsFile(), mctx.ModuleName(), msg)
+			getBackend(mctx).getLogger().Warn(warnings.DefaultSrcsWarning, mctx.BlueprintsFile(), mctx.ModuleName())
 		}
 	}
 

--- a/core/generated.go
+++ b/core/generated.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 Arm Limited.
+ * Copyright 2018-2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -905,8 +905,7 @@ func getGeneratedFiles(ctx blueprint.ModuleContext) []string {
 func generatedDependerMutator(mctx blueprint.BottomUpMutatorContext) {
 
 	if _, ok := mctx.Module().(*generateSource); ok {
-		msg := "`bob_generate_source` is deprecated, use `bob_genrule` instead"
-		getBackend(mctx).getLogger().Warn(warnings.GenerateRuleWarning, mctx.BlueprintsFile(), mctx.ModuleName(), msg)
+		getBackend(mctx).getLogger().Warn(warnings.GenerateRuleWarning, mctx.BlueprintsFile(), mctx.ModuleName())
 	}
 
 	if e, ok := mctx.Module().(enableable); ok {

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 Arm Limited.
+ * Copyright 2018-2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -233,7 +233,7 @@ func Main() {
 		f.Close()
 
 		if errCnt > 0 {
-			utils.Die("%d error(s) ocurred!\n", errCnt)
+			utils.Die("%d error(s) ocurred!\n\n%s\n", errCnt, logger.InfoMessage())
 		}
 	}()
 

--- a/docs/warnings/default-srcs.md
+++ b/docs/warnings/default-srcs.md
@@ -1,0 +1,49 @@
+`default-srcs` warning
+==================
+
+## Warns when `srcs`/`exclude_srcs` property is used in `bob_defaults`.
+
+## Problematic code:
+```bp
+bob_defaults {
+    name: "my_defaults",
+    cflags: ["-DDEBUG=1", "-Wall"],
+    srcs: [a.cpp],
+}
+
+bob_binary {
+    name: "my_binary",
+    defaults: ["my_defaults"],
+    srcs: ["main.cpp"],
+}
+```
+
+## Correct code:
+```bp
+bob_defaults {
+    name: "my_defaults",
+    cflags: ["-DDEBUG=1"],
+}
+
+bob_filegroup {
+    name: "my_filegroup",
+    srcs: [a.cpp],
+}
+
+bob_binary {
+    name: "my_binary",
+    defaults: ["my_defaults"],
+    srcs: ["main.cpp"],
+    filegroup_srcs: ["my_filegroup"],
+}
+```
+
+## Rationale:
+Bazel build system does not support such concept of `defaults`.
+Including sources through `bob_defaults` across the modules makes
+things really hard to convert and is contrary to Bazel principles.
+
+Shared sources should use a `bob_filegroup` instead.
+
+This warning should ease removal of global include headers since
+each target will have to specify its own include paths and sources.

--- a/docs/warnings/generate-rule.md
+++ b/docs/warnings/generate-rule.md
@@ -1,0 +1,38 @@
+`generate-rule` warning
+==================
+
+## Warns when deprecated `bob_generate_source` module is used
+
+## Problematic code:
+```bp
+bob_generate_source {
+    name: "my_generate",
+    srcs: [
+        "input.txt",
+    ],
+    out: ["main.cpp"],
+    tools: ["tool.py"],
+    cmd: "python ${tool} --in ${in} --out ${out},
+}
+```
+
+## Correct code:
+```bp
+bob_genrule {
+    name: "generate_source_single_new",
+    srcs: [
+        "input.txt",
+    ],
+    out: ["main.cpp"],
+    tool_files: ["tool.py"],
+    cmd: "python $(location) --in $(in) --out $(out),
+}
+```
+
+## Rationale:
+`bob_generate_source` contains some functionality which cannot be moved
+straightforward to Android's native rules, which in turn makes the
+transition to other build systems (e.g. `Bazel`) impossible.
+
+`bob_generate_source` module is considered as **deprecated** and
+`bob_genrule` should be preferred where possible.

--- a/docs/warnings/relative-up-link.md
+++ b/docs/warnings/relative-up-link.md
@@ -1,0 +1,41 @@
+`relative-up-link` warning
+==================
+
+## Warns when target name contains up-level references `'..'`
+
+## Problematic code:
+```bp
+bob_generate_source {
+    name: "my_generate",
+    srcs: [
+        "../subdir1/file1.cpp",
+        "../subdir2/file2.cpp",
+    ],
+}
+```
+
+## Correct code:
+```bp
+bob_filegroup {
+    name: "my_filegroup",
+    srcs: [
+        "subdir1/file1.cpp",
+        "subdir2/file2.cpp",
+    ],
+}
+
+bob_generate_source {
+    name: "my_generate",
+    srcs: [
+        "main.cpp",
+    ],
+    filegroup_srcs: ["my_filegroup"],
+}
+```
+
+## Rationale:
+Use of up-level references (`..`) breaks the concept of hermeticity.
+Sources for a module should be relative to its current directory or
+its subdirectories.
+If files outside current build file have to be used, use `bob_filegroup`
+as a dependency.

--- a/docs/warnings/warnings.md
+++ b/docs/warnings/warnings.md
@@ -1,6 +1,34 @@
 WarningLogger
 ==================
 
+# Preface
+
+`Bob` is based on Google's [Blueprint](https://github.com/google/blueprint)
+repository which has been archived some time ago.
+Beside it implements few handy features it breaks some core rules
+which new solid build system should have like hermeticity.
+
+The main feature of `Bob` is to building for both Android and Linux.
+Constant evolution of _Android_ makes things harder and forces `Bob`
+to implement things which are not necessarily features but rather
+workarounds. That causes more breakage of build system principles.
+
+Apart of that an Android will be switching to
+[Bazel](https://bazel.build) with incoming releases.
+
+Thus `Bob` will be deprecated when Android will move to Bazel.
+
+All above makes us to _adjust_ `Bob` to the form its `build.bp` files
+will be easily convertible to Bazel.
+
+`WarningLogger` is a first step to help with such transition and warn
+about all the issues currently implemented in `build.bp` files that does
+not conform to the new approach.
+When all risen issues become fixed, particular warnings will be
+promoted to error to prevent using all prohibited `Bob`'s functionality.
+
+# WarningLogger
+
 `WarningLogger` allows to write out the warnings to any `io.Writer`
 with the CSV format of:
 ```
@@ -14,11 +42,10 @@ action will be printed to `os.Stderr`.
 
 There are few types to categorize a warning:
 
-- `DirectPathsWarning`
-- `GenerateRuleWarning`
-- `PropertyWarning`
-- `RelativeUpLinkWarning`
-- `UserWarning`
+- [DefaultSrcsWarning](default-srcs.md) - `[default-srcs]`
+- [GenerateRuleWarning](generate-rule.md) - `[generate-rule]`
+- [PropertyWarning](property.md) - `[property]`
+- [RelativeUpLinkWarning](relative-up-link.md) - `[relative-up-link]`
 
 
 ## Warning actions


### PR DESCRIPTION
There is a need to have a better documentation
for every introduced warning category to advice
about exact issue and possible changes how to
replace `obsolete` code. Every warning category
will have its own `<categoryName>.md` doc page.

All warning categories drop the `*Warning` suffix.

Additionally every warning category name is changed to the kebab-casing so that printed category
matches the `gcc` or `mypy` way
(e.g. DefaultSrcs="default-srcs")

Few terminals have support for hyperlinks thus
logger will print them for a limited subset.

Signed-off-by: Sebastian Birunt <sebastian.birunt@arm.com>
Change-Id: I14a936d86d847638c63c75d656d4b067419fcc7a