### PR TITLE
Config local paths store to Mconfig parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,11 +94,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.x' ]
+        python: [ '3.7', '3.8', '3.9' ]
         os: [ ubuntu-latest ]
         include:
-          - python: '3.x'
+          - python: '3.7'
             os: macos-latest
+          - python: '3.6'
+            os: ubuntu-20.04
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -134,11 +136,14 @@ jobs:
       matrix:
         go: [ '1.11', '1.12', '1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20' ]
         os: [ ubuntu-latest ]
-        python: [ '3.x' ]
+        python: [ '3.7', '3.8', '3.9' ]
         include:
           - go: '1.13'
             os: macos-latest
-            python: '3.x'
+            python: '3.7'
+          - go: '1.13'
+            os: ubuntu-20.04
+            python: '3.6'
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ do the heavy lifting. As such it has similarities with
 To use Bob you will need:
 -  golang (>=1.11)
 -  ninja-build (>=1.8)
--  python3
+-  python3 (>=3.6)
 -  python3-ply
 
 ## License

--- a/config_system/config_system/config_json.py
+++ b/config_system/config_system/config_json.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2018-2019, 2021-2022 Arm Limited.
+# Copyright 2018-2019, 2021-2023 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,6 @@
 
 import json
 import logging
-import os
 
 from config_system import data, utils
 

--- a/config_system/config_system/lex.py
+++ b/config_system/config_system/lex.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 Arm Limited.
+# Copyright 2018-2023 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import ply.lex as lex
+
+from pathlib import Path
 
 
 verbose_flag = False
@@ -246,10 +248,12 @@ def report_error(msg, t, err_type=TokenizeError):
     raise err_type()
 
 
-def create_mconfig_lexer(fname, verbose=False):
+def create_mconfig_lexer(fname, verbose=False, root_dir=Path(".")):
     lexer = lex.lex()
     global verbose_flag
     verbose_flag = verbose
     lexer.lineno = 1
     lexer.fname = fname
+    lexer.relPath = Path(fname).relative_to(root_dir).parent
+
     return lexer

--- a/config_system/config_system/lex_wrapper.py
+++ b/config_system/config_system/lex_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Arm Limited.
+# Copyright 2018-202, 2023 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import os
+
+from pathlib import Path
 
 from config_system import lex
 
@@ -37,7 +39,7 @@ class LexWrapper:
         with open(fname, "rt") as fp:
             file_contents = fp.read()
 
-        lexer = lex.create_mconfig_lexer(fname, verbose=self.verbose)
+        lexer = lex.create_mconfig_lexer(fname, verbose=self.verbose, root_dir=Path(self.root_dir))
 
         self.push_lexer(lexer)
         self.input(file_contents)
@@ -74,6 +76,11 @@ class LexWrapper:
         if t is None:
             self.pop_lexer()
             t = self.token()
+
+        # Inject lexer for every "IDENTIFIER" token
+        # to allow the parser read lexer's `relPath`
+        if t is not None and t.type == "IDENTIFIER":
+            t.lexer = self.current_lexer()
 
         return t
 

--- a/config_system/get_configs_gazelle.py
+++ b/config_system/get_configs_gazelle.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+# Copyright 2023 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""JSON Config generator
+
+This script allows the user to generate JSON configuration based on Mconfig file
+to be used by Gazelle plugin.
+
+Script reads the input from the `stdin` with the JSON format:
+
+`{"root_path": ".","rel_package_path": "subdir","file_name": "Mconfig","ignore_source":false}`
+
+where:
+
+- `root_path` - the root directory of the repository
+- `rel_package_path` - the relative path to `root_path` where to start parse
+  (mostly where the root Mconfig file resides)
+- `file_name` (optional) - the name of the Mconfig file to read (`Mconfig` by default)
+- `ignore_source` (optional) - ignore all `source` and `source_local` directives
+  from the parsed Mconfig file.
+
+In case `root_path` and `rel_package_path` are the pointing the same directory,
+it means we want to start reading configs form the `root_path` Mconfig.
+
+Multiline JSON input can be provided to parse every input line separately.
+
+"""
+
+import json
+import sys
+
+from pathlib import Path
+
+from config_system import lex_wrapper, syntax
+
+
+class SetEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, set):
+            return list(obj)
+        if isinstance(obj, Path):
+            return str(obj)
+        return json.JSONEncoder.default(self, obj)
+
+
+def main() -> int:
+    if not sys.stdin.isatty():
+        for request in sys.stdin.read().splitlines():
+            r = json.loads(request.strip())
+            ignore_source = r.get("ignore_source", False)
+            root_path = Path(r["root_path"])
+            rel_path = Path(r["rel_package_path"])
+            file_name = r.get("file_name", "Mconfig")
+
+            if rel_path.is_absolute():
+                raise ValueError(f"Absolute path is not allowed! '{rel_path}'")
+
+            # root Mconfig file to parse
+            root_file = root_path / rel_path / file_name
+
+            # ignore_missing = True
+            lexer = lex_wrapper.LexWrapper(True)
+            lexer.source(root_file)
+
+            syntax.parser.ignore_source = ignore_source
+            cfg = syntax.parser.parse(None, debug=False, lexer=lexer)['config']
+
+            for k, v in cfg.items():
+                cfg[k]["relPath"] = rel_path / v["relPath"]
+
+            print(f"{json.dumps(cfg, indent=4, cls=SetEncoder)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/config_system/tests/test_get_configs_gazelle.py
+++ b/config_system/tests/test_get_configs_gazelle.py
@@ -1,0 +1,103 @@
+# Copyright 2023 Arm Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import io
+import pytest
+
+from pathlib import Path
+
+import get_configs_gazelle
+
+
+option_config = [
+    (
+        "subdir",
+        "internal/libA",
+    ),
+    (
+        "other_relative_path",
+        "external/crypto/tool",
+    )
+]
+
+
+@pytest.mark.parametrize("relativePath,submodule", option_config)
+def test_option_config_relPath(capfd, monkeypatch, tmp_path, relativePath, submodule):
+    """
+    For each test case, run get_configs_gazelle's `main()` function for two
+    Mconfig files located as:
+
+    tmp_path
+    └── relativePath
+        ├── Mconfig
+        └── submodule
+            └── Mconfig
+
+    Check weather configurations `relPath` property is properly set.
+    Starting point for parse is `tmp_path/relativePath` directory thus
+    `relPath` property for all configs of the root Mconfig file
+    (`tmp_path/relativePath/Mconfig`) should be "relativePath" where for the
+    configs of internal one (`tmp_path/relativePath/submodule/Mconfig`)
+    should be "relativePath/submodule".
+    """
+
+    input_json = f"{{\"root_path\": \"{tmp_path}\",\"rel_package_path\": \"{relativePath}\"," + \
+        f"\"file_name\": \"Mconfig\"}}"
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(input_json))
+
+    mconfig_data = f"""
+config SUB_FEATURE_X
+    bool "Enable Feature X"
+    default y
+source "{submodule}/Mconfig"
+config SUB_FEATURE_Y
+    bool "Enable Feature Y"
+    default n
+"""
+
+    submconfig_data = """
+config FEATURE_A
+    bool "Enable Feature A"
+    default y
+config OPTION_B
+    string "Set Option XY"
+    default "--secret"
+"""
+
+    mconfig_dir = tmp_path / relativePath
+    mconfig_dir.mkdir(parents=True, exist_ok=True)
+    mconfig_fname = tmp_path / relativePath / "Mconfig"
+    mconfig_fname.write_text(mconfig_data)
+
+    submconfig_dir = tmp_path / relativePath / submodule
+    submconfig_dir.mkdir(parents=True, exist_ok=True)
+    submconfig_fname = submconfig_dir / "Mconfig"
+    submconfig_fname.write_text(submconfig_data)
+
+    returncode = get_configs_gazelle.main()
+
+    out = capfd.readouterr()
+
+    configuration = json.loads(out.out.strip())
+
+    for cfg in ["SUB_FEATURE_X", "SUB_FEATURE_Y"]:
+        assert configuration[cfg]["relPath"] == relativePath
+
+    for cfg in ["FEATURE_A", "OPTION_B"]:
+        assert configuration[cfg]["relPath"] == str(Path(relativePath, submodule))
+
+    assert returncode == 0


### PR DESCRIPTION
The current Mconfig parser crawls the workspace recurisvely.

We need a way to easily integrate the Mconfig parser results with the Bob Gazelle plugin. The best way is to generate configuration structure as a JSON output.

If we add the current relative path to each configuration item, we can very simply be able to register the correct configuration flags for each module and avoid creating excess rules in the root Bazel file.

Add a python script which outputs the JSON configuration for desired Mconfig files.

Change-Id: I64a697bc42b18ba08ab4126dee0f807e5dc57b5a