### PR TITLE
feat: add `bob_glob` module

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020, 2022 Arm Limited.
+ * Copyright 2018-2020, 2022-2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,6 +59,7 @@ bootstrap_go_package {
         "core/gen_shared.go",
         "core/gen_static.go",
         "core/generated.go",
+        "core/glob.go",
         "core/graphviz.go",
         "core/install.go",
         "core/filegroup.go",

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "gen_shared.go",
         "gen_static.go",
         "generated.go",
+        "glob.go",
         "graphviz.go",
         "install.go",
         "kernel_module.go",

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -441,6 +441,8 @@ func getFileGroupDeps(mctx blueprint.BaseModuleContext) (srcs []string) {
 		func(m blueprint.Module) {
 			if fg, ok := m.(*filegroup); ok {
 				srcs = append(srcs, fg.getSources(mctx)...)
+			} else if mg, ok := m.(*moduleGlob); ok {
+				srcs = append(srcs, mg.getSources(mctx)...)
 			}
 		})
 	return
@@ -689,6 +691,7 @@ func registerModuleTypes(register func(string, factoryWithConfig)) {
 	// Swapping to new rules that are more strict and adhere to the Android Modules
 	register("bob_genrule", generateRuleAndroidFactory)
 	register("bob_filegroup", filegroupFactory)
+	register("bob_glob", globFactory)
 
 	register("bob_alias", aliasFactory)
 	register("bob_kernel_module", kernelModuleFactory)

--- a/core/glob.go
+++ b/core/glob.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2023 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ARM-software/bob-build/internal/utils"
+	"github.com/ARM-software/bob-build/internal/warnings"
+	"github.com/google/blueprint"
+)
+
+type GlobProps struct {
+	// Path patterns that are relative to the current module
+	Srcs []string
+
+	// Path patterns that are relative to the current module to exclude from `Srcs`
+	Exclude []string
+
+	// Omitted directories from the `Files` result
+	Exclude_directories *bool
+
+	// Error-out if the result `Files` is empty
+	Allow_empty *bool
+
+	// Found module sources
+	Files []string `blueprint:"mutated"`
+}
+
+type moduleGlob struct {
+	moduleBase
+	Properties struct {
+		GlobProps
+	}
+}
+
+func (m *moduleGlob) shortName() string {
+	return m.Name()
+}
+
+func (m *moduleGlob) getSources(ctx blueprint.BaseModuleContext) []string {
+	return m.Properties.Files
+}
+
+func (m *moduleGlob) processPaths(ctx blueprint.BaseModuleContext, g generatorBackend) {
+
+	if len(m.Properties.Srcs) == 0 {
+		ctx.PropertyErrorf("srcs", "Missed required property.")
+		return
+	}
+
+	prefix := filepath.Join(getSourceDir(), ctx.ModuleDir())
+	excludes := utils.PrefixDirs(m.Properties.Exclude, prefix)
+
+	addPath := func(p string) {
+		dir := filepath.Join(prefix, p)
+		isDir, err := ctx.Fs().IsDir(dir)
+		if os.IsNotExist(err) || err != nil {
+			ctx.ModuleErrorf("glob failed with: %s", err)
+		}
+		if !(isDir && *m.Properties.Exclude_directories) {
+			m.Properties.Files = append(m.Properties.Files, p)
+		}
+	}
+
+	for _, file := range m.Properties.Srcs {
+		if strings.ContainsAny(file, "*?[") {
+			// Globs need to be calculated relative to the module
+			// directory but not current working directory,
+			// thus need to be prefixed with `source_dir/module_dir`
+			// (i.e. `getSourceDir() + ctx.ModuleDir()`)
+			// so add it to `file`, and remove it afterwards.
+
+			file = filepath.Join(prefix, file)
+			matches, err := ctx.GlobWithDeps(file, excludes)
+
+			if err != nil {
+				ctx.ModuleErrorf("glob failed with: %s", err)
+			}
+
+			for _, match := range matches {
+				rel, err := filepath.Rel(prefix, match)
+				if err != nil {
+					panic(err)
+				}
+				addPath(rel)
+			}
+		} else if !utils.Contains(m.Properties.Exclude, file) {
+			addPath(file)
+		}
+	}
+
+	if len(m.Properties.Files) == 0 && !(*m.Properties.Allow_empty) {
+		ctx.ModuleErrorf("Glob is empty!")
+	}
+
+	for _, s := range append(m.Properties.Srcs, m.Properties.Exclude...) {
+		if strings.HasPrefix(filepath.Clean(s), "../") {
+			g.getLogger().Warn(warnings.RelativeUpLinkWarning, ctx.BlueprintsFile(), ctx.ModuleName())
+		}
+	}
+
+	m.Properties.Files = utils.PrefixDirs(m.Properties.Files, ctx.ModuleDir())
+}
+
+func (g *moduleGlob) GenerateBuildActions(ctx blueprint.ModuleContext) {
+	// `moduleGlob` does not need any generate actions.
+	// Only sources should be returned to the modules depending on.
+}
+
+func globFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+	t := true
+	module := &moduleGlob{}
+
+	// set `Allow_empty` and `Exclude_directories` to true
+	// to match Bazel's `glob`
+	module.Properties.GlobProps.Exclude_directories = &t
+	module.Properties.GlobProps.Allow_empty = &t
+
+	return module, []interface{}{&module.Properties, &module.SimpleName.Properties}
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,3 +29,4 @@ Bob
 - [bob_shared_library](module_types/bob_shared_library.md)
 - [bob_static_library](module_types/bob_static_library.md)
 - [bob_transform_source](module_types/bob_transform_source.md)
+- [bob_glob](module_types/bob_glob.md)

--- a/docs/module_types/bob_glob.md
+++ b/docs/module_types/bob_glob.md
@@ -1,0 +1,45 @@
+Module: bob_glob
+====================
+
+Glob is a helper module that finds all files that match certain path patterns
+and returns a list of their paths.
+
+## Full specification of `bob_glob` properties
+
+```bp
+bob_glob {
+    name: "glob_lib_srcs",
+    srcs: ["src/**/*.cpp"],
+    exclude: ["src/**/exclude_*.cpp"],
+    exclude_directories: True
+    allow_empty: False
+}
+```
+
+----
+### **bob_glob.name** (required)
+
+The unique identifier that can be used to refer to this module.
+
+----
+### **bob_glob.srcs** (required)
+
+Path patterns that are relative to the current module.
+
+----
+### **bob_glob.exclude** (optional)
+
+Path patterns that are relative to the current module
+to exclude from `srcs`.
+
+----
+### **bob_glob.exclude_directories** (optional)
+
+If the `exclude_directories` argument is set to `true` (default),
+the directories will be omitted from the results.
+
+----
+### **bob_glob.allow_empty** (optional)
+
+If the `allow_empty` argument is set to `false`, the glob function will
+error-out if the result is the empty list. By default it is set to `true`.

--- a/tests/filegroups/build.bp
+++ b/tests/filegroups/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Arm Limited.
+ * Copyright 2022-2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,12 @@ bob_filegroup {
     srcs: ["src/impl.cpp"],
 }
 
+bob_glob {
+    name: "glob_main",
+    srcs: ["**/main.cpp"],
+    allow_empty: false,
+}
+
 bob_filegroup {
     name: "forward_filegroup",
     filegroup_srcs: ["filegroup_impl"],
@@ -27,8 +33,8 @@ bob_filegroup {
 
 bob_binary {
     name: "test_filegroup_simple",
-    srcs: ["src/main.cpp",],
-    filegroup_srcs: ["forward_filegroup"],
+    srcs: [],
+    filegroup_srcs: ["forward_filegroup", "glob_main"],
 }
 
 bob_alias {

--- a/tests/globs/build.bp
+++ b/tests/globs/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Arm Limited.
+ * Copyright 2019, 2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +15,14 @@
  * limitations under the License.
  */
 
+bob_glob {
+    name: "src_glob",
+    srcs: ["**/*.c"],
+}
+
 bob_binary {
     name: "glob_test",
-    srcs: ["**/*.c"],
+    filegroup_srcs: ["src_glob"]
 }
 
 bob_binary {
@@ -26,15 +31,22 @@ bob_binary {
     exclude_srcs: ["src/**/exclude_*.cpp"],
 }
 
+bob_glob {
+    name: "src_glob_exclude",
+    srcs: ["src/**/*.cpp"],
+    exclude: [
+        "src/**/main.cpp",
+        "**/exclude_this_file.cpp",
+        "src/inside/a/exclude_this_too.cpp",
+    ],
+}
+
 bob_binary {
     name: "test_exclude_srcs",
     srcs: [
         "src/inside/a/namespace/main.cpp",
-        "src/inside/a/exclude_this_too.cpp",
     ],
-    exclude_srcs: [
-        "src/inside/a/exclude_this_too.cpp",
-    ],
+    filegroup_srcs: ["src_glob_exclude"],
 }
 
 bob_alias {

--- a/tests/globs/src/inside/a/namespace/func.cpp
+++ b/tests/globs/src/inside/a/namespace/func.cpp
@@ -1,0 +1,3 @@
+int funcX(void) {
+    return 123;
+}

--- a/tests/globs/src/inside/a/namespace/main.cpp
+++ b/tests/globs/src/inside/a/namespace/main.cpp
@@ -1,3 +1,5 @@
+int funcX(void);
+
 int main(void) {
-    return 0;
+    return funcX() == 123 ? 0 : 1;
 }


### PR DESCRIPTION
A new target to store glob expressions to aid
the Bazel migration.
The API works the same way as Bazel's `glob`
(see: https://bazel.build/reference/be/functions#glob)

Change-Id: Iae56129ccb44e649355e68b55e6d6163bee2be39