### PR TITLE
Implement BobConfig spoof

### DIFF
--- a/core/alias.go
+++ b/core/alias.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Arm Limited.
+ * Copyright 2018-2020, 2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,7 +74,7 @@ func (m *alias) GenerateBuildActions(ctx blueprint.ModuleContext) {
 }
 
 // Create the structure representing the bob_alias
-func aliasFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func aliasFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &alias{}
 	module.Properties.Features.Init(&config.Properties, AliasProps{})
 	return module, []interface{}{&module.Properties, &module.SimpleName.Properties}

--- a/core/androidbp_backend.go
+++ b/core/androidbp_backend.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Arm Limited.
+ * Copyright 2020-2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -322,7 +322,7 @@ func (cm *codeMatcher) match() bool {
 	return matched
 }
 
-func getSoongCompatFile(config *bobConfig) string {
+func getSoongCompatFile(config *BobConfig) string {
 	type compatVersion struct {
 		matches          []codeMatcher
 		android_versions []int
@@ -488,7 +488,7 @@ func (g *androidBpGenerator) getLogger() *warnings.WarningLogger {
 	return g.logger
 }
 
-func (g *androidBpGenerator) init(ctx *blueprint.Context, config *bobConfig) {
+func (g *androidBpGenerator) init(ctx *blueprint.Context, config *BobConfig) {
 	// Do not run in parallel to avoid locking issues on the map
 	ctx.RegisterBottomUpMutator("collect_buildbp", collectBuildBpFilesMutator)
 

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -119,7 +119,7 @@ type generatorBackend interface {
 	escapeFlag(string) string
 
 	// Backend initialisation
-	init(*blueprint.Context, *bobConfig)
+	init(*blueprint.Context, *BobConfig)
 
 	// Access to backend configuration
 	getToolchain(tgt tgtType) toolchain
@@ -127,9 +127,9 @@ type generatorBackend interface {
 	getLogger() *warnings.WarningLogger
 }
 
-// The bobConfig type is stored against the Blueprint context, and allows us to
+// The `BobConfig` type is stored against the Blueprint context, and allows us to
 // retrieve the backend and configuration values from within Blueprint callbacks.
-type bobConfig struct {
+type BobConfig struct {
 	Generator  generatorBackend
 	Properties configProperties
 }
@@ -675,7 +675,7 @@ func checkDisabledMutator(mctx blueprint.BottomUpMutatorContext) {
 	}
 }
 
-type factoryWithConfig func(*bobConfig) (blueprint.Module, []interface{})
+type factoryWithConfig func(*BobConfig) (blueprint.Module, []interface{})
 
 func registerModuleTypes(register func(string, factoryWithConfig)) {
 	register("bob_binary", binaryFactory)

--- a/core/config_props.go
+++ b/core/config_props.go
@@ -32,22 +32,22 @@ import (
 type configProperties struct {
 	// Map of all available features (e.g. noasserts: { cflags: ["-DNDEBUG]" }),
 	// and whether they are enabled or not.
-	features map[string]bool
+	Features map[string]bool
 
 	// Map of all available properties which can be used in templates. Features are
 	// not automatically included in this by Bob, so should be added explicitly by the
 	// config system if required. These are converted to strings, then made available
 	// for use in templates.
-	properties map[string]interface{}
+	Properties map[string]interface{}
 
 	// Sorted array of available features
-	featureList []string
+	FeatureList []string
 
 	stringMap map[string]string
 }
 
 func (properties configProperties) getProp(name string) interface{} {
-	if elem, ok := properties.properties[name]; ok {
+	if elem, ok := properties.Properties[name]; ok {
 		return elem
 	}
 	utils.Die("No property found: %s", name)
@@ -169,9 +169,9 @@ func (properties *configProperties) LoadConfig(filename string) error {
 	// This is actually a string, which is what we want.
 	d.UseNumber()
 
-	properties.properties = make(map[string]interface{})
+	properties.Properties = make(map[string]interface{})
 	properties.stringMap = make(map[string]string)
-	properties.features = make(map[string]bool)
+	properties.Features = make(map[string]bool)
 
 	var configData map[string]interface{}
 	err = d.Decode(&configData)
@@ -187,7 +187,7 @@ func (properties *configProperties) LoadConfig(filename string) error {
 		// Identify that configuration is ignored or not
 		if ignore, ok := boolValue(configMap["ignore"]); ok {
 			if !ignore {
-				properties.properties[key] = configMap["value"]
+				properties.Properties[key] = configMap["value"]
 
 				// Create a mapping of properties to values that will be used
 				// by templates
@@ -195,14 +195,14 @@ func (properties *configProperties) LoadConfig(filename string) error {
 
 				// Identify features and whether they are enabled
 				if v, ok := boolValue(configMap["value"]); ok {
-					properties.features[key] = v
+					properties.Features[key] = v
 				}
 			}
 		}
 	}
 
 	// Calculate the plain list of features once.
-	properties.featureList = utils.SortedKeysBoolMap(properties.features)
+	properties.FeatureList = utils.SortedKeysBoolMap(properties.Features)
 
 	return nil
 }

--- a/core/defaults.go
+++ b/core/defaults.go
@@ -132,7 +132,7 @@ func (m *defaults) getMatchSourcePropNames() []string {
 	return []string{"Ldflags", "Cflags", "Conlyflags", "Cxxflags"}
 }
 
-func defaultsFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func defaultsFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &defaults{}
 
 	module.Properties.Features.Init(&config.Properties, CommonProps{}, BuildProps{}, KernelProps{}, SplittableProps{})

--- a/core/external_library.go
+++ b/core/external_library.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Arm Limited.
+ * Copyright 2019-2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -79,7 +79,7 @@ var _ splittable = (*externalLib)(nil)
 // External libraries have no actions - they are already built.
 func (m *externalLib) GenerateBuildActions(ctx blueprint.ModuleContext) {}
 
-func externalLibFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func externalLibFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &externalLib{}
 	module.Properties.Features.Init(&config.Properties, ExternalLibProps{})
 	return module, []interface{}{&module.Properties, &module.SimpleName.Properties}

--- a/core/feature.go
+++ b/core/feature.go
@@ -82,9 +82,9 @@ func (f *Features) Init(properties *configProperties, list ...interface{}) {
 	}
 
 	propsType := coalesceTypes(typesOf(list...)...)
-	fields := make([]reflect.StructField, len(properties.featureList))
+	fields := make([]reflect.StructField, len(properties.FeatureList))
 
-	for i, featureName := range properties.featureList {
+	for i, featureName := range properties.FeatureList {
 		fields[i] = reflect.StructField{
 			Name: featurePropertyName(featureName),
 			Type: reflect.TypeOf(singleFeature{}),
@@ -96,7 +96,7 @@ func (f *Features) Init(properties *configProperties, list ...interface{}) {
 	f.BlueprintEmbed = instancePtr.Interface()
 
 	instance := reflect.Indirect(instancePtr)
-	for i := range properties.featureList {
+	for i := range properties.FeatureList {
 		propsInFeature := instance.Field(i).Addr().Interface().(*singleFeature)
 		propsInFeature.BlueprintEmbed = reflect.New(propsType).Interface()
 	}
@@ -175,8 +175,8 @@ func (f *Features) AppendProps(dst []interface{}, properties *configProperties) 
 	// featuresData is struct created in Features.Init function
 	featuresData := reflect.ValueOf(f.BlueprintEmbed).Elem()
 
-	for _, featureKey := range properties.featureList {
-		if properties.features[featureKey] { // Check the feature is enabled
+	for _, featureKey := range properties.FeatureList {
+		if properties.Features[featureKey] { // Check the feature is enabled
 			// Features are matched like "Feature_name" - feature structure
 			featureFieldName := featurePropertyName(featureKey)
 			featureStruct := featuresData.FieldByName(featureFieldName)

--- a/core/feature_test.go
+++ b/core/feature_test.go
@@ -30,12 +30,12 @@ import (
 
 // enabledFeatures is just wrapper function to easily enable features that we want
 func enabledFeatures(featuresList ...string) (properties configProperties) {
-	properties.features = make(map[string]bool)
+	properties.Features = make(map[string]bool)
 	for _, feature := range featuresList {
 		// Features keys should be in lowercase
-		properties.features[feature] = true
+		properties.Features[feature] = true
 	}
-	properties.featureList = utils.SortedKeysBoolMap(properties.features)
+	properties.FeatureList = utils.SortedKeysBoolMap(properties.Features)
 	return
 }
 
@@ -162,10 +162,10 @@ func createTestModuleAndFeatures() (testProps, configProperties) {
 func Test_should_return_expected_default_values_when_using_setup_function(t *testing.T) {
 	module, properties := createTestModuleAndFeatures()
 
-	assert.True(t, properties.features["feature_a"], "feature_a should be enabled by default")
-	assert.True(t, properties.features["feature_b"], "feature_b should be enabled by default")
-	assert.True(t, properties.features["feature_c"], "feature_c should be enabled by default")
-	assert.True(t, properties.features["feature_d"], "feature_d should be enabled by default")
+	assert.True(t, properties.Features["feature_a"], "feature_a should be enabled by default")
+	assert.True(t, properties.Features["feature_b"], "feature_b should be enabled by default")
+	assert.True(t, properties.Features["feature_c"], "feature_c should be enabled by default")
+	assert.True(t, properties.Features["feature_d"], "feature_d should be enabled by default")
 
 	assert.Equalf(t, "a", module.FieldA, "module.FieldA should be equal to default value")
 	assert.Equalf(t, "b", module.FieldB, "module.FieldB should be equal to default value")
@@ -194,11 +194,11 @@ func Test_should_not_change_when_appending_empty_features(t *testing.T) {
 
 func Test_should_append_matching_properties_when_one_feature_is_enabled(t *testing.T) {
 	module, properties := createTestModuleAndFeatures()
-	properties.features["feature_a"] = false
-	properties.features["feature_c"] = false
-	properties.features["feature_d"] = false
+	properties.Features["feature_a"] = false
+	properties.Features["feature_c"] = false
+	properties.Features["feature_d"] = false
 
-	assert.True(t, properties.features["feature_b"], "Feature should be enabled")
+	assert.True(t, properties.Features["feature_b"], "Feature should be enabled")
 	if err := module.AppendProps([]interface{}{&module}, &properties); err != nil {
 		panic(err)
 	}
@@ -217,7 +217,7 @@ func Test_should_not_modify_when_no_feature_is_enabled(t *testing.T) {
 	// The current implementation allows for properties.Features to contain
 	// a subset of the features Init was called with - check that this works.
 	// However, this functionality is not actually required by Bob.
-	properties.features = map[string]bool{} // all disabled (when key isn't present it should be treated as disabled)
+	properties.Features = map[string]bool{} // all disabled (when key isn't present it should be treated as disabled)
 
 	if err := module.AppendProps([]interface{}{&module}, &properties); err != nil {
 		panic(err)
@@ -234,10 +234,10 @@ func Test_should_not_modify_when_no_feature_is_enabled(t *testing.T) {
 
 func Test_should_append_properties_in_desired_order_when_using_append_props(t *testing.T) {
 	module, properties := createTestModuleAndFeatures()
-	properties.features["feature_a"] = true
-	properties.features["feature_b"] = true
-	properties.features["feature_c"] = false
-	properties.features["feature_d"] = false
+	properties.Features["feature_a"] = true
+	properties.Features["feature_b"] = true
+	properties.Features["feature_c"] = false
+	properties.Features["feature_d"] = false
 
 	if err := module.AppendProps([]interface{}{&module}, &properties); err != nil {
 		panic(err)
@@ -250,10 +250,10 @@ func Test_should_append_properties_in_desired_order_when_using_append_props(t *t
 	assert.Equalf(t, "f", module.FieldF, "module.FieldF incorrect")
 	assert.Equalf(t, "gProps_g", module.FieldG, "module.FieldG incorrect")
 
-	properties.features["feature_a"] = false
-	properties.features["feature_b"] = false
-	properties.features["feature_c"] = false
-	properties.features["feature_d"] = true
+	properties.Features["feature_a"] = false
+	properties.Features["feature_b"] = false
+	properties.Features["feature_c"] = false
+	properties.Features["feature_d"] = true
 
 	if err := module.AppendProps([]interface{}{&module}, &properties); err != nil {
 		panic(err)
@@ -266,10 +266,10 @@ func Test_should_append_properties_in_desired_order_when_using_append_props(t *t
 	assert.Equalf(t, "f+D_f", module.FieldF, "module.FieldF incorrect")
 	assert.Equalf(t, "gProps_g+D_g", module.FieldG, "module.FieldG incorrect")
 
-	properties.features["feature_a"] = false
-	properties.features["feature_b"] = true
-	properties.features["feature_c"] = false
-	properties.features["feature_d"] = true
+	properties.Features["feature_a"] = false
+	properties.Features["feature_b"] = true
+	properties.Features["feature_c"] = false
+	properties.Features["feature_d"] = true
 
 	if err := module.AppendProps([]interface{}{&module}, &properties); err != nil {
 		panic(err)

--- a/core/filegroup.go
+++ b/core/filegroup.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 Arm Limited.
+ * Copyright 2018-2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -109,7 +109,7 @@ func propogateFilegroupData(mctx blueprint.BottomUpMutatorContext) {
 	}
 }
 
-func filegroupFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func filegroupFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &filegroup{}
 	module.Properties.Features.Init(&config.Properties, FileGroupProps{})
 	return module, []interface{}{&module.Properties,

--- a/core/gen_binary.go
+++ b/core/gen_binary.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Arm Limited.
+ * Copyright 2018-2021, 2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,7 +58,7 @@ func (m *generateBinary) GenerateBuildActions(ctx blueprint.ModuleContext) {
 
 //// Factory functions
 
-func genBinaryFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func genBinaryFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &generateBinary{}
 	module.generateCommon.init(&config.Properties, GenerateProps{})
 

--- a/core/gen_shared.go
+++ b/core/gen_shared.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Arm Limited.
+ * Copyright 2018-2021, 2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,7 +66,7 @@ func (m *generateSharedLibrary) getTocName() string {
 
 //// Factory functions
 
-func genSharedLibFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func genSharedLibFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &generateSharedLibrary{}
 	module.generateCommon.init(&config.Properties, GenerateProps{},
 		GenerateLibraryProps{})

--- a/core/gen_static.go
+++ b/core/gen_static.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Arm Limited.
+ * Copyright 2018-2021, 2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,7 +58,7 @@ func (m *generateStaticLibrary) outputFileName() string {
 
 //// Factory functions
 
-func genStaticLibFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func genStaticLibFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &generateStaticLibrary{}
 	module.generateCommon.init(&config.Properties, GenerateProps{},
 		GenerateLibraryProps{})

--- a/core/generated.go
+++ b/core/generated.go
@@ -857,7 +857,7 @@ type transformSource struct {
 // transformSource supports installation
 var _ installable = (*transformSource)(nil)
 
-func generateSourceFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func generateSourceFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &generateSource{}
 	module.generateCommon.init(&config.Properties,
 		GenerateProps{}, GenerateSourceProps{})
@@ -866,7 +866,7 @@ func generateSourceFactory(config *bobConfig) (blueprint.Module, []interface{}) 
 		&module.SimpleName.Properties}
 }
 
-func transformSourceFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func transformSourceFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &transformSource{}
 	module.generateCommon.init(&config.Properties,
 		GenerateProps{}, TransformSourceProps{})
@@ -876,7 +876,7 @@ func transformSourceFactory(config *bobConfig) (blueprint.Module, []interface{})
 		&module.SimpleName.Properties}
 }
 
-func generateRuleAndroidFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func generateRuleAndroidFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &androidGenerateRule{}
 
 	return module, []interface{}{&module.androidGenerateCommon.Properties, &module.Properties,

--- a/core/glob.go
+++ b/core/glob.go
@@ -125,7 +125,7 @@ func (g *moduleGlob) GenerateBuildActions(ctx blueprint.ModuleContext) {
 	// Only sources should be returned to the modules depending on.
 }
 
-func globFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func globFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	t := true
 	module := &moduleGlob{}
 

--- a/core/install.go
+++ b/core/install.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 Arm Limited.
+ * Copyright 2018-2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -254,14 +254,14 @@ func (m *resource) getAliasList() []string {
 	return m.Properties.getAliasList()
 }
 
-func installGroupFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func installGroupFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &installGroup{}
 	module.Properties.Features.Init(&config.Properties, InstallGroupProps{})
 	return module, []interface{}{&module.Properties,
 		&module.SimpleName.Properties}
 }
 
-func resourceFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func resourceFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &resource{}
 	module.Properties.Features.Init(&config.Properties, ResourceProps{})
 	return module, []interface{}{&module.Properties,

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Arm Limited.
+ * Copyright 2018-2021, 2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -266,7 +266,7 @@ func (m *kernelModule) GenerateBuildActions(ctx blueprint.ModuleContext) {
 	}
 }
 
-func kernelModuleFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func kernelModuleFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &kernelModule{}
 
 	module.Properties.Features.Init(&config.Properties, CommonProps{}, KernelProps{})

--- a/core/library.go
+++ b/core/library.go
@@ -808,7 +808,7 @@ func (m *binary) outputFileName() string {
 	return m.outputName()
 }
 
-func (l *library) LibraryFactory(config *bobConfig, module blueprint.Module) (blueprint.Module, []interface{}) {
+func (l *library) LibraryFactory(config *BobConfig, module blueprint.Module) (blueprint.Module, []interface{}) {
 	l.Properties.Features.Init(&config.Properties, CommonProps{}, BuildProps{}, SplittableProps{})
 	l.Properties.Host.init(&config.Properties, CommonProps{}, BuildProps{})
 	l.Properties.Target.init(&config.Properties, CommonProps{}, BuildProps{})
@@ -816,12 +816,12 @@ func (l *library) LibraryFactory(config *bobConfig, module blueprint.Module) (bl
 	return module, []interface{}{&l.Properties, &l.SimpleName.Properties}
 }
 
-func staticLibraryFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func staticLibraryFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &staticLibrary{}
 	return module.LibraryFactory(config, module)
 }
 
-func sharedLibraryFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func sharedLibraryFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &sharedLibrary{}
 	if config.Properties.GetBool("osx") {
 		module.fileNameExtension = ".dylib"
@@ -831,7 +831,7 @@ func sharedLibraryFactory(config *bobConfig) (blueprint.Module, []interface{}) {
 	return module.LibraryFactory(config, module)
 }
 
-func binaryFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func binaryFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &binary{}
 	return module.LibraryFactory(config, module)
 }

--- a/core/linux_backend.go
+++ b/core/linux_backend.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 Arm Limited.
+ * Copyright 2018-2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -371,6 +371,6 @@ func (g *linuxGenerator) getLogger() *warnings.WarningLogger {
 	return g.logger
 }
 
-func (g *linuxGenerator) init(ctx *blueprint.Context, config *bobConfig) {
+func (g *linuxGenerator) init(ctx *blueprint.Context, config *BobConfig) {
 	g.toolchainSet.parseConfig(config)
 }

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -55,8 +55,8 @@ func projectModuleDir(ctx blueprint.BaseModuleContext) string {
 	return ctx.ModuleDir()
 }
 
-func getConfig(ctx configProvider) *bobConfig {
-	return ctx.Config().(*bobConfig)
+func getConfig(ctx configProvider) *BobConfig {
+	return ctx.Config().(*BobConfig)
 }
 
 func getBuildDir() string {
@@ -82,7 +82,7 @@ func Main() {
 	// Load the config first. This is needed because some of the module
 	// types' definitions contain a struct-per-feature, and features are
 	// specified in the config.
-	config := &bobConfig{}
+	config := &BobConfig{}
 	err := config.Properties.LoadConfig(configJSONFile)
 	if err != nil {
 		utils.Die("%v", err)

--- a/core/strict_library.go
+++ b/core/strict_library.go
@@ -164,7 +164,7 @@ func (m *strictLibrary) getTocName() string {
 	return m.Name() + tocExt
 }
 
-func LibraryFactory(config *bobConfig) (blueprint.Module, []interface{}) {
+func LibraryFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &strictLibrary{}
 	module.Properties.Features.Init(&config.Properties, StrictLibraryProps{})
 	return module, []interface{}{&module.Properties,

--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -435,7 +435,7 @@ func (tc toolchainGnuCross) getStdCxxHeaderDirs() []string {
 	}
 }
 
-func newToolchainGnuCommon(config *bobConfig, tgt tgtType) (tc toolchainGnuCommon) {
+func newToolchainGnuCommon(config *BobConfig, tgt tgtType) (tc toolchainGnuCommon) {
 	props := config.Properties
 	tc.prefix = props.GetString(string(tgt) + "_gnu_prefix")
 	tc.arBinary = props.GetString(string(tgt) + "_ar_binary")
@@ -464,12 +464,12 @@ func newToolchainGnuCommon(config *bobConfig, tgt tgtType) (tc toolchainGnuCommo
 	return
 }
 
-func newToolchainGnuNative(config *bobConfig) (tc toolchainGnuNative) {
+func newToolchainGnuNative(config *BobConfig) (tc toolchainGnuNative) {
 	tc.toolchainGnuCommon = newToolchainGnuCommon(config, tgtTypeHost)
 	return
 }
 
-func newToolchainGnuCross(config *bobConfig) (tc toolchainGnuCross) {
+func newToolchainGnuCross(config *BobConfig) (tc toolchainGnuCross) {
 	tc.toolchainGnuCommon = newToolchainGnuCommon(config, tgtTypeTarget)
 	return
 }
@@ -552,7 +552,7 @@ func (tc toolchainClangCommon) checkFlagIsSupported(language, flag string) bool 
 	return tc.flagCache.checkFlag(tc, language, flag)
 }
 
-func newToolchainClangCommon(config *bobConfig, tgt tgtType) (tc toolchainClangCommon) {
+func newToolchainClangCommon(config *BobConfig, tgt tgtType) (tc toolchainClangCommon) {
 	props := config.Properties
 	tc.prefix = props.GetString(string(tgt) + "_clang_prefix")
 
@@ -666,12 +666,12 @@ func newToolchainClangCommon(config *bobConfig, tgt tgtType) (tc toolchainClangC
 	return
 }
 
-func newToolchainClangNative(config *bobConfig) (tc toolchainClangNative) {
+func newToolchainClangNative(config *BobConfig) (tc toolchainClangNative) {
 	tc.toolchainClangCommon = newToolchainClangCommon(config, tgtTypeHost)
 	return
 }
 
-func newToolchainClangCross(config *bobConfig) (tc toolchainClangCross) {
+func newToolchainClangCross(config *BobConfig) (tc toolchainClangCross) {
 	tc.toolchainClangCommon = newToolchainClangCommon(config, tgtTypeTarget)
 	return
 }
@@ -735,7 +735,7 @@ func (tc toolchainArmClang) checkFlagIsSupported(language, flag string) bool {
 	return tc.flagCache.checkFlag(tc, language, flag)
 }
 
-func newToolchainArmClangCommon(config *bobConfig, tgt tgtType) (tc toolchainArmClang) {
+func newToolchainArmClangCommon(config *BobConfig, tgt tgtType) (tc toolchainArmClang) {
 	props := config.Properties
 	tc.prefix = props.GetString(string(tgt) + "_gnu_prefix")
 	tc.arBinary = tc.prefix + props.GetString("armclang_ar_binary")
@@ -752,12 +752,12 @@ func newToolchainArmClangCommon(config *bobConfig, tgt tgtType) (tc toolchainArm
 	return
 }
 
-func newToolchainArmClangNative(config *bobConfig) (tc toolchainArmClangNative) {
+func newToolchainArmClangNative(config *BobConfig) (tc toolchainArmClangNative) {
 	tc.toolchainArmClang = newToolchainArmClangCommon(config, tgtTypeHost)
 	return
 }
 
-func newToolchainArmClangCross(config *bobConfig) (tc toolchainArmClangCross) {
+func newToolchainArmClangCross(config *BobConfig) (tc toolchainArmClangCross) {
 	tc.toolchainArmClang = newToolchainArmClangCommon(config, tgtTypeTarget)
 	return
 }
@@ -889,7 +889,7 @@ func (tc toolchainXcode) checkFlagIsSupported(language, flag string) bool {
 	return tc.flagCache.checkFlag(tc, language, flag)
 }
 
-func newToolchainXcodeCommon(config *bobConfig, tgt tgtType) (tc toolchainXcode) {
+func newToolchainXcodeCommon(config *BobConfig, tgt tgtType) (tc toolchainXcode) {
 	props := config.Properties
 	tc.prefix = props.GetString(string(tgt) + "_xcode_prefix")
 	tc.arBinary = props.GetString(string(tgt) + "_ar_binary")
@@ -915,12 +915,12 @@ func newToolchainXcodeCommon(config *bobConfig, tgt tgtType) (tc toolchainXcode)
 	return
 }
 
-func newToolchainXcodeNative(config *bobConfig) (tc toolchainXcodeNative) {
+func newToolchainXcodeNative(config *BobConfig) (tc toolchainXcodeNative) {
 	tc.toolchainXcode = newToolchainXcodeCommon(config, tgtTypeHost)
 	return
 }
 
-func newToolchainXcodeCross(config *bobConfig) (tc toolchainXcodeCross) {
+func newToolchainXcodeCross(config *BobConfig) (tc toolchainXcodeCross) {
 	tc.toolchainXcode = newToolchainXcodeCommon(config, tgtTypeTarget)
 	return
 }
@@ -937,7 +937,7 @@ func (tcs *toolchainSet) getToolchain(tgt tgtType) toolchain {
 	return tcs.target
 }
 
-func (tcs *toolchainSet) parseConfig(config *bobConfig) {
+func (tcs *toolchainSet) parseConfig(config *BobConfig) {
 	props := config.Properties
 
 	if props.GetBool("target_toolchain_clang") {

--- a/gazelle/BUILD.bazel
+++ b/gazelle/BUILD.bazel
@@ -27,6 +27,10 @@ go_library(
         "@bazel_gazelle//repo:go_default_library",
         "@bazel_gazelle//resolve:go_default_library",
         "@bazel_gazelle//rule:go_default_library",
+        "@bob//core",
+        "@com_github_google_blueprint//:blueprint",
+        "@com_github_google_blueprint//parser",
+        "@com_github_google_blueprint//proptools",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/gazelle/WORKSPACE
+++ b/gazelle/WORKSPACE
@@ -45,7 +45,7 @@ load("@rules_python//python:repositories.bzl", "py_repositories")
 py_repositories()
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")  # keep
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")  # keep
 
 go_rules_dependencies()
 
@@ -74,3 +74,10 @@ pip_parse(
 load("@config_deps//:requirements.bzl", "install_deps")
 
 install_deps()
+
+# keep
+go_repository(
+    name = "com_github_google_blueprint",
+    commit = "6957a46d",
+    importpath = "github.com/google/blueprint",
+)

--- a/gazelle/mconfig_parser.go
+++ b/gazelle/mconfig_parser.go
@@ -79,6 +79,7 @@ type configData struct {
 	Type      string      `json:"type"`
 	Default   interface{} `json:"default"`
 	Condition interface{} `json:"default_cond"`
+	Ignore    string      `json:"bob_ignore,omitempty"`
 }
 
 // Constructs a new `mconfigParser`


### PR DESCRIPTION
The default Bob module factories require some of
the Bob's `bobConfig` structure fields to be populated during generation.

Export Bob's configuration to be used by gazelle plugin.

Change-Id: Ideb2ed8cf00f8b6a720d37742f5e747c3f3ddcfe