### PR TITLE
chore: export `Featurable` interface

### DIFF
--- a/core/alias.go
+++ b/core/alias.go
@@ -73,6 +73,10 @@ func (m *alias) GenerateBuildActions(ctx blueprint.ModuleContext) {
 	getBackend(ctx).aliasActions(m, ctx)
 }
 
+func (m alias) GetProperties() interface{} {
+	return m.Properties
+}
+
 // Create the structure representing the bob_alias
 func aliasFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &alias{}

--- a/core/alias.go
+++ b/core/alias.go
@@ -55,11 +55,11 @@ type alias struct {
 	}
 }
 
-func (m *alias) features() *Features {
+func (m *alias) Features() *Features {
 	return &m.Properties.Features
 }
 
-func (m *alias) featurableProperties() []interface{} {
+func (m *alias) FeaturableProperties() []interface{} {
 	return []interface{}{&m.Properties.AliasProps}
 }
 

--- a/core/androidbp_backend.go
+++ b/core/androidbp_backend.go
@@ -124,7 +124,7 @@ func (g *androidBpGenerator) bobScriptsDir() string {
 	return srcToScripts
 }
 
-func (g *androidBpGenerator) sharedLibsDir(tgtType) string {
+func (g *androidBpGenerator) sharedLibsDir(TgtType) string {
 	// When writing link commands, it's common to put all the shared
 	// libraries in a single location to make it easy for the linker to
 	// find them. This function tells us where this is for the current

--- a/core/binary.go
+++ b/core/binary.go
@@ -43,6 +43,10 @@ func (b *binary) outputFileName() string {
 	return b.outputName()
 }
 
+func (b binary) GetProperties() interface{} {
+	return b.library.Properties
+}
+
 func binaryFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &binary{}
 	return module.LibraryFactory(config, module)

--- a/core/build.go
+++ b/core/build.go
@@ -34,7 +34,7 @@ type Build struct {
 	SplittableProps
 }
 
-func (b *Build) getTargetSpecific(tgt tgtType) *TargetSpecific {
+func (b *Build) getTargetSpecific(tgt TgtType) *TargetSpecific {
 	if tgt == tgtTypeHost {
 		return &b.Host
 	} else if tgt == tgtTypeTarget {

--- a/core/build_props.go
+++ b/core/build_props.go
@@ -137,7 +137,7 @@ type BuildProps struct {
 
 	Hwasan_enabled *bool
 
-	TargetType tgtType `blueprint:"mutated"`
+	TargetType TgtType `blueprint:"mutated"`
 }
 
 func (b *BuildProps) processBuildWrapper(ctx blueprint.BaseModuleContext) {

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -113,7 +113,7 @@ type generatorBackend interface {
 	buildDir() string
 	sourceDir() string
 	bobScriptsDir() string
-	sharedLibsDir(tgt tgtType) string
+	sharedLibsDir(tgt TgtType) string
 
 	// Backend flag escaping
 	escapeFlag(string) string
@@ -122,7 +122,7 @@ type generatorBackend interface {
 	init(*blueprint.Context, *BobConfig)
 
 	// Access to backend configuration
-	getToolchain(tgt tgtType) toolchain
+	getToolchain(tgt TgtType) toolchain
 
 	getLogger() *warnings.WarningLogger
 }
@@ -296,12 +296,12 @@ func (ag *AndroidGenerateCommonProps) processPaths(ctx blueprint.BaseModuleConte
 	}
 }
 
-type tgtType string
+type TgtType string
 
 const (
-	tgtTypeHost    tgtType = "host"
-	tgtTypeTarget  tgtType = "target"
-	tgtTypeUnknown tgtType = ""
+	tgtTypeHost    TgtType = "host"
+	tgtTypeTarget  TgtType = "target"
+	tgtTypeUnknown TgtType = ""
 )
 
 func stripEmptyComponents(list []string) []string {
@@ -330,15 +330,15 @@ func stripEmptyComponentsRecursive(propsVal reflect.Value) {
 }
 
 func stripEmptyComponentsMutator(mctx blueprint.BottomUpMutatorContext) {
-	f, ok := mctx.Module().(featurable)
+	f, ok := mctx.Module().(Featurable)
 	if !ok {
 		return
 	}
 
-	strippableProps := f.featurableProperties()
+	strippableProps := f.FeaturableProperties()
 
 	if t, ok := mctx.Module().(targetSpecificLibrary); ok {
-		for _, tgt := range []tgtType{tgtTypeHost, tgtTypeTarget} {
+		for _, tgt := range []TgtType{tgtTypeHost, tgtTypeTarget} {
 			tgtSpecific := t.getTargetSpecific(tgt)
 			tgtSpecificData := tgtSpecific.getTargetSpecificProps()
 			strippableProps = append(strippableProps, tgtSpecificData)

--- a/core/defaults.go
+++ b/core/defaults.go
@@ -132,6 +132,10 @@ func (m *defaults) getMatchSourcePropNames() []string {
 	return []string{"Ldflags", "Cflags", "Conlyflags", "Cxxflags"}
 }
 
+func (m defaults) GetProperties() interface{} {
+	return m.Properties
+}
+
 func defaultsFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &defaults{}
 

--- a/core/defaults.go
+++ b/core/defaults.go
@@ -38,15 +38,15 @@ type defaults struct {
 	}
 }
 
-func (m *defaults) supportedVariants() []tgtType {
-	return []tgtType{tgtTypeHost, tgtTypeTarget}
+func (m *defaults) supportedVariants() []TgtType {
+	return []TgtType{tgtTypeHost, tgtTypeTarget}
 }
 
 func (m *defaults) disable() {
 	panic("disable() called on Default")
 }
 
-func (m *defaults) setVariant(variant tgtType) {
+func (m *defaults) setVariant(variant TgtType) {
 	m.Properties.TargetType = variant
 }
 
@@ -71,7 +71,7 @@ func (m *defaults) defaultableProperties() []interface{} {
 	}
 }
 
-func (m *defaults) featurableProperties() []interface{} {
+func (m *defaults) FeaturableProperties() []interface{} {
 	return []interface{}{
 		&m.Properties.Build.CommonProps,
 		&m.Properties.Build.BuildProps,
@@ -89,15 +89,15 @@ func (m *defaults) targetableProperties() []interface{} {
 	}
 }
 
-func (m *defaults) features() *Features {
+func (m *defaults) Features() *Features {
 	return &m.Properties.Features
 }
 
-func (m *defaults) getTarget() tgtType {
+func (m *defaults) getTarget() TgtType {
 	return m.Properties.TargetType
 }
 
-func (m *defaults) getTargetSpecific(variant tgtType) *TargetSpecific {
+func (m *defaults) getTargetSpecific(variant TgtType) *TargetSpecific {
 	return m.Properties.getTargetSpecific(variant)
 }
 
@@ -163,7 +163,7 @@ var _ moduleWithBuildProps = (*defaults)(nil)
 var _ targetSpecificLibrary = (*defaults)(nil)
 
 // Defaults support conditional properties via "features"
-var _ featurable = (*defaults)(nil)
+var _ Featurable = (*defaults)(nil)
 
 // Defaults contain path fragments which need to be prefixes
 var _ pathProcessor = (*defaults)(nil)

--- a/core/dep_sorter.go
+++ b/core/dep_sorter.go
@@ -24,7 +24,7 @@ import (
 )
 
 type graphMutatorHandler struct {
-	graphs map[tgtType]graph.Graph
+	graphs map[TgtType]graph.Graph
 }
 
 const (

--- a/core/external_library.go
+++ b/core/external_library.go
@@ -79,6 +79,10 @@ var _ splittable = (*externalLib)(nil)
 // External libraries have no actions - they are already built.
 func (m *externalLib) GenerateBuildActions(ctx blueprint.ModuleContext) {}
 
+func (m externalLib) GetProperties() interface{} {
+	return m.Properties
+}
+
 func externalLibFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &externalLib{}
 	module.Properties.Features.Init(&config.Properties, ExternalLibProps{})

--- a/core/external_library.go
+++ b/core/external_library.go
@@ -26,7 +26,7 @@ type ExternalLibProps struct {
 	Export_ldflags []string
 	Ldlibs         []string
 
-	TargetType tgtType `blueprint:"mutated"`
+	TargetType TgtType `blueprint:"mutated"`
 }
 
 type externalLib struct {
@@ -37,11 +37,11 @@ type externalLib struct {
 	}
 }
 
-func (m *externalLib) featurableProperties() []interface{} {
+func (m *externalLib) FeaturableProperties() []interface{} {
 	return []interface{}{&m.Properties.ExternalLibProps}
 }
 
-func (m *externalLib) features() *Features {
+func (m *externalLib) Features() *Features {
 	return &m.Properties.Features
 }
 
@@ -55,10 +55,10 @@ func (m *externalLib) outputs() []string         { return []string{} }
 func (m *externalLib) implicitOutputs() []string { return []string{} }
 
 // Implement the splittable interface so "normal" libraries can depend on external ones.
-func (m *externalLib) supportedVariants() []tgtType         { return []tgtType{tgtTypeHost, tgtTypeTarget} }
+func (m *externalLib) supportedVariants() []TgtType         { return []TgtType{tgtTypeHost, tgtTypeTarget} }
 func (m *externalLib) disable()                             {}
-func (m *externalLib) setVariant(tgt tgtType)               { m.Properties.TargetType = tgt }
-func (m *externalLib) getTarget() tgtType                   { return m.Properties.TargetType }
+func (m *externalLib) setVariant(tgt TgtType)               { m.Properties.TargetType = tgt }
+func (m *externalLib) getTarget() TgtType                   { return m.Properties.TargetType }
 func (m *externalLib) getSplittableProps() *SplittableProps { return &SplittableProps{} }
 
 // Implement the propertyExporter interface so that external libraries can pass

--- a/core/filegroup.go
+++ b/core/filegroup.go
@@ -91,6 +91,10 @@ func propogateFilegroupData(mctx blueprint.BottomUpMutatorContext) {
 	}
 }
 
+func (m filegroup) GetProperties() interface{} {
+	return m.Properties
+}
+
 func filegroupFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &filegroup{}
 	module.Properties.Features.Init(&config.Properties, SourceProps{})

--- a/core/filegroup.go
+++ b/core/filegroup.go
@@ -58,6 +58,16 @@ func (m *filegroup) processPaths(ctx blueprint.BaseModuleContext, g generatorBac
 	m.Properties.SourceProps.processPaths(ctx, g)
 }
 
+func (m *filegroup) FeaturableProperties() []interface{} {
+	return []interface{}{
+		&m.Properties.SourceProps,
+	}
+}
+
+func (m *filegroup) Features() *Features {
+	return &m.Properties.Features
+}
+
 var (
 	filegroupMap = depmap.NewDepmap()
 )

--- a/core/gen_binary.go
+++ b/core/gen_binary.go
@@ -56,6 +56,10 @@ func (m *generateBinary) GenerateBuildActions(ctx blueprint.ModuleContext) {
 	}
 }
 
+func (m generateBinary) GetProperties() interface{} {
+	return m.generateLibrary.Properties
+}
+
 //// Factory functions
 
 func genBinaryFactory(config *BobConfig) (blueprint.Module, []interface{}) {

--- a/core/gen_library.go
+++ b/core/gen_library.go
@@ -106,8 +106,8 @@ func (m *generateLibrary) getImplicitSources(ctx blueprint.BaseModuleContext) []
 
 //// Support splittable
 
-func (m *generateLibrary) supportedVariants() []tgtType {
-	return []tgtType{m.generateCommon.Properties.Target}
+func (m *generateLibrary) supportedVariants() []TgtType {
+	return []TgtType{m.generateCommon.Properties.Target}
 }
 
 func (m *generateLibrary) disable() {
@@ -115,7 +115,7 @@ func (m *generateLibrary) disable() {
 	panic("disable() called on GenerateLibrary")
 }
 
-func (m *generateLibrary) setVariant(variant tgtType) {
+func (m *generateLibrary) setVariant(variant TgtType) {
 	// No need to actually track this, as a single target is always supported
 }
 
@@ -123,8 +123,8 @@ func (m *generateLibrary) getSplittableProps() *SplittableProps {
 	return &m.generateCommon.Properties.FlagArgsBuild.SplittableProps
 }
 
-func (m *generateLibrary) featurableProperties() []interface{} {
-	return append(m.generateCommon.featurableProperties(), &m.Properties.GenerateLibraryProps)
+func (m *generateLibrary) FeaturableProperties() []interface{} {
+	return append(m.generateCommon.FeaturableProperties(), &m.Properties.GenerateLibraryProps)
 }
 
 //// Support singleOutputModule interface

--- a/core/gen_shared.go
+++ b/core/gen_shared.go
@@ -64,6 +64,10 @@ func (m *generateSharedLibrary) getTocName() string {
 	return m.outputFileName() + tocExt
 }
 
+func (m generateSharedLibrary) GetProperties() interface{} {
+	return m.generateLibrary.Properties
+}
+
 //// Factory functions
 
 func genSharedLibFactory(config *BobConfig) (blueprint.Module, []interface{}) {

--- a/core/gen_static.go
+++ b/core/gen_static.go
@@ -56,6 +56,10 @@ func (m *generateStaticLibrary) outputFileName() string {
 	return m.altName() + m.libExtension()
 }
 
+func (m generateStaticLibrary) GetProperties() interface{} {
+	return m.generateLibrary.Properties
+}
+
 //// Factory functions
 
 func genStaticLibFactory(config *BobConfig) (blueprint.Module, []interface{}) {

--- a/core/generated.go
+++ b/core/generated.go
@@ -857,6 +857,18 @@ type transformSource struct {
 // transformSource supports installation
 var _ installable = (*transformSource)(nil)
 
+func (m generateSource) GetProperties() interface{} {
+	return m.Properties
+}
+
+func (m transformSource) GetProperties() interface{} {
+	return m.Properties
+}
+
+func (m androidGenerateRule) GetProperties() interface{} {
+	return m.Properties
+}
+
 func generateSourceFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &generateSource{}
 	module.generateCommon.init(&config.Properties,

--- a/core/generated.go
+++ b/core/generated.go
@@ -134,7 +134,7 @@ type GenerateProps struct {
 	Flag_defaults []string
 
 	// The target type - must be either "host" or "target"
-	Target tgtType
+	Target TgtType
 
 	// If true, depfile name will be generated and can be used as ${depfile} reference in 'cmd'
 	Depfile *bool
@@ -206,7 +206,7 @@ type androidGenerateRule struct {
 // * use of {{match_srcs}} on some properties
 // * properties that require escaping
 // * sharing properties from defaults via `flag_defaults` property
-var _ featurable = (*generateCommon)(nil)
+var _ Featurable = (*generateCommon)(nil)
 var _ enableable = (*generateCommon)(nil)
 var _ splittable = (*generateCommon)(nil)
 var _ matchSourceInterface = (*generateCommon)(nil)
@@ -262,15 +262,15 @@ func (m *androidGenerateCommon) getAndroidGenerateCommon() *androidGenerateCommo
 	return m
 }
 
-func (m *generateCommon) featurableProperties() []interface{} {
+func (m *generateCommon) FeaturableProperties() []interface{} {
 	return []interface{}{&m.Properties.GenerateProps}
 }
 
-func (m *generateCommon) features() *Features {
+func (m *generateCommon) Features() *Features {
 	return &m.Properties.Features
 }
 
-func (m *generateCommon) getTarget() tgtType {
+func (m *generateCommon) getTarget() TgtType {
 	return m.Properties.Target
 }
 
@@ -282,15 +282,15 @@ func (m *generateCommon) getInstallDepPhonyNames(ctx blueprint.ModuleContext) []
 	return getShortNamesForDirectDepsWithTags(ctx, installDepTag)
 }
 
-func (m *generateCommon) supportedVariants() []tgtType {
-	return []tgtType{m.Properties.Target}
+func (m *generateCommon) supportedVariants() []TgtType {
+	return []TgtType{m.Properties.Target}
 }
 
 func (m *generateCommon) disable() {
 	*m.Properties.Enabled = false
 }
 
-func (m *generateCommon) setVariant(variant tgtType) {
+func (m *generateCommon) setVariant(variant TgtType) {
 	if variant != m.Properties.Target {
 		utils.Die("Variant mismatch: %s != %s", variant, m.Properties.Target)
 	}
@@ -442,8 +442,8 @@ func (m *generateSource) GenerateBuildActions(ctx blueprint.ModuleContext) {
 	}
 }
 
-func (m *generateSource) featurableProperties() []interface{} {
-	return append(m.generateCommon.featurableProperties(), &m.Properties.GenerateSourceProps)
+func (m *generateSource) FeaturableProperties() []interface{} {
+	return append(m.generateCommon.FeaturableProperties(), &m.Properties.GenerateSourceProps)
 }
 
 func (m *generateCommon) hostBinName(mctx blueprint.ModuleContext) (name string) {
@@ -468,7 +468,7 @@ func (m *generateCommon) hostBinName(mctx blueprint.ModuleContext) (name string)
 // target type and shared library dependencies for a generator module.
 // This is different from the "tool" in that it used to depend on
 // a bob_binary module.
-func (m *generateCommon) hostBinOuts(mctx blueprint.ModuleContext) (string, []string, tgtType) {
+func (m *generateCommon) hostBinOuts(mctx blueprint.ModuleContext) (string, []string, TgtType) {
 	// No host_bin provided
 	if m.Properties.Host_bin == nil {
 		return "", []string{}, tgtTypeUnknown
@@ -552,7 +552,7 @@ func getDependentArgsAndFiles(ctx blueprint.ModuleContext, args map[string]strin
 	return
 }
 
-func (m *generateCommon) getArgs(ctx blueprint.ModuleContext) (string, map[string]string, []string, tgtType) {
+func (m *generateCommon) getArgs(ctx blueprint.ModuleContext) (string, map[string]string, []string, TgtType) {
 	g := getBackend(ctx)
 
 	tc := g.getToolchain(m.Properties.Target)
@@ -799,8 +799,8 @@ func (m *androidGenerateRule) GenerateBuildActions(ctx blueprint.ModuleContext) 
 	}
 }
 
-func (m *transformSource) featurableProperties() []interface{} {
-	return append(m.generateCommon.featurableProperties(), &m.Properties.TransformSourceProps)
+func (m *transformSource) FeaturableProperties() []interface{} {
+	return append(m.generateCommon.FeaturableProperties(), &m.Properties.TransformSourceProps)
 }
 
 func (m *transformSource) sourceInfo(ctx blueprint.ModuleContext, g generatorBackend) []filePath {

--- a/core/glob.go
+++ b/core/glob.go
@@ -133,6 +133,10 @@ func (g *moduleGlob) GenerateBuildActions(ctx blueprint.ModuleContext) {
 	// Only sources should be returned to the modules depending on.
 }
 
+func (g moduleGlob) GetProperties() interface{} {
+	return g.Properties
+}
+
 func globFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	t := true
 	module := &moduleGlob{}

--- a/core/install.go
+++ b/core/install.go
@@ -254,6 +254,14 @@ func (m *resource) getAliasList() []string {
 	return m.Properties.getAliasList()
 }
 
+func (m installGroup) GetProperties() interface{} {
+	return m.Properties
+}
+
+func (m resource) GetProperties() interface{} {
+	return m.Properties
+}
+
 func installGroupFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &installGroup{}
 	module.Properties.Features.Init(&config.Properties, InstallGroupProps{})

--- a/core/install.go
+++ b/core/install.go
@@ -166,11 +166,11 @@ func (m *installGroup) GenerateBuildActions(ctx blueprint.ModuleContext) {
 	// No build actions for a bob_install_group
 }
 
-func (m *installGroup) featurableProperties() []interface{} {
+func (m *installGroup) FeaturableProperties() []interface{} {
 	return []interface{}{&m.Properties.InstallGroupProps}
 }
 
-func (m *installGroup) features() *Features {
+func (m *installGroup) Features() *Features {
 	return &m.Properties.Features
 }
 
@@ -209,11 +209,11 @@ func (m *resource) GenerateBuildActions(ctx blueprint.ModuleContext) {
 	}
 }
 
-func (m *resource) featurableProperties() []interface{} {
+func (m *resource) FeaturableProperties() []interface{} {
 	return []interface{}{&m.Properties.ResourceProps}
 }
 
-func (m *resource) features() *Features {
+func (m *resource) Features() *Features {
 	return &m.Properties.Features
 }
 

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -266,6 +266,10 @@ func (m *kernelModule) GenerateBuildActions(ctx blueprint.ModuleContext) {
 	}
 }
 
+func (m kernelModule) GetProperties() interface{} {
+	return m.Properties
+}
+
 func kernelModuleFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &kernelModule{}
 

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -78,7 +78,7 @@ type kernelModule struct {
 // * module enabling/disabling
 // * appending to aliases
 var _ defaultable = (*kernelModule)(nil)
-var _ featurable = (*kernelModule)(nil)
+var _ Featurable = (*kernelModule)(nil)
 var _ installable = (*kernelModule)(nil)
 var _ enableable = (*kernelModule)(nil)
 var _ aliasable = (*kernelModule)(nil)
@@ -91,11 +91,11 @@ func (m *kernelModule) defaultableProperties() []interface{} {
 	return []interface{}{&m.Properties.CommonProps, &m.Properties.KernelProps}
 }
 
-func (m *kernelModule) featurableProperties() []interface{} {
+func (m *kernelModule) FeaturableProperties() []interface{} {
 	return []interface{}{&m.Properties.CommonProps, &m.Properties.KernelProps}
 }
 
-func (m *kernelModule) features() *Features {
+func (m *kernelModule) Features() *Features {
 	return &m.Properties.Features
 }
 

--- a/core/late_template.go
+++ b/core/late_template.go
@@ -223,7 +223,7 @@ func setupAddIfSupported(mctx blueprint.BaseModuleContext,
 // Applies late templates to the given module
 func applyLateTemplates(mctx blueprint.BaseModuleContext) {
 
-	m, ok := mctx.Module().(featurable)
+	m, ok := mctx.Module().(Featurable)
 	if !ok {
 		// Features and templates not supported by this module type
 		return
@@ -244,7 +244,7 @@ func applyLateTemplates(mctx blueprint.BaseModuleContext) {
 	}
 
 	// Generic template expansion
-	for _, p := range m.featurableProperties() {
+	for _, p := range m.FeaturableProperties() {
 		propsVal := reflect.Indirect(reflect.ValueOf(p))
 
 		// Properties have already been expanded, so set stringvalues to nil

--- a/core/library.go
+++ b/core/library.go
@@ -57,7 +57,7 @@ type library struct {
 // * properties that require escaping
 // * appending to aliases
 var _ defaultable = (*library)(nil)
-var _ featurable = (*library)(nil)
+var _ Featurable = (*library)(nil)
 var _ targetSpecificLibrary = (*library)(nil)
 var _ installable = (*library)(nil)
 var _ enableable = (*library)(nil)
@@ -84,7 +84,7 @@ func (l *library) build() *Build {
 	return &l.Properties.Build
 }
 
-func (l *library) featurableProperties() []interface{} {
+func (l *library) FeaturableProperties() []interface{} {
 	return []interface{}{
 		&l.Properties.Build.CommonProps,
 		&l.Properties.Build.BuildProps,
@@ -100,11 +100,11 @@ func (l *library) targetableProperties() []interface{} {
 	}
 }
 
-func (l *library) features() *Features {
+func (l *library) Features() *Features {
 	return &l.Properties.Features
 }
 
-func (l *library) getTarget() tgtType {
+func (l *library) getTarget() TgtType {
 	return l.Properties.TargetType
 }
 
@@ -139,7 +139,7 @@ func (l *library) getAliasList() []string {
 	return l.Properties.getAliasList()
 }
 
-func (l *library) supportedVariants() (tgts []tgtType) {
+func (l *library) supportedVariants() (tgts []TgtType) {
 	if l.Properties.isHostSupported() {
 		tgts = append(tgts, tgtTypeHost)
 	}
@@ -154,7 +154,7 @@ func (l *library) disable() {
 	l.Properties.Enabled = &f
 }
 
-func (l *library) setVariant(tgt tgtType) {
+func (l *library) setVariant(tgt TgtType) {
 	l.Properties.TargetType = tgt
 }
 
@@ -162,7 +162,7 @@ func (l *library) getSplittableProps() *SplittableProps {
 	return &l.Properties.SplittableProps
 }
 
-func (l *library) getTargetSpecific(tgt tgtType) *TargetSpecific {
+func (l *library) getTargetSpecific(tgt TgtType) *TargetSpecific {
 	return l.Properties.getTargetSpecific(tgt)
 }
 

--- a/core/library_shared.go
+++ b/core/library_shared.go
@@ -103,6 +103,10 @@ func (l *sharedLibrary) getTocName() string {
 	return l.getRealName() + tocExt
 }
 
+func (l sharedLibrary) GetProperties() interface{} {
+	return l.library.Properties
+}
+
 func sharedLibraryFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &sharedLibrary{}
 	if config.Properties.GetBool("osx") {

--- a/core/library_static.go
+++ b/core/library_static.go
@@ -35,6 +35,10 @@ func (l *staticLibrary) outputFileName() string {
 	return l.outputName() + ".a"
 }
 
+func (l staticLibrary) GetProperties() interface{} {
+	return l.library.Properties
+}
+
 func staticLibraryFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &staticLibrary{}
 	return module.LibraryFactory(config, module)

--- a/core/linux_backend.go
+++ b/core/linux_backend.go
@@ -119,7 +119,7 @@ type singleOutputModule interface {
 
 type targetableModule interface {
 	singleOutputModule
-	getTarget() tgtType
+	getTarget() TgtType
 }
 
 // Modules implementing sharedLibProducer create a shared library
@@ -140,7 +140,7 @@ func (g *linuxGenerator) staticLibOutputDir(m *staticLibrary) string {
 	return filepath.Join("${BuildDir}", string(m.Properties.TargetType), "static")
 }
 
-func (g *linuxGenerator) sharedLibsDir(tgt tgtType) string {
+func (g *linuxGenerator) sharedLibsDir(tgt TgtType) string {
 	return filepath.Join("${BuildDir}", string(tgt), "shared")
 }
 
@@ -166,7 +166,7 @@ var tocRule = pctx.StaticRule("shared_library_toc",
 	},
 	"tocflags")
 
-func (g *linuxGenerator) addSharedLibToc(ctx blueprint.ModuleContext, soFile, tocFile string, tgt tgtType) {
+func (g *linuxGenerator) addSharedLibToc(ctx blueprint.ModuleContext, soFile, tocFile string, tgt TgtType) {
 	tc := g.getToolchain(tgt)
 	tocFlags := tc.getLibraryTocFlags()
 
@@ -180,7 +180,7 @@ func (g *linuxGenerator) addSharedLibToc(ctx blueprint.ModuleContext, soFile, to
 		})
 }
 
-func (g *linuxGenerator) binaryOutputDir(tgt tgtType) string {
+func (g *linuxGenerator) binaryOutputDir(tgt TgtType) string {
 	return filepath.Join("${BuildDir}", string(tgt), "executable")
 }
 

--- a/core/properties.go
+++ b/core/properties.go
@@ -204,22 +204,22 @@ func appendDefaults(dst []interface{}, src []interface{}) error {
 }
 
 // Modules implementing featurable support the use of features and templates.
-type featurable interface {
-	featurableProperties() []interface{}
-	features() *Features
+type Featurable interface {
+	FeaturableProperties() []interface{}
+	Features() *Features
 }
 
 func templateApplierMutator(mctx blueprint.TopDownMutatorContext) {
 	module := mctx.Module()
 	cfg := getConfig(mctx)
 
-	if m, ok := module.(featurable); ok {
+	if m, ok := module.(Featurable); ok {
 		cfgProps := &cfg.Properties
 
 		// TemplateApplier mutator is run before TargetApplier, so we
 		// need to apply templates with the core set, as well as
 		// host-specific and target-specific sets (where applicable).
-		props := append([]interface{}{}, m.featurableProperties()...)
+		props := append([]interface{}{}, m.FeaturableProperties()...)
 
 		if ts, ok := module.(targetSpecificLibrary); ok {
 			host := ts.getTargetSpecific(tgtTypeHost)
@@ -246,13 +246,13 @@ func featureApplierMutator(mctx blueprint.TopDownMutatorContext) {
 	module := mctx.Module()
 	cfg := getConfig(mctx)
 
-	if m, ok := module.(featurable); ok {
+	if m, ok := module.(Featurable); ok {
 		cfgProps := &cfg.Properties
 
 		// FeatureApplier mutator is run first. We need to flatten the
 		// feature specific properties in the core set, and where
 		// supported, the host-specific and target-specific set.
-		var props = []propmap{{m.featurableProperties(), m.features()}}
+		var props = []propmap{{m.FeaturableProperties(), m.Features()}}
 
 		// Apply features in target-specific properties.
 		// This should happen for all modules which support host:{} and target:{}

--- a/core/splitter.go
+++ b/core/splitter.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Arm Limited.
+ * Copyright 2018-2021, 2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,16 +36,16 @@ type SplittableProps struct {
 // the different variants by the splitterMutator
 type splittable interface {
 	// Retrieve all the different variations to create
-	supportedVariants() []tgtType
+	supportedVariants() []TgtType
 
 	// Disables the module is no variations supported
 	disable()
 
 	// Set the particular variant
-	setVariant(tgtType)
+	setVariant(TgtType)
 
 	// Retrieve the module target type variant as set by setVariant
-	getTarget() tgtType
+	getTarget() TgtType
 
 	// Get the properties related to which variants are available
 	getSplittableProps() *SplittableProps
@@ -57,7 +57,7 @@ type targetSpecificLibrary interface {
 	splittable
 
 	// Get the target specific properties i.e. host:{} or target:{}
-	getTargetSpecific(tgtType) *TargetSpecific
+	getTargetSpecific(TgtType) *TargetSpecific
 
 	// Get the set of the module main properties for
 	// that target specific properties would be applied to
@@ -112,7 +112,7 @@ func supportedVariantsMutator(mctx blueprint.BottomUpMutatorContext) {
 	}
 }
 
-func tgtToString(tgts []tgtType) []string {
+func tgtToString(tgts []TgtType) []string {
 	variants := make([]string, len(tgts))
 	for i, v := range tgts {
 		variants[i] = string(v)
@@ -133,7 +133,7 @@ func splitterMutator(mctx blueprint.BottomUpMutatorContext) {
 				if !ok {
 					panic(errors.New("newly created variation is not splittable - should not happen"))
 				}
-				newsplit.setVariant(tgtType(v))
+				newsplit.setVariant(TgtType(v))
 			}
 		}
 	}

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -46,6 +46,10 @@ type moduleBase struct {
 	blueprint.SimpleName
 }
 
+type PropertyProvider interface {
+	GetProperties() interface{}
+}
+
 // configProvider allows the retrieval of configuration
 type configProvider interface {
 	Config() interface{}

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -195,7 +195,7 @@ func Main() {
 
 		ctx.RegisterTopDownMutator("export_lib_flags", exportLibFlagsMutator).Parallel()
 		dependencyGraphHandler := graphMutatorHandler{
-			map[tgtType]graph.Graph{
+			map[TgtType]graph.Graph{
 				tgtTypeHost:   graph.NewGraph("All"),
 				tgtTypeTarget: graph.NewGraph("All"),
 			},

--- a/core/strict_library.go
+++ b/core/strict_library.go
@@ -47,7 +47,7 @@ type StrictLibraryProps struct {
 	Deps          []string
 	Out           *string // TODO:
 	// unused but needed for the output interface, no easy way to hide it
-	TargetType tgtType `blueprint:"mutated"`
+	TargetType TgtType `blueprint:"mutated"`
 }
 
 type strictLibrary struct {
@@ -129,7 +129,7 @@ func (l *strictLibrary) getSrcs() []string {
 	return l.Properties.Srcs
 }
 
-func (l *strictLibrary) supportedVariants() (tgts []tgtType) {
+func (l *strictLibrary) supportedVariants() (tgts []TgtType) {
 	// TODO: Change tgts based on if host or target supported.
 	tgts = append(tgts, tgtTypeHost)
 	return
@@ -140,11 +140,11 @@ func (l *strictLibrary) disable() {
 	l.Properties.Enabled = &f
 }
 
-func (l *strictLibrary) setVariant(tgt tgtType) {
+func (l *strictLibrary) setVariant(tgt TgtType) {
 	l.Properties.TargetType = tgt
 }
 
-func (l *strictLibrary) getTarget() tgtType {
+func (l *strictLibrary) getTarget() TgtType {
 	return l.Properties.TargetType
 }
 

--- a/core/strict_library.go
+++ b/core/strict_library.go
@@ -176,6 +176,10 @@ func (m *strictLibrary) getTocName() string {
 	return m.Name() + tocExt
 }
 
+func (m strictLibrary) GetProperties() interface{} {
+	return m.Properties
+}
+
 func LibraryFactory(config *BobConfig) (blueprint.Module, []interface{}) {
 	module := &strictLibrary{}
 	module.Properties.Features.Init(&config.Properties, StrictLibraryProps{})

--- a/core/strip.go
+++ b/core/strip.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 Arm Limited.
+ * Copyright 2019-2020, 2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +56,7 @@ func (props *StripProps) setDebugPath(path *string) {
 
 type stripable interface {
 	strip() bool
-	getTarget() tgtType
+	getTarget() TgtType
 	stripOutputDir(g generatorBackend) string
 
 	getDebugInfo() *string

--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -435,7 +435,7 @@ func (tc toolchainGnuCross) getStdCxxHeaderDirs() []string {
 	}
 }
 
-func newToolchainGnuCommon(config *BobConfig, tgt tgtType) (tc toolchainGnuCommon) {
+func newToolchainGnuCommon(config *BobConfig, tgt TgtType) (tc toolchainGnuCommon) {
 	props := config.Properties
 	tc.prefix = props.GetString(string(tgt) + "_gnu_prefix")
 	tc.arBinary = props.GetString(string(tgt) + "_ar_binary")
@@ -552,7 +552,7 @@ func (tc toolchainClangCommon) checkFlagIsSupported(language, flag string) bool 
 	return tc.flagCache.checkFlag(tc, language, flag)
 }
 
-func newToolchainClangCommon(config *BobConfig, tgt tgtType) (tc toolchainClangCommon) {
+func newToolchainClangCommon(config *BobConfig, tgt TgtType) (tc toolchainClangCommon) {
 	props := config.Properties
 	tc.prefix = props.GetString(string(tgt) + "_clang_prefix")
 
@@ -735,7 +735,7 @@ func (tc toolchainArmClang) checkFlagIsSupported(language, flag string) bool {
 	return tc.flagCache.checkFlag(tc, language, flag)
 }
 
-func newToolchainArmClangCommon(config *BobConfig, tgt tgtType) (tc toolchainArmClang) {
+func newToolchainArmClangCommon(config *BobConfig, tgt TgtType) (tc toolchainArmClang) {
 	props := config.Properties
 	tc.prefix = props.GetString(string(tgt) + "_gnu_prefix")
 	tc.arBinary = tc.prefix + props.GetString("armclang_ar_binary")
@@ -889,7 +889,7 @@ func (tc toolchainXcode) checkFlagIsSupported(language, flag string) bool {
 	return tc.flagCache.checkFlag(tc, language, flag)
 }
 
-func newToolchainXcodeCommon(config *BobConfig, tgt tgtType) (tc toolchainXcode) {
+func newToolchainXcodeCommon(config *BobConfig, tgt TgtType) (tc toolchainXcode) {
 	props := config.Properties
 	tc.prefix = props.GetString(string(tgt) + "_xcode_prefix")
 	tc.arBinary = props.GetString(string(tgt) + "_ar_binary")
@@ -930,7 +930,7 @@ type toolchainSet struct {
 	target toolchain
 }
 
-func (tcs *toolchainSet) getToolchain(tgt tgtType) toolchain {
+func (tcs *toolchainSet) getToolchain(tgt TgtType) toolchain {
 	if tgt == tgtTypeHost {
 		return tcs.host
 	}

--- a/mconfig/host_toolchain.Mconfig
+++ b/mconfig/host_toolchain.Mconfig
@@ -16,7 +16,7 @@
 ### Host toolchain options ###
 # The host options are not yet read by `toolchain.go`, so are empty, and
 # exist so that `host_explore.py` can be agnostic to the target type when
-# doing e.g. `get_config_string(tgtType + "_GNU_PREFIX")`. They are
+# doing e.g. `get_config_string(TgtType + "_GNU_PREFIX")`. They are
 # defined here, rather than in the superproject, because even when they are
 # fully supported, they will be empty most of the time.
 

--- a/mconfig/target_toolchain.Mconfig
+++ b/mconfig/target_toolchain.Mconfig
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Arm Limited.
+# Copyright 2016-2023 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 
 # The target options are defined here so that `host_explore.py` can be
 # agnostic to the target type when doing
-# e.g. `get_config_string(tgtType + "_GNU_PREFIX")`.
+# e.g. `get_config_string(TgtType + "_GNU_PREFIX")`.
 # These are defined here, rather than in the superproject, because
 # they will be empty most of the time.
 

--- a/tests/filegroups/build.bp
+++ b/tests/filegroups/build.bp
@@ -28,7 +28,9 @@ bob_glob {
 
 bob_filegroup {
     name: "forward_filegroup",
-    srcs: [":filegroup_impl"],
+    always_enabled_feature: {
+        srcs: [":filegroup_impl"],
+    }
 }
 
 bob_binary {


### PR DESCRIPTION
Gazelle need to parse Bob's module Features
thus it has to be exported outside the package.

Additionally make `filegroup` featureable
as it should implement this interface too.

Also export `TgtType` type which mimics string.

Change-Id: Iecbccb64cd81236984588895d7516216b16d0655