### PR TITLE
chore: add bpfmt to pre-commit

### DIFF
--- a/.github/pre-commit.Dockerfile
+++ b/.github/pre-commit.Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.20-bullseye as go
 
+ARG BAZELISK_VERSION=1.16.0
+RUN CGO_ENABLED=0 GOOS=linux GOBIN=/opt/bazelisk/bin go install github.com/bazelbuild/bazelisk@v${BAZELISK_VERSION}
+
 FROM debian:bullseye-slim
 
 RUN apt update \
@@ -27,3 +30,9 @@ RUN python3 -m pip install --user --no-cache-dir --upgrade pip==23.0
 RUN python3 -m pip install --user --no-cache-dir pre-commit==3.0.2
 
 COPY --from=go /usr/local/go /usr/local/go
+COPY --from=go /opt/bazelisk/bin/bazelisk /home/ci/.local/bin/bazelisk
+
+ENV BAZELISK_HOME /home/ci/.cache/bazelisk
+
+# Pre-download some bazel version to save time in CI
+RUN USE_BAZEL_VERSION=latest bazelisk --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: "true"
       - uses: actions/setup-python@v3
       - uses: actions/setup-go@v3
+      - uses: bazelbuild/setup-bazelisk@v2
       - run: echo "PATH=$PATH:/home/runner/go/bin" >> $GITHUB_ENV
       - uses: pre-commit/action@v3.0.0
 
@@ -221,6 +225,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: "true"
       - uses: bazelbuild/setup-bazelisk@v2
       - name: Mount bazel cache # Optional
         uses: actions/cache@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,11 @@ repos:
         files: (BUILD|WORKSPACE|.+\.bazel|.+\.bzl)$
         entry: buildifier
         args: ["--lint=fix"]
+
+      - id: bpfmt
+        name: "blueprint formatter"
+        entry: bazelisk run //:bpfmt_wrapper -- -w
+        language: system
+        files: ^.*build.bp$
+        types_or: [text]
+        require_serial: true

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 # TODO: Fix config system import structure
 # load("@rules_python_gazelle_plugin//:def.bzl", "GAZELLE_PYTHON_RUNTIME_DEPS")
@@ -34,4 +35,32 @@ gazelle(
         "-build_file_proto_mode=disable_global",
     ],
     command = "update-repos",
+)
+
+# Blueprint does not support Bazel, build the formatter here.
+go_library(
+    name = "bpfmt_lib",
+    srcs = ["blueprint/bpfmt/bpfmt.go"],
+    importpath = "github.com/google/blueprint/bpfmt",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_google_blueprint//:blueprint",
+        "@com_github_google_blueprint//parser",
+    ],
+)
+
+go_binary(
+    name = "bpfmt",
+    embed = [":bpfmt_lib"],
+    visibility = ["//visibility:public"],
+)
+
+# By default, bazel run executes the binary in the sandbox with its runfiles.
+# This breaks the pre-commit convention which uses relative paths from workspace root.
+# This wrapper captures the location of the needed binary and changes dir to the working
+# directory before calling bpfmt.
+sh_binary(
+    name = "bpfmt_wrapper",
+    srcs = ["bpfmt_wrapper.sh"],
+    data = [":bpfmt"],
 )

--- a/bpfmt_wrapper.sh
+++ b/bpfmt_wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+WORK_DIR=$(pwd)
+if test "${BUILD_WORKING_DIRECTORY+x}"; then
+  cd $BUILD_WORKING_DIRECTORY
+fi
+$WORK_DIR/bpfmt_/bpfmt "${@:1}"

--- a/gazelle/tests/example/build.bp
+++ b/gazelle/tests/example/build.bp
@@ -7,21 +7,24 @@ bob_binary {
     ],
     feature_a: {
         static_libs: [
-            "hello_test"
-        ]
+            "hello_test",
+        ],
     },
 }
 
 bob_static_library {
     name: "hello_test",
     srcs: [
-        "src/hello.c"
+        "src/hello.c",
     ],
     feature_a: {
         export_cflags: ["-DFOO=2"],
-        cflags: ["-Wall"]
+        cflags: ["-Wall"],
     },
     debug: {
-       cflags: ["-g", "-O0"]
-    }
+        cflags: [
+            "-g",
+            "-O0",
+        ],
+    },
 }

--- a/tests/filegroups/build.bp
+++ b/tests/filegroups/build.bp
@@ -30,15 +30,21 @@ bob_filegroup {
     name: "forward_filegroup",
     always_enabled_feature: {
         srcs: [":filegroup_impl"],
-    }
+    },
 }
 
 bob_binary {
     name: "test_filegroup_simple",
-    srcs: [ ":glob_main", ":forward_filegroup"],
+    srcs: [
+        ":glob_main",
+        ":forward_filegroup",
+    ],
 }
 
 bob_alias {
     name: "bob_test_filegroups",
-    srcs: ["test_filegroup_simple", "test_filegroup_simple_deprecated"],
+    srcs: [
+        "test_filegroup_simple",
+        "test_filegroup_simple_deprecated",
+    ],
 }

--- a/tests/filegroups/deprecated/build.bp
+++ b/tests/filegroups/deprecated/build.bp
@@ -15,9 +15,11 @@
  * limitations under the License.
  */
 
-
 bob_binary {
     name: "test_filegroup_simple_deprecated",
     srcs: [],
-    filegroup_srcs: ["forward_filegroup", "glob_main"], // filegroup_srcs is no longer recommended. But can be used in legacy targets.
+    filegroup_srcs: [ // filegroup_srcs is no longer recommended. But can be used in legacy targets.
+        "forward_filegroup",
+        "glob_main",
+    ],
 }

--- a/tests/flag_supported/build.bp
+++ b/tests/flag_supported/build.bp
@@ -17,15 +17,21 @@
 
 bob_binary {
     name: "bob_test_flag_supported",
-    srcs: ["test.c", "test_cpp.cpp"],
+    srcs: [
+        "test.c",
+        "test_cpp.cpp",
+    ],
     conlyflags: [
         "{{add_if_supported \"-Wno-discarded-qualifiers\"}}",
         "{{add_if_supported \"-Wno-ignored-qualifiers\"}}",
         "{{add_if_supported \"-Wno-main-return-type\"}}",
-	/* old gcc uses -Wmain to warn about the declaration of 'main' */
+        /* old gcc uses -Wmain to warn about the declaration of 'main' */
         "{{add_if_supported \"-Wno-main\"}}",
     ],
-    cflags: ["-Wall", "-Werror"],
+    cflags: [
+        "-Wall",
+        "-Werror",
+    ],
     cxxflags: [
         "{{add_if_supported \"-Wno-ignored-qualifiers\"}}",
     ],

--- a/tests/generate_source/build.bp
+++ b/tests/generate_source/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 Arm Limited.
+ * Copyright 2018-2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -196,7 +196,7 @@ bob_generate_source {
     srcs: ["depgen1.in"],
     out: [
         "output.txt",
-        "out.h"
+        "out.h",
     ],
     depfile: true,
     tools: ["gen_with_dep.py"],

--- a/tests/generate_source_new/build.bp
+++ b/tests/generate_source_new/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 Arm Limited.
+ * Copyright 2018-2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -183,8 +183,9 @@ bob_binary {
 bob_genrule {
     name: "gen_source_depfile_new",
     srcs: [
-    "depgen1.in",
-    "depgen2.in",],
+        "depgen1.in",
+        "depgen2.in",
+    ],
     out: ["output.txt"],
     depfile: true,
     tool_files: ["gen_with_dep.py"],
@@ -193,10 +194,13 @@ bob_genrule {
 
 bob_genrule {
     name: "gen_source_depfile_with_implicit_outs_new",
-    srcs: ["depgen1.in","depgen2.in",],
+    srcs: [
+        "depgen1.in",
+        "depgen2.in",
+    ],
     out: [
         "output.txt",
-        "out.h"
+        "out.h",
     ],
     depfile: true,
     tool_files: ["gen_with_dep.py"],
@@ -231,12 +235,15 @@ bob_genrule {
 
 bob_genrule {
     name: "multi_tool_file",
-    srcs: ["depgen2.in",],
+    srcs: ["depgen2.in"],
     out: [
         "output.txt",
-        "out.h"
+        "out.h",
     ],
-    tool_files: ["gen_with_dep.py", "depgen1.in",],
+    tool_files: [
+        "gen_with_dep.py",
+        "depgen1.in",
+    ],
     depfile: true,
     cmd: "$(location gen_with_dep.py) --gen-implicit-out -o $(genDir)/output.txt -d $(depfile) --in $(location depgen1.in) $(in)",
 }

--- a/tests/generated_headers/build.bp
+++ b/tests/generated_headers/build.bp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Arm Limited.
+ * Copyright 2020-2021, 2023 Arm Limited.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,7 +34,7 @@ bob_static_library {
     srcs: ["null.c"],
     export_generated_headers: [
         "generated_header",
-        "generated_header_single"
+        "generated_header_single",
     ],
 }
 

--- a/tests/globs/build.bp
+++ b/tests/globs/build.bp
@@ -22,7 +22,7 @@ bob_glob {
 
 bob_binary {
     name: "glob_test",
-    srcs: [":src_glob"]
+    srcs: [":src_glob"],
 }
 
 bob_binary {
@@ -45,7 +45,7 @@ bob_binary {
     name: "test_exclude_srcs",
     srcs: [
         "src/inside/a/namespace/main.cpp",
-        ":src_glob_exclude"
+        ":src_glob_exclude",
     ],
 }
 

--- a/tests/header_libs/build.bp
+++ b/tests/header_libs/build.bp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 bob_alias {
     name: "bob_test_header_libs",
     srcs: [
@@ -31,7 +30,7 @@ bob_static_library {
 bob_static_library {
     name: "hl_b",
     export_local_include_dirs: ["include"],
-    static_libs: ["hl_a"]
+    static_libs: ["hl_a"],
 }
 
 bob_binary {

--- a/tests/kernel_module/build.bp
+++ b/tests/kernel_module/build.bp
@@ -1,6 +1,9 @@
 bob_alias {
     name: "bob_test_kernel_module",
-    srcs: ["test_module1", "test_module2"],
+    srcs: [
+        "test_module1",
+        "test_module2",
+    ],
 }
 
 bob_install_group {

--- a/tests/strict_libs/interopt/build.bp
+++ b/tests/strict_libs/interopt/build.bp
@@ -19,6 +19,6 @@ bob_binary {
 bob_alias {
     name: "bob_test_strict_libs_interopt",
     srcs: [
-    "strict_lib_binary_with_transitive_define",
+        "strict_lib_binary_with_transitive_define",
     ],
 }

--- a/tests/strict_libs/shared/build.bp
+++ b/tests/strict_libs/shared/build.bp
@@ -12,7 +12,6 @@
 //     build_by_default: true,
 // }
 
-
 bob_alias {
     name: "bob_test_strict_shared_libs",
 }

--- a/tests/strict_libs/static/build.bp
+++ b/tests/strict_libs/static/build.bp
@@ -40,7 +40,7 @@ bob_binary {
 bob_alias {
     name: "bob_test_strict_static_libs",
     srcs: [
-    "strict_lib_binary_with_forward_define",
-    "strict_lib_binary_with_dep",
+        "strict_lib_binary_with_forward_define",
+        "strict_lib_binary_with_dep",
     ],
 }


### PR DESCRIPTION
Runs the format hook on all files.
Adds `bazelisk` to the pre-commit Docker
image.

Change-Id: I4d7d188f555b9aef938aee37a094015b05874ea8