### PR TITLE
Extend `BobModule` with the type

### DIFF
--- a/gazelle/BUILD.bazel
+++ b/gazelle/BUILD.bazel
@@ -68,6 +68,7 @@ go_test(
     name = "gazelle_test",
     srcs = [
         "bob_parser_test.go",
+        "config_test.go",
         "registry_test.go",
     ],
     # TODO: we need to keep here as it sets the embed to `:gazelle` incorrectly.

--- a/gazelle/bob_parser.go
+++ b/gazelle/bob_parser.go
@@ -50,10 +50,9 @@ func (p *bobParser) parse() []*BobModule {
 	var bobModulesMutex sync.RWMutex
 
 	bp.RegisterBottomUpMutator("register_bob_modules", func(mctx blueprint.BottomUpMutatorContext) {
-		bpModule := mctx.Module()
-		bobModule := NewBobModule(bpModule.Name(), p.rootPath, mctx.ModuleDir())
+		bobModule := NewBobModule(mctx.ModuleName(), mctx.ModuleType(), mctx.ModuleDir(), p.rootPath)
 
-		parseBpModule(bpModule, func(feature string, attribute string, v interface{}) {
+		parseBpModule(mctx.Module(), func(feature string, attribute string, v interface{}) {
 			bobModule.addFeatureAttribute(feature, attribute, v)
 		})
 

--- a/gazelle/config_test.go
+++ b/gazelle/config_test.go
@@ -1,0 +1,35 @@
+package plugin
+
+import (
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+)
+
+func TestBobConfigSpoof(t *testing.T) {
+
+	var configs map[string]configData = make(map[string]configData)
+
+	configs["feature_x"] = configData{Type: "config", Datatype: "bool"}
+	configs["feature_y"] = configData{Type: "config", Datatype: "string"}
+
+	bobConfig := createBobConfigSpoof(&configs)
+
+	assert.Equal(t, len(bobConfig.Properties.FeatureList), 2, "Wrong features inside config")
+	assert.Contains(t, bobConfig.Properties.FeatureList, "feature_x")
+	assert.Contains(t, bobConfig.Properties.FeatureList, "feature_y")
+
+	if v, ok := bobConfig.Properties.Properties["feature_x"].(configData); ok {
+		assert.Equal(t, "bool", v.Datatype)
+		assert.Equal(t, "config", v.Type)
+	} else {
+		t.Errorf("configData.Datatype of 'feature_x' has wrong type: %s", reflect.TypeOf(v))
+	}
+
+	if v, ok := bobConfig.Properties.Properties["feature_y"].(configData); ok {
+		assert.Equal(t, "string", v.Datatype)
+		assert.Equal(t, "config", v.Type)
+	} else {
+		t.Errorf("configData.Datatype of 'feature_y' has wrong type: %s", reflect.TypeOf(v))
+	}
+}

--- a/gazelle/module.go
+++ b/gazelle/module.go
@@ -7,6 +7,7 @@ import (
 type AttributesMap map[string]interface{}
 type BobModule struct {
 	bobName      string
+	bobType      string
 	relativePath string
 	bazelLabel   label.Label
 	features     map[string]AttributesMap
@@ -34,12 +35,13 @@ func (m *BobModule) addFeatureAttribute(feature string, attribute string, v inte
 	}
 }
 
-func NewBobModule(name string, repoRoot string, relPath string) *BobModule {
+func NewBobModule(moduleName string, moduleType string, relPath string, rootPath string) *BobModule {
 
 	bobModule := &BobModule{}
-	bobModule.bobName = name
+	bobModule.bobName = moduleName
+	bobModule.bobType = moduleType
 	bobModule.relativePath = relPath
-	bobModule.bazelLabel = label.Label{Repo: repoRoot, Pkg: relPath, Name: name}
+	bobModule.bazelLabel = label.Label{Repo: rootPath, Pkg: relPath, Name: moduleName}
 	bobModule.features = make(map[string]AttributesMap)
 
 	return bobModule

--- a/gazelle/registry_test.go
+++ b/gazelle/registry_test.go
@@ -8,7 +8,7 @@ import (
 func Test_register_module(t *testing.T) {
 	registry := NewRegistry()
 	testLabel := label.Label{Repo: "repo", Pkg: "some/pkg", Name: "m_name"}
-	m := NewBobModule("m_name", "repo", "some/pkg")
+	m := NewBobModule("m_name", "bob_binary", "some/pkg", "repo")
 	registry.register(m)
 	if !registry.nameExists("m_name") {
 		t.Errorf("module %d not successfully registered", m.getName())


### PR DESCRIPTION
`BobModule` has to contain exact module type registered by Bob that gazelle could generate correct counterpart Bazel types.