### PR TITLE
feat(meta): produce metadata for targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
     ],
 )
 
+# keep
 go_binary(
     name = "bpfmt",
     embed = [":bpfmt_lib"],

--- a/Blueprints
+++ b/Blueprints
@@ -79,6 +79,7 @@ bootstrap_go_package {
         "core/linux_cclibs.go",
         "core/linux_generated.go",
         "core/linux_kernel_module.go",
+        "core/metadata.go",
         "core/output_producer.go",
         "core/properties.go",
         "core/property_exporter.go",

--- a/bob.bootstrap.in
+++ b/bob.bootstrap.in
@@ -1,4 +1,4 @@
-# Copyright 2018-2019, 2021-2022 Arm Limited.
+# Copyright 2018-2019, 2021-2023 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,4 +31,5 @@ export BOB_CONFIG_OPTS="@@BobConfigOpts@@"
 export BOB_CONFIG_PLUGIN_OPTS="@@BobConfigPluginOpts@@"
 export BOB_BOOTSTRAP_VERSION="@@BobBootstrapVersion@@"
 export BOB_LOG_WARNINGS_FILE="@@BobLogWarningsFile@@"
+export BOB_META_FILE="@@BobMetaFile@@"
 export BOB_LOG_WARNINGS="@@BobLogWarnings@@"

--- a/bob.bootstrap.version
+++ b/bob.bootstrap.version
@@ -1,2 +1,2 @@
 # Version number used to identify whether the user needs to re-boostrap their build directory.
-BOB_VERSION="10"
+BOB_VERSION="11"

--- a/bootstrap/utils.bash
+++ b/bootstrap/utils.bash
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 Arm Limited.
+# Copyright 2018-2023 Arm Limited.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +38,7 @@ function write_bootstrap() {
         -e "s|@@BobConfigPluginOpts@@|${BOB_CONFIG_PLUGIN_OPTS}|" \
         -e "s|@@BobBootstrapVersion@@|${BOB_VERSION}|" \
         -e "s|@@BobLogWarningsFile@@|${BOB_LOG_WARNINGS_FILE}|" \
+        -e "s|@@BobMetaFile@@|${BOB_META_FILE}|" \
         -e "s|@@BobLogWarnings@@|${BOB_LOG_WARNINGS}|" \
         "${BOB_DIR}/bob.bootstrap.in" > "${BUILDDIR}/.bob.bootstrap.tmp"
     rsync -c "${BUILDDIR}/.bob.bootstrap.tmp" "${BUILDDIR}/.bob.bootstrap"

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "linux_cclibs.go",
         "linux_generated.go",
         "linux_kernel_module.go",
+        "metadata.go",
         "output_producer.go",
         "properties.go",
         "property_exporter.go",

--- a/core/metadata.go
+++ b/core/metadata.go
@@ -1,0 +1,81 @@
+package core
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"sync"
+
+	"github.com/ARM-software/bob-build/internal/utils"
+	"github.com/google/blueprint"
+)
+
+type ModuleMeta struct {
+	TransitiveSrcs []string `json:"srcs"`
+	TransitiveDeps []string `json:"deps"`
+}
+
+// Map of metadata keyed by module name.
+type BuildMeta map[string]ModuleMeta
+
+var (
+	metaData     BuildMeta
+	metaDataLock sync.RWMutex
+)
+
+func init() {
+	metaData = BuildMeta{}
+	metaDataLock = sync.RWMutex{}
+}
+
+// Helper to extract sources from various types of modules.
+func (m *ModuleMeta) extractSrcs(module blueprint.Module) {
+	if s, ok := module.(sourceInterface); ok {
+		m.TransitiveSrcs = utils.AppendUnique(m.TransitiveSrcs, s.getSourceFiles(nil))
+	} else if s, ok := module.(getGenerateCommonInterface); ok {
+		gc := s.getGenerateCommon()
+		m.TransitiveSrcs = utils.AppendUnique(m.TransitiveSrcs, gc.Properties.Tools)
+		m.TransitiveSrcs = utils.AppendUnique(m.TransitiveSrcs, gc.Properties.Srcs)
+	}
+}
+
+// Collects information about targets.
+//
+// Currently collects `srcs` and deps.
+func metaDataCollector(mctx blueprint.BottomUpMutatorContext) {
+	// Alias/defaults are skipped to avoid polluting the file.
+	if _, ok := mctx.Module().(*alias); ok {
+		return
+	} else if _, ok := mctx.Module().(*defaults); ok {
+		return
+	}
+
+	meta := ModuleMeta{}
+	meta.extractSrcs(mctx.Module())
+
+	mctx.WalkDeps(func(dep, parent blueprint.Module) bool {
+		meta.TransitiveDeps = utils.AppendIfUnique(meta.TransitiveDeps, dep.Name())
+		meta.extractSrcs(dep)
+		return true
+	})
+
+	metaDataLock.Lock()
+	defer metaDataLock.Unlock()
+	metaData[mctx.ModuleName()] = meta
+}
+
+// Writes the metadata to specified file if the path is set.
+func MetaDataWriteToFile(file string) {
+	if file == "" {
+		return
+	}
+
+	bytes, err := json.Marshal(metaData)
+	if err != nil {
+		utils.Die("error converting to JSON from: '%v' error: %v", metaData, err)
+	}
+
+	err = ioutil.WriteFile(file, bytes, 0644)
+	if err != nil {
+		utils.Die("error writing to '%s' file: %v", file, err)
+	}
+}

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -40,6 +40,7 @@ var (
 	srcdir          = os.Getenv("SRCDIR")
 	configJSONFile  = os.Getenv("CONFIG_JSON")
 	logWarningsFile = os.Getenv("BOB_LOG_WARNINGS_FILE")
+	buildMetaFile   = os.Getenv("BOB_META_FILE")
 )
 
 type moduleBase struct {
@@ -190,6 +191,7 @@ func Main() {
 	ctx.RegisterBottomUpMutator("generated", generatedDependerMutator).Parallel()
 	ctx.RegisterBottomUpMutator("filegroup_deps1", prepFilegroupMapMutator).Parallel()
 	ctx.RegisterBottomUpMutator("filegroup_deps2", propogateFilegroupData).Parallel()
+	ctx.RegisterBottomUpMutator("collect_metadata", metaDataCollector).Parallel()
 
 	if handler := initGrapvizHandler(); handler != nil {
 		ctx.RegisterBottomUpMutator("graphviz_output", handler.graphvizMutator)
@@ -241,6 +243,8 @@ func Main() {
 			utils.Die("%d error(s) ocurred!\n\n%s\n", errCnt, logger.InfoMessage())
 		}
 	}()
+
+	defer MetaDataWriteToFile(buildMetaFile)
 
 	if builder_ninja {
 		config.Generator = &linuxGenerator{logger: logger}

--- a/tests/bootstrap_linux
+++ b/tests/bootstrap_linux
@@ -83,6 +83,7 @@ export SRCDIR="${SCRIPT_DIR}"
 export BUILDDIR
 export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 export BOB_LOG_WARNINGS_FILE="${BUILDDIR}/.bob.warnings.csv"
+export BOB_META_FILE="${BUILDDIR}/.bob.meta.json"
 export BOB_LOG_WARNINGS="DeprecatedFilegroupSrcs:W"
 
 "${SCRIPT_DIR}/bob/bootstrap_linux.bash"


### PR DESCRIPTION
When the env variable `BOB_META_FILE` is set
to a path, Bob will write the metadata JSON
file to that path.

Currently only sources and dependancies are
supported. These are __transitive__, meaning
every target will contain a list of __all__
sources required to build it.

Change-Id: Ieaf287f454ee2b1c0b9e50b65ce21ee15507467b