### PR TITLE
fix: correct `select()` for features

### DIFF
--- a/gazelle/tests/generate_filegroup/BUILD.out
+++ b/gazelle/tests/generate_filegroup/BUILD.out
@@ -14,7 +14,13 @@ filegroup(
     name = "greet_srcs",
     srcs = glob(["srcs/*.c"]) + select({
         ":feature_a": [
-            "internal/secure.c",
+            "internal/file1.c",
         ],
+        "//conditions:default": [],
+    }) + select({
+        ":feature_b": [
+            "internal/file2.c",
+        ],
+        "//conditions:default": [],
     }),
 )

--- a/gazelle/tests/generate_filegroup/Mconfig
+++ b/gazelle/tests/generate_filegroup/Mconfig
@@ -2,6 +2,10 @@ config FEATURE_A
     bool "Enable Feature A"
     default n
 
+config FEATURE_B
+    bool "Enable Feature B"
+    default y
+
 config OPTION_B
     string "Set Option B"
     default "--secret"

--- a/gazelle/tests/generate_filegroup/build.bp
+++ b/gazelle/tests/generate_filegroup/build.bp
@@ -5,7 +5,12 @@ bob_filegroup {
     srcs: ["srcs/*.c"],
     feature_a: {
         srcs: [
-            "internal/secure.c",
+            "internal/file1.c",
+        ],
+    },
+    feature_b: {
+        srcs: [
+            "internal/file2.c",
         ],
     },
 }


### PR DESCRIPTION
Module features should stand as separate `select()` statements to not exclude themself.

Split feature attributes from default attributes

This helps to differentiate modules attributes from its features and allows better control while generating Bazel rules.

Handle sorted features to preserve generation order.

Change-Id: Ib4342945e4a2501af5e6c13f6e081871e08d1513