### PR TITLE
chore: fix test sizes for bazel unit tests

### DIFF
--- a/config_system/tests/BUILD.bazel
+++ b/config_system/tests/BUILD.bazel
@@ -3,6 +3,7 @@ load("@config_deps//:requirements.bzl", "requirement")
 [
     py_test(
         name = test,
+        size = "small",
         srcs = [
             "{}.py".format(test),
         ],
@@ -22,6 +23,7 @@ load("@config_deps//:requirements.bzl", "requirement")
 
 py_test(
     name = "test_get_configs_gazelle",
+    size = "small",
     srcs = [
         "test_get_configs_gazelle.py",
     ],
@@ -37,6 +39,7 @@ py_test(
 
 py_test(
     name = "test_update_config",
+    size = "small",
     srcs = [
         "test_update_config.py",
     ],
@@ -52,6 +55,7 @@ py_test(
 
 py_test(
     name = "run_tests_formatter",
+    size = "small",
     srcs = [
         "run_tests_formatter.py",
     ],
@@ -64,6 +68,7 @@ py_test(
 
 py_test(
     name = "run_tests",
+    size = "small",
     srcs = [
         "run_tests.py",
     ],

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -80,6 +80,7 @@ go_library(
 
 go_test(
     name = "core_test",
+    size = "small",
     srcs = [
         "android_test.go",
         "androidbp_test.go",

--- a/gendiffer/gendiffer.bzl
+++ b/gendiffer/gendiffer.bzl
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
-def bob_generation_test(name, bob_binary, test_data, bob_timeout_seconds = 60, size = None, **kwargs):
+def bob_generation_test(name, bob_binary, test_data, bob_timeout_seconds = 60, size = "small", **kwargs):
     [
         go_test(
             name = name + "_" + backend,

--- a/internal/depmap/BUILD.bazel
+++ b/internal/depmap/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
 
 go_test(
     name = "depmap_test",
+    size = "small",
     srcs = ["depmap_test.go"],
     embed = [":depmap"],
     deps = ["@com_github_stretchr_testify//assert"],

--- a/internal/escape/BUILD.bazel
+++ b/internal/escape/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
 
 go_test(
     name = "escape_test",
+    size = "small",
     srcs = ["escape_test.go"],
     embed = [":escape"],
     deps = ["@com_github_stretchr_testify//assert"],

--- a/internal/graph/BUILD.bazel
+++ b/internal/graph/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
 
 go_test(
     name = "graph_test",
+    size = "small",
     srcs = ["graph_test.go"],
     embed = [":graph"],
     deps = [

--- a/internal/utils/BUILD.bazel
+++ b/internal/utils/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
 
 go_test(
     name = "utils_test",
+    size = "small",
     srcs = ["utils_test.go"],
     embed = [":utils"],
     deps = ["@com_github_stretchr_testify//assert"],

--- a/internal/warnings/BUILD.bazel
+++ b/internal/warnings/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
 
 go_test(
     name = "warnings_test",
+    size = "small",
     srcs = ["warnings_test.go"],
     embed = [":warnings"],
     deps = ["@com_github_stretchr_testify//assert"],


### PR DESCRIPTION
Most unit tests should be 'small', this translates to 20MB of RAM and and 'short' timeout (1 minute).

Bazel makes use of these attributes to load balance the tests on the machine.

Change-Id: I9bd0a9cc7b15015af10fb3806fe9e9116b0c6c5f