### PR TITLE
chore: add exclude_srcs coverage for new gensrc

### DIFF
--- a/tests/gendiffer/gensrcs_new/app/build.bp
+++ b/tests/gendiffer/gensrcs_new/app/build.bp
@@ -234,3 +234,18 @@ bob_genrule {
     tool_files: ["generator.py"],
     cmd: "python $(location generator.py) --in $(in) --out $(out) --expect-in before_generate.in $(location :generate_source_single_new)",
 }
+
+bob_genrule {
+    name: "exclude_support",
+    srcs: [
+        "input1.in",
+        "input2.in",
+        "input3.in",
+    ],
+    exclude_srcs: ["input2.in"],
+    out: [
+        "input1.out",
+        "input3.out",
+    ],
+    cmd: "touch $(out)",
+}

--- a/tests/gendiffer/gensrcs_new/out/android/Android.bp.out
+++ b/tests/gendiffer/gensrcs_new/out/android/Android.bp.out
@@ -2,6 +2,21 @@
 
 
 genrule {
+    name: "exclude_support",
+    srcs: [
+        "input1.in",
+        "input2.in",
+        "input3.in",
+    ],
+    exclude_srcs: ["input2.in"],
+    cmd: "touch $(out)",
+    out: [
+        "input1.out",
+        "input3.out",
+    ],
+}
+
+genrule {
     name: "gen_source_depfile_new",
     srcs: [
         "depgen1.in",

--- a/tests/gendiffer/gensrcs_new/out/linux/build.ninja.out
+++ b/tests/gendiffer/gensrcs_new/out/linux/build.ninja.out
@@ -54,6 +54,27 @@ rule g.bootstrap.cp
     description = cp ${out}
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Module:  exclude_support
+# Variant:
+# Type:    bob_genrule
+# Factory: github.com/ARM-software/bob-build/core.Main.func1.1
+# Defined: build.bp:238:1
+
+rule m.exclude_support_.gen_exclude_support
+    command = touch ${_out_}
+    description = ${out}
+    restat = true
+
+build ${g.bob.BuildDir}/gen/exclude_support/input1.out $
+        ${g.bob.BuildDir}/gen/exclude_support/input3.out: $
+        m.exclude_support_.gen_exclude_support ${g.bob.SrcDir}/input1.in $
+        ${g.bob.SrcDir}/input3.in
+    _out_ = ${g.bob.BuildDir}/gen/exclude_support/input1.out ${g.bob.BuildDir}/gen/exclude_support/input3.out
+
+build exclude_support: phony ${g.bob.BuildDir}/gen/exclude_support/input1.out $
+        ${g.bob.BuildDir}/gen/exclude_support/input3.out
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Module:  gen_source_depfile_new
 # Variant:
 # Type:    bob_genrule


### PR DESCRIPTION
This commit adds a generation diff test for the
`exclude_srcs` attribute for the `bob_genrule` type.

Change-Id: Idb4ff40a89af0b00b861dee1789d9d8c08e71276