### PR TITLE
fix(gendiffer): update regex to match longer entries

### DIFF
--- a/gendiffer/gendiffer.go
+++ b/gendiffer/gendiffer.go
@@ -155,7 +155,7 @@ func getFileContents(t *testing.T, filename string) string {
 
 func redactWorkspacePath(s, wsPath string) string {
 	// We must cleanup a specific Android.bp target that is unique to each generation. It is non-hermetic.
-	re := regexp.MustCompile("genrule {\n.*_check_buildbp_updates.*\n.*\n.*\n.*\n.*\n.*")
+	re := regexp.MustCompile("genrule {\n.*_check_buildbp_updates[^}]*}")
 	res := re.ReplaceAllString(s, "")
 	return strings.ReplaceAll(res, wsPath, "%WORKSPACEPATH%")
 }

--- a/tests/gendiffer/genlib/out/android/Android.bp.out
+++ b/tests/gendiffer/genlib/out/android/Android.bp.out
@@ -1,6 +1,3 @@
 
 
-    tool_files: ["scripts/verify_hash.py"],
-    cmd: "python $(location scripts/verify_hash.py) --hash 9184b3ceeee6993813b94dd264c203b75412fc2b --out $(out) -- $(in)",
-}
 

--- a/tests/gendiffer/gensrcs/out/android/Android.bp.out
+++ b/tests/gendiffer/gensrcs/out/android/Android.bp.out
@@ -1,8 +1,5 @@
 
 
-    tool_files: ["scripts/verify_hash.py"],
-    cmd: "python $(location scripts/verify_hash.py) --hash 910f0726ba7231a4c08366477c4af0eea976c49b --out $(out) -- $(in)",
-}
 
 genrule_bob {
     name: "gen_source_depfile",

--- a/tests/gendiffer/gensrcs_new/out/android/Android.bp.out
+++ b/tests/gendiffer/gensrcs_new/out/android/Android.bp.out
@@ -1,8 +1,5 @@
 
 
-    tool_files: ["scripts/verify_hash.py"],
-    cmd: "python $(location scripts/verify_hash.py) --hash b0056baba0a40b11e47c2e959fc2c310be94dc5a --out $(out) -- $(in)",
-}
 
 genrule {
     name: "exclude_support",

--- a/tests/gendiffer/transformsrcs/out/android/Android.bp.out
+++ b/tests/gendiffer/transformsrcs/out/android/Android.bp.out
@@ -1,8 +1,5 @@
 
 
-    tool_files: ["scripts/verify_hash.py"],
-    cmd: "python $(location scripts/verify_hash.py) --hash e76ad65d53ec20b25be85feea6ae705ab9088eb4 --out $(out) -- $(in)",
-}
 
 genrule_bob {
     name: "combine_sources",


### PR DESCRIPTION
When using nested workspaces the current regex
fails to match the update rule with expanded `srcs`. This commit fixes this and updates broken Android
files in gendiff.

Change-Id: I0d52df435197a22df402ad1ae8a6d8eb46c26dc5