### PR TITLE
fix: correct attributes order

### DIFF
--- a/gazelle/generator.go
+++ b/gazelle/generator.go
@@ -77,6 +77,15 @@ func (s *GlobValue) BzlExpr() bzl.Expr {
 	patternsValue := rule.ExprFromValue(s.Patterns)
 	globArgs := []bzl.Expr{patternsValue}
 
+	if s.AllowEmpty != nil {
+		allowEmptyValue := rule.ExprFromValue(*s.AllowEmpty)
+		globArgs = append(globArgs, &bzl.AssignExpr{
+			LHS: &bzl.LiteralExpr{Token: "allow_empty"},
+			Op:  "=",
+			RHS: allowEmptyValue,
+		})
+	}
+
 	if len(s.Excludes) > 0 {
 		excludesValue := rule.ExprFromValue(s.Excludes)
 		globArgs = append(globArgs, &bzl.AssignExpr{
@@ -96,15 +105,6 @@ func (s *GlobValue) BzlExpr() bzl.Expr {
 			LHS: &bzl.LiteralExpr{Token: "exclude_directories"},
 			Op:  "=",
 			RHS: excludeDirValue,
-		})
-	}
-
-	if s.AllowEmpty != nil {
-		allowEmptyValue := rule.ExprFromValue(*s.AllowEmpty)
-		globArgs = append(globArgs, &bzl.AssignExpr{
-			LHS: &bzl.LiteralExpr{Token: "allow_empty"},
-			Op:  "=",
-			RHS: allowEmptyValue,
 		})
 	}
 

--- a/gazelle/tests/generate_filegroup/BUILD.out
+++ b/gazelle/tests/generate_filegroup/BUILD.out
@@ -62,8 +62,8 @@ filegroup(
     name = "glob_lib_srcs",
     srcs = glob(
         ["lib/**/*.c"],
+        allow_empty = False,
         exclude = ["lib/**/exclude_*.cpp"],
         exclude_directories = 1,
-        allow_empty = False,
     ),
 )

--- a/gazelle/tests/preserve_order/BUILD.out
+++ b/gazelle/tests/preserve_order/BUILD.out
@@ -32,8 +32,8 @@ filegroup(
     name = "glob_102_1",
     srcs = glob(
         ["lib/**/*_102_1.c"],
-        exclude_directories = 1,
         allow_empty = True,
+        exclude_directories = 1,
     ),
 )
 
@@ -69,9 +69,9 @@ filegroup(
     name = "glob_lib_107",
     srcs = glob(
         ["lib/**/*_107.c"],
+        allow_empty = True,
         exclude = ["lib/**/exclude_*_107.cpp"],
         exclude_directories = 1,
-        allow_empty = True,
     ),
 )
 
@@ -79,9 +79,9 @@ filegroup(
     name = "glob_lib_108",
     srcs = glob(
         ["lib/**/*_108.c"],
+        allow_empty = True,
         exclude = ["lib/**/exclude_*_108.cpp"],
         exclude_directories = 1,
-        allow_empty = True,
     ),
 )
 
@@ -89,9 +89,9 @@ filegroup(
     name = "glob_lib_109",
     srcs = glob(
         ["lib/**/*_109.c"],
+        allow_empty = True,
         exclude = ["lib/**/exclude_*_109.cpp"],
         exclude_directories = 1,
-        allow_empty = True,
     ),
 )
 
@@ -99,9 +99,9 @@ filegroup(
     name = "glob_lib_110",
     srcs = glob(
         ["lib/**/*_110.c"],
+        allow_empty = True,
         exclude = ["lib/**/exclude_*_110.cpp"],
         exclude_directories = 1,
-        allow_empty = True,
     ),
 )
 
@@ -109,9 +109,9 @@ filegroup(
     name = "glob_lib_111",
     srcs = glob(
         ["lib/**/*_111.c"],
+        allow_empty = True,
         exclude = ["lib/**/exclude_*_111.cpp"],
         exclude_directories = 1,
-        allow_empty = True,
     ),
 )
 
@@ -119,8 +119,8 @@ filegroup(
     name = "glob_lib_112",
     srcs = glob(
         ["lib/**/*_112.c"],
+        allow_empty = True,
         exclude = ["lib/**/exclude_*_112.cpp"],
         exclude_directories = 1,
-        allow_empty = True,
     ),
 )

--- a/gazelle/tests/preserve_order/internal/BUILD.out
+++ b/gazelle/tests/preserve_order/internal/BUILD.out
@@ -44,8 +44,8 @@ filegroup(
     name = "glob_204_1",
     srcs = glob(
         ["lib/**/*_204_1.c"],
-        exclude_directories = 1,
         allow_empty = True,
+        exclude_directories = 1,
     ),
 )
 
@@ -67,9 +67,9 @@ filegroup(
     name = "glob_lib_207",
     srcs = glob(
         ["lib/**/*_207.c"],
+        allow_empty = True,
         exclude = ["lib/**/exclude_*_207.cpp"],
         exclude_directories = 1,
-        allow_empty = True,
     ),
 )
 
@@ -77,9 +77,9 @@ filegroup(
     name = "glob_lib_208",
     srcs = glob(
         ["lib/**/*_208.c"],
+        allow_empty = True,
         exclude = ["lib/**/exclude_*_208.cpp"],
         exclude_directories = 1,
-        allow_empty = True,
     ),
 )
 
@@ -87,9 +87,9 @@ filegroup(
     name = "glob_lib_209",
     srcs = glob(
         ["lib/**/*_209.c"],
+        allow_empty = True,
         exclude = ["lib/**/exclude_*_209.cpp"],
         exclude_directories = 1,
-        allow_empty = True,
     ),
 )
 
@@ -97,9 +97,9 @@ filegroup(
     name = "glob_lib_210",
     srcs = glob(
         ["lib/**/*_210.c"],
+        allow_empty = True,
         exclude = ["lib/**/exclude_*_210.cpp"],
         exclude_directories = 1,
-        allow_empty = True,
     ),
 )
 
@@ -107,9 +107,9 @@ filegroup(
     name = "glob_lib_211",
     srcs = glob(
         ["lib/**/*_211.c"],
+        allow_empty = True,
         exclude = ["lib/**/exclude_*_211.cpp"],
         exclude_directories = 1,
-        allow_empty = True,
     ),
 )
 
@@ -117,8 +117,8 @@ filegroup(
     name = "glob_lib_212",
     srcs = glob(
         ["lib/**/*_212.c"],
+        allow_empty = True,
         exclude = ["lib/**/exclude_*_212.cpp"],
         exclude_directories = 1,
-        allow_empty = True,
     ),
 )


### PR DESCRIPTION
Generated attributes for `glob` rules has to be sorted in alphabetic order cause if such rule already exists, Gazelle merge mechanism will sort them in the end, even if merged values are the same. This will prevent of reordering attributes within consecutive Gazelle run.

Change-Id: I593808627f3fe0afc1555da3589582bfb4daf53f