### PR TITLE
refactor: move `baseModule` to separate package

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -38,6 +38,7 @@ bootstrap_go_package {
         "bob-utils",
         "bob-warnings",
         "bob-depmap",
+        "bob-module",
     ],
     srcs: [
         "core/alias.go",
@@ -195,4 +196,15 @@ bootstrap_go_package {
         "internal/warnings/warnings_test.go",
     ],
     pkgPath: "github.com/ARM-software/bob-build/internal/warnings",
+}
+
+bootstrap_go_package {
+    name: "bob-module",
+    srcs: [
+        "core/module/module.go",
+    ],
+    deps: [
+        "blueprint",
+    ],
+    pkgPath: "github.com/ARM-software/bob-build/core/module",
 }

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -65,6 +65,7 @@ go_library(
     importpath = "github.com/ARM-software/bob-build/core",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/module",
         "//internal/bpwriter",
         "//internal/ccflags",
         "//internal/depmap",

--- a/core/alias.go
+++ b/core/alias.go
@@ -18,6 +18,8 @@
 package core
 
 import (
+	"github.com/ARM-software/bob-build/core/module"
+
 	"github.com/google/blueprint"
 )
 
@@ -46,7 +48,7 @@ type AliasProps struct {
 
 // Type representing each bob_alias module
 type ModuleAlias struct {
-	moduleBase
+	module.ModuleBase
 	Properties struct {
 		AliasProps
 		Features

--- a/core/defaults.go
+++ b/core/defaults.go
@@ -20,14 +20,15 @@ package core
 import (
 	"sync"
 
-	"github.com/google/blueprint"
-
+	"github.com/ARM-software/bob-build/core/module"
 	"github.com/ARM-software/bob-build/internal/utils"
 	"github.com/ARM-software/bob-build/internal/warnings"
+
+	"github.com/google/blueprint"
 )
 
 type ModuleDefaults struct {
-	moduleBase
+	module.ModuleBase
 
 	Properties struct {
 		Features

--- a/core/external_library.go
+++ b/core/external_library.go
@@ -18,6 +18,8 @@
 package core
 
 import (
+	"github.com/ARM-software/bob-build/core/module"
+
 	"github.com/google/blueprint"
 )
 
@@ -30,7 +32,7 @@ type ExternalLibProps struct {
 }
 
 type ModuleExternalLibrary struct {
-	moduleBase
+	module.ModuleBase
 	Properties struct {
 		ExternalLibProps
 		Features

--- a/core/filegroup.go
+++ b/core/filegroup.go
@@ -18,11 +18,13 @@
 package core
 
 import (
+	"github.com/ARM-software/bob-build/core/module"
+
 	"github.com/google/blueprint"
 )
 
 type ModuleFilegroup struct {
-	moduleBase
+	module.ModuleBase
 	Properties struct {
 		SourceProps
 		Features

--- a/core/generated_common.go
+++ b/core/generated_common.go
@@ -23,7 +23,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ARM-software/bob-build/core/module"
 	"github.com/ARM-software/bob-build/internal/utils"
+
 	"github.com/google/blueprint"
 	"github.com/google/blueprint/proptools"
 )
@@ -77,7 +79,7 @@ func splitGeneratedComponent(comp string) (module string, lib string) {
 }
 
 type ModuleGenerateCommon struct {
-	moduleBase
+	module.ModuleBase
 	simpleOutputProducer
 	headerProducer
 	Properties struct {

--- a/core/glob.go
+++ b/core/glob.go
@@ -21,8 +21,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ARM-software/bob-build/core/module"
 	"github.com/ARM-software/bob-build/internal/utils"
 	"github.com/ARM-software/bob-build/internal/warnings"
+
 	"github.com/google/blueprint"
 )
 
@@ -44,7 +46,7 @@ type GlobProps struct {
 }
 
 type ModuleGlob struct {
-	moduleBase
+	module.ModuleBase
 	Properties struct {
 		GlobProps
 	}

--- a/core/install.go
+++ b/core/install.go
@@ -20,9 +20,10 @@ package core
 import (
 	"path/filepath"
 
-	"github.com/google/blueprint"
-
+	"github.com/ARM-software/bob-build/core/module"
 	"github.com/ARM-software/bob-build/internal/utils"
+
+	"github.com/google/blueprint"
 )
 
 // EnableableProps allow a module to be disabled or only built when explicitly requested
@@ -155,7 +156,7 @@ type InstallGroupProps struct {
 }
 
 type ModuleInstallGroup struct {
-	moduleBase
+	module.ModuleBase
 	Properties struct {
 		InstallGroupProps
 		Features
@@ -196,7 +197,7 @@ type ResourceProps struct {
 }
 
 type ModuleResource struct {
-	moduleBase
+	module.ModuleBase
 	Properties struct {
 		ResourceProps
 		Features

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -21,10 +21,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ARM-software/bob-build/core/module"
+	"github.com/ARM-software/bob-build/internal/utils"
+
 	"github.com/google/blueprint"
 	"github.com/google/blueprint/proptools"
-
-	"github.com/ARM-software/bob-build/internal/utils"
 )
 
 type KernelProps struct {
@@ -61,7 +62,7 @@ func (k *KernelProps) processPaths(ctx blueprint.BaseModuleContext) {
 }
 
 type ModuleKernelObject struct {
-	moduleBase
+	module.ModuleBase
 	simpleOutputProducer
 	Properties struct {
 		Features

--- a/core/library.go
+++ b/core/library.go
@@ -23,16 +23,17 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/google/blueprint"
-
+	"github.com/ARM-software/bob-build/core/module"
 	"github.com/ARM-software/bob-build/internal/utils"
+
+	"github.com/google/blueprint"
 )
 
 var depOutputsVarRegexp = regexp.MustCompile(`^\$\{(.+)_out\}$`)
 
 // ModuleLibrary is a base class for modules which are generated from sets of object files
 type ModuleLibrary struct {
-	moduleBase
+	module.ModuleBase
 	simpleOutputProducer
 
 	Properties struct {

--- a/core/module/BUILD.bazel
+++ b/core/module/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "module",
+    srcs = [
+        "module.go",
+    ],
+    importpath = "github.com/ARM-software/bob-build/core/module",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_google_blueprint//:blueprint",
+    ],
+)

--- a/core/module/module.go
+++ b/core/module/module.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Arm Limited.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package module
+
+import (
+	"github.com/google/blueprint"
+)
+
+type ModuleBase struct {
+	blueprint.SimpleName
+}

--- a/core/module_genrule.go
+++ b/core/module_genrule.go
@@ -20,7 +20,9 @@ package core
 import (
 	"strings"
 
+	"github.com/ARM-software/bob-build/core/module"
 	"github.com/ARM-software/bob-build/internal/utils"
+
 	"github.com/google/blueprint"
 )
 
@@ -114,7 +116,7 @@ func (ag *AndroidGenerateCommonProps) GetSrcs(ctx blueprint.BaseModuleContext) F
 }
 
 type ModuleGenruleCommon struct {
-	moduleBase
+	module.ModuleBase
 	EnableableProps
 	simpleOutputProducer
 	headerProducer

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -43,10 +43,6 @@ var (
 	buildMetaFile   = os.Getenv("BOB_META_FILE")
 )
 
-type moduleBase struct {
-	blueprint.SimpleName
-}
-
 type PropertyProvider interface {
 	GetProperties() interface{}
 }

--- a/core/strict_library.go
+++ b/core/strict_library.go
@@ -21,7 +21,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ARM-software/bob-build/core/module"
 	"github.com/ARM-software/bob-build/internal/utils"
+
 	"github.com/google/blueprint"
 )
 
@@ -53,7 +55,7 @@ type StrictLibraryProps struct {
 }
 
 type ModuleStrictLibrary struct {
-	moduleBase
+	module.ModuleBase
 	simpleOutputProducer // band-aid so legacy don't complain the interface isn't implemented
 	Properties           struct {
 		StrictLibraryProps


### PR DESCRIPTION
Clean up Bob codebase conventions.

All `Module*` structs should be moved to new/separate `module` package.
This change starts the transition.


Change-Id: Icccab3c8f95fb09092b28bc686f9f29a6035f3ce