### PR TITLE
fix: correct versioned shared library symlinks order

### DIFF
--- a/core/linux_backend.go
+++ b/core/linux_backend.go
@@ -20,6 +20,8 @@ package core
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/google/blueprint"
@@ -332,8 +334,18 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 	if symlinkIns, ok := m.(symlinkInstaller); ok {
 		symlinks := symlinkIns.librarySymlinks(ctx)
 
-		for key, value := range symlinks {
-			symlink := filepath.Join(installPath, key)
+		symlinkKeys := make([]string, len(symlinks))
+		keys := reflect.ValueOf(symlinks).MapKeys()
+
+		for i, k := range keys {
+			symlinkKeys[i] = k.String()
+		}
+
+		sort.Strings(symlinkKeys)
+
+		for _, sym := range symlinkKeys {
+			value := symlinks[sym]
+			symlink := filepath.Join(installPath, sym)
 			symlinkTgt := filepath.Join(installPath, value)
 			ctx.Build(pctx,
 				blueprint.BuildParams{

--- a/core/linux_cclibs.go
+++ b/core/linux_cclibs.go
@@ -20,7 +20,9 @@ package core
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -523,9 +525,22 @@ func (g *linuxGenerator) sharedActions(m *ModuleSharedLibrary, ctx blueprint.Mod
 
 	installDeps := g.install(m, ctx)
 
+	// Sort symlinks
+	symlinks := m.librarySymlinks(ctx)
+	symlinkKeys := make([]string, len(symlinks))
+	keys := reflect.ValueOf(symlinks).MapKeys()
+
+	for i, k := range keys {
+		symlinkKeys[i] = k.String()
+	}
+
+	sort.Strings(symlinkKeys)
+
 	// Create symlinks if needed
-	for name, symlinkTgt := range m.librarySymlinks(ctx) {
+	for _, name := range symlinkKeys {
+		symlinkTgt := symlinks[name]
 		symlink := filepath.Join(m.outputDir(), name)
+
 		lib := filepath.Join(m.outputDir(), symlinkTgt)
 		ctx.Build(pctx,
 			blueprint.BuildParams{

--- a/tests/gendiffer/libraries/app/build.bp
+++ b/tests/gendiffer/libraries/app/build.bp
@@ -41,6 +41,7 @@ bob_shared_library {
     cflags: ["-fPIC"],
     host_supported: true,
     target_supported: true,
+    library_version: "1.2.1",
 }
 
 bob_binary {

--- a/tests/gendiffer/libraries/out/linux/build.ninja.out
+++ b/tests/gendiffer/libraries/out/linux/build.ninja.out
@@ -75,6 +75,10 @@ rule g.bob.strip
     command = ${g.bob.strip} ${args} -o ${out} ${in}
     description = strip ${out}
 
+rule g.bob.symlink
+    command = for i in ${out}; do ln -nsf ${target} $$i; done;
+    description = ${out}
+
 rule g.bob.whole_static_library
     command = ${g.bob.whole_static_tool} --build-wrapper "${build_wrapper}" --ar ${ar} --out ${out} ${in} ${whole_static_libs}
     description = ${out}
@@ -88,7 +92,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:469:1
+# Defined: build.bp:470:1
 
 m.bob_test_local_consumer_target.cflags = -Wconversion -Werror -isystem ${g.bob.SrcDir}/public
 m.bob_test_local_consumer_target.conlyflags = 
@@ -122,7 +126,7 @@ default bob_test_local_consumer
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:459:1
+# Defined: build.bp:460:1
 
 m.bob_test_local_libconsumer_target.cflags = -Wconversion -Werror -isystem ${g.bob.SrcDir}/public
 m.bob_test_local_libconsumer_target.conlyflags = 
@@ -152,7 +156,7 @@ build bob_test_local_libconsumer: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:440:1
+# Defined: build.bp:441:1
 
 m.bob_test_local_libpublic_target.cflags = -Wconversion -I${g.bob.SrcDir}/include -I${g.bob.SrcDir}/public
 m.bob_test_local_libpublic_target.conlyflags = 
@@ -179,7 +183,7 @@ build bob_test_local_libpublic: phony $
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:502:1
+# Defined: build.bp:503:1
 
 m.bob_test_target_specific_link_host.cflags = 
 m.bob_test_target_specific_link_host.conlyflags = 
@@ -212,7 +216,7 @@ default bob_test_target_specific_link__host
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:502:1
+# Defined: build.bp:503:1
 
 m.bob_test_target_specific_link_target.cflags = 
 m.bob_test_target_specific_link_target.conlyflags = 
@@ -246,7 +250,7 @@ default bob_test_target_specific_link__target
 # Variant: host
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:56:1
+# Defined: build.bp:57:1
 
 rule m.gen_output_host.gen_gen_output
     command = LD_LIBRARY_PATH=${g.bob.BuildDir}/host/shared:$$LD_LIBRARY_PATH ${tool} -u ${host_bin} -i ${in} -o ${_out_}
@@ -256,7 +260,7 @@ rule m.gen_output_host.gen_gen_output
 build ${g.bob.BuildDir}/gen/gen_output/input_one.gen: $
         m.gen_output_host.gen_gen_output ${g.bob.SrcDir}/input/input_one.in | $
         ${g.bob.BuildDir}/host/executable/utility $
-        ${g.bob.BuildDir}/host/shared/libsharedtest.so $
+        ${g.bob.BuildDir}/host/shared/libsharedtest.so.1.2.1 $
         ${g.bob.SrcDir}/transform.py
     _out_ = ${g.bob.BuildDir}/gen/gen_output/input_one.gen
     host_bin = ${g.bob.BuildDir}/host/executable/utility
@@ -265,7 +269,7 @@ build ${g.bob.BuildDir}/gen/gen_output/input_one.gen: $
 build ${g.bob.BuildDir}/gen/gen_output/input_two.gen: $
         m.gen_output_host.gen_gen_output ${g.bob.SrcDir}/input/input_two.in | $
         ${g.bob.BuildDir}/host/executable/utility $
-        ${g.bob.BuildDir}/host/shared/libsharedtest.so $
+        ${g.bob.BuildDir}/host/shared/libsharedtest.so.1.2.1 $
         ${g.bob.SrcDir}/transform.py
     _out_ = ${g.bob.BuildDir}/gen/gen_output/input_two.gen
     host_bin = ${g.bob.BuildDir}/host/executable/utility
@@ -279,7 +283,7 @@ build gen_output: phony ${g.bob.BuildDir}/gen/gen_output/input_one.gen $
 # Variant: host
 # Type:    bob_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:414:1
+# Defined: build.bp:415:1
 
 build ${g.bob.BuildDir}/host/objects/lib_dep/lib_dep.a: g.bob.static_library $
         || $
@@ -294,7 +298,7 @@ default lib_dep.a
 # Variant: host
 # Type:    bob_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:406:1
+# Defined: build.bp:407:1
 
 m.lib_forward_defines_host.cflags = -DLOCAL_DEFINE -DFORWARDED_DEFINE
 m.lib_forward_defines_host.cxxflags = 
@@ -319,7 +323,7 @@ default lib_forward_defines.a
 # Variant: host
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:389:1
+# Defined: build.bp:390:1
 
 build ${g.bob.BuildDir}/host/static/lib_transitive_define.a: $
         g.bob.static_library
@@ -335,7 +339,7 @@ default lib_transitive_define
 # Variant: host
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:479:1
+# Defined: build.bp:480:1
 
 m.libonly_works_on_target_host.cflags = -DFAIL=1
 m.libonly_works_on_target_host.conlyflags = 
@@ -362,7 +366,7 @@ build libonly_works_on_target__host: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:479:1
+# Defined: build.bp:480:1
 
 m.libonly_works_on_target_target.cflags = -DFAIL=0
 m.libonly_works_on_target_target.conlyflags = 
@@ -401,23 +405,34 @@ build ${g.bob.BuildDir}/host/objects/libsharedtest/srcs/lib.c.o: g.bob.cc $
     cflags = ${m.libsharedtest_host.cflags}
     conlyflags = ${m.libsharedtest_host.conlyflags}
 
-build ${g.bob.BuildDir}/host/shared/libsharedtest.so: g.bob.shared_library $
+build ${g.bob.BuildDir}/host/shared/libsharedtest.so: g.bob.symlink $
+        ${g.bob.BuildDir}/host/shared/libsharedtest.so.1
+    target = libsharedtest.so.1
+
+build ${g.bob.BuildDir}/host/shared/libsharedtest.so.1: g.bob.symlink $
+        ${g.bob.BuildDir}/host/shared/libsharedtest.so.1.2.1
+    target = libsharedtest.so.1.2.1
+
+build ${g.bob.BuildDir}/host/shared/libsharedtest.so.1.2.1: $
+        g.bob.shared_library $
         ${g.bob.BuildDir}/host/objects/libsharedtest/srcs/lib.c.o
     build_wrapper = 
-    ldflags = -Wl,--as-needed 
+    ldflags = -Wl,--as-needed -Wl,-soname,libsharedtest.so.1
     ldlibs = 
     linker = g++
     shared_libs_dir = ${g.bob.BuildDir}/host/shared
     shared_libs_flags = -Wl,-rpath-link,${g.bob.BuildDir}/host/shared
     static_libs = 
 
-build ${g.bob.BuildDir}/host/shared/libsharedtest.so.toc: $
+build ${g.bob.BuildDir}/host/shared/libsharedtest.so.1.2.1.toc: $
         g.bob.shared_library_toc $
-        ${g.bob.BuildDir}/host/shared/libsharedtest.so | ${g.bob.toc}
+        ${g.bob.BuildDir}/host/shared/libsharedtest.so.1.2.1 | ${g.bob.toc}
     tocflags = --format elf --objdump-tool objdump
 
 build libsharedtest__host: phony $
-        ${g.bob.BuildDir}/host/shared/libsharedtest.so
+        ${g.bob.BuildDir}/host/shared/libsharedtest.so $
+        ${g.bob.BuildDir}/host/shared/libsharedtest.so.1 $
+        ${g.bob.BuildDir}/host/shared/libsharedtest.so.1.2.1
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Module:  libsharedtest
@@ -436,30 +451,41 @@ build ${g.bob.BuildDir}/target/objects/libsharedtest/srcs/lib.c.o: g.bob.cc $
     cflags = ${m.libsharedtest_target.cflags}
     conlyflags = ${m.libsharedtest_target.conlyflags}
 
-build ${g.bob.BuildDir}/target/shared/libsharedtest.so: g.bob.shared_library $
+build ${g.bob.BuildDir}/target/shared/libsharedtest.so: g.bob.symlink $
+        ${g.bob.BuildDir}/target/shared/libsharedtest.so.1
+    target = libsharedtest.so.1
+
+build ${g.bob.BuildDir}/target/shared/libsharedtest.so.1: g.bob.symlink $
+        ${g.bob.BuildDir}/target/shared/libsharedtest.so.1.2.1
+    target = libsharedtest.so.1.2.1
+
+build ${g.bob.BuildDir}/target/shared/libsharedtest.so.1.2.1: $
+        g.bob.shared_library $
         ${g.bob.BuildDir}/target/objects/libsharedtest/srcs/lib.c.o
     build_wrapper = 
-    ldflags = -Wl,--as-needed 
+    ldflags = -Wl,--as-needed -Wl,-soname,libsharedtest.so.1
     ldlibs = 
     linker = g++
     shared_libs_dir = ${g.bob.BuildDir}/target/shared
     shared_libs_flags = -Wl,-rpath-link,${g.bob.BuildDir}/target/shared
     static_libs = 
 
-build ${g.bob.BuildDir}/target/shared/libsharedtest.so.toc: $
+build ${g.bob.BuildDir}/target/shared/libsharedtest.so.1.2.1.toc: $
         g.bob.shared_library_toc $
-        ${g.bob.BuildDir}/target/shared/libsharedtest.so | ${g.bob.toc}
+        ${g.bob.BuildDir}/target/shared/libsharedtest.so.1.2.1 | ${g.bob.toc}
     tocflags = --format elf --objdump-tool objdump
 
 build libsharedtest__target: phony $
-        ${g.bob.BuildDir}/target/shared/libsharedtest.so
+        ${g.bob.BuildDir}/target/shared/libsharedtest.so $
+        ${g.bob.BuildDir}/target/shared/libsharedtest.so.1 $
+        ${g.bob.BuildDir}/target/shared/libsharedtest.so.1.2.1
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Module:  libsharedtest_installed
 # Variant: host
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:72:1
+# Defined: build.bp:73:1
 
 m.libsharedtest_installed_host.cflags = -DFUNC_NAME=sharedtest_installed
 m.libsharedtest_installed_host.conlyflags = 
@@ -500,7 +526,7 @@ build libsharedtest_installed__host: phony $
 # Variant: target
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:72:1
+# Defined: build.bp:73:1
 
 m.libsharedtest_installed_target.cflags = -DFUNC_NAME=sharedtest_installed
 m.libsharedtest_installed_target.conlyflags = 
@@ -541,7 +567,7 @@ build libsharedtest_installed__target: phony $
 # Variant: host
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:86:1
+# Defined: build.bp:87:1
 
 m.libsharedtest_not_installed_host.cflags = -DFUNC_NAME=sharedtest_not_installed
 m.libsharedtest_not_installed_host.conlyflags = 
@@ -578,7 +604,7 @@ build libsharedtest_not_installed__host: phony $
 # Variant: target
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:86:1
+# Defined: build.bp:87:1
 
 m.libsharedtest_not_installed_target.cflags = -DFUNC_NAME=sharedtest_not_installed
 m.libsharedtest_not_installed_target.conlyflags = 
@@ -615,7 +641,7 @@ build libsharedtest_not_installed__target: phony $
 # Variant: target
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:121:1
+# Defined: build.bp:122:1
 
 m.libstripped_library_target.cflags = -DFUNC_NAME=func
 m.libstripped_library_target.conlyflags = 
@@ -660,7 +686,7 @@ build libstripped_library: phony $
 # Variant: host
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:492:1
+# Defined: build.bp:493:1
 
 m.libuses_target_specific_link_host.cflags = 
 m.libuses_target_specific_link_host.conlyflags = 
@@ -686,7 +712,7 @@ build libuses_target_specific_link__host: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:492:1
+# Defined: build.bp:493:1
 
 m.libuses_target_specific_link_target.cflags = 
 m.libuses_target_specific_link_target.conlyflags = 
@@ -712,7 +738,7 @@ build libuses_target_specific_link__target: phony $
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:96:1
+# Defined: build.bp:97:1
 
 m.sharedtest_host.cflags = 
 m.sharedtest_host.conlyflags = 
@@ -745,7 +771,7 @@ build sharedtest__host: phony ${g.bob.BuildDir}/host/executable/sharedtest
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:96:1
+# Defined: build.bp:97:1
 
 m.sharedtest_target.cflags = 
 m.sharedtest_target.conlyflags = 
@@ -779,7 +805,7 @@ default sharedtest__target
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:173:1
+# Defined: build.bp:174:1
 
 m.sl_liba_target.cflags = -fPIC -DFOO=1
 m.sl_liba_target.conlyflags = 
@@ -803,7 +829,7 @@ build sl_liba: phony ${g.bob.BuildDir}/target/static/sl_liba.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:364:1
+# Defined: build.bp:365:1
 
 m.sl_liba_duplicates_target.cflags = -DFOO=1
 m.sl_liba_duplicates_target.conlyflags = 
@@ -837,7 +863,7 @@ build sl_liba_duplicates: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:373:1
+# Defined: build.bp:374:1
 
 build ${g.bob.BuildDir}/target/static/sl_liba_duplicates_2.a: $
         g.bob.whole_static_library | ${g.bob.whole_static_tool} $
@@ -854,7 +880,7 @@ build sl_liba_duplicates_2: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:198:1
+# Defined: build.bp:199:1
 
 m.sl_libb_target.cflags = -fPIC -DFOO=1
 m.sl_libb_target.conlyflags = 
@@ -878,7 +904,7 @@ build sl_libb: phony ${g.bob.BuildDir}/target/static/sl_libb.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:246:1
+# Defined: build.bp:247:1
 
 m.sl_libb_export_static_target.cflags = -DFOO=1
 m.sl_libb_export_static_target.conlyflags = 
@@ -904,7 +930,7 @@ build sl_libb_export_static: phony $
 # Variant: target
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:227:1
+# Defined: build.bp:228:1
 
 build ${g.bob.BuildDir}/target/shared/sl_libb_shared.so: g.bob.shared_library $
         | ${g.bob.BuildDir}/target/static/sl_libb.a $
@@ -929,7 +955,7 @@ build sl_libb_shared: phony ${g.bob.BuildDir}/target/shared/sl_libb_shared.so
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:182:1
+# Defined: build.bp:183:1
 
 m.sl_libb_whole_inclusion_target.cflags = -fPIC -DFOO=1
 m.sl_libb_whole_inclusion_target.conlyflags = 
@@ -957,7 +983,7 @@ build sl_libb_whole_inclusion: phony $
 # Variant: target
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:215:1
+# Defined: build.bp:216:1
 
 build ${g.bob.BuildDir}/target/shared/sl_libb_whole_shared.so: $
         g.bob.shared_library | $
@@ -983,7 +1009,7 @@ build sl_libb_whole_shared: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:280:1
+# Defined: build.bp:281:1
 
 m.sl_libc_target.cflags = -DFUNCTION=do_c -DCALL1=do_e1 -DCALL2=do_f
 m.sl_libc_target.conlyflags = 
@@ -1007,7 +1033,7 @@ build sl_libc: phony ${g.bob.BuildDir}/target/static/sl_libc.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:294:1
+# Defined: build.bp:295:1
 
 m.sl_libd_target.cflags = -DFUNCTION=do_d -DCALL1=do_g1 -DCALL2=do_h
 m.sl_libd_target.conlyflags = 
@@ -1031,7 +1057,7 @@ build sl_libd: phony ${g.bob.BuildDir}/target/static/sl_libd.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:328:1
+# Defined: build.bp:329:1
 
 m.sl_libe_target.cflags = -DFUNCTION=do_e
 m.sl_libe_target.conlyflags = 
@@ -1055,7 +1081,7 @@ build sl_libe: phony ${g.bob.BuildDir}/target/static/sl_libe.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:308:1
+# Defined: build.bp:309:1
 
 m.sl_libf_target.cflags = -DFUNCTION=do_f -DCALL=do_g2
 m.sl_libf_target.conlyflags = 
@@ -1079,7 +1105,7 @@ build sl_libf: phony ${g.bob.BuildDir}/target/static/sl_libf.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:336:1
+# Defined: build.bp:337:1
 
 m.sl_libg_target.cflags = -DFUNCTION=do_g
 m.sl_libg_target.conlyflags = 
@@ -1103,7 +1129,7 @@ build sl_libg: phony ${g.bob.BuildDir}/target/static/sl_libg.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:318:1
+# Defined: build.bp:319:1
 
 m.sl_libh_target.cflags = -DFUNCTION=do_h -DCALL=do_e2
 m.sl_libh_target.conlyflags = 
@@ -1127,7 +1153,7 @@ build sl_libh: phony ${g.bob.BuildDir}/target/static/sl_libh.a
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:344:1
+# Defined: build.bp:345:1
 
 m.sl_main_dd_target.cflags = 
 m.sl_main_dd_target.conlyflags = 
@@ -1163,7 +1189,7 @@ default sl_main_dd
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:378:1
+# Defined: build.bp:379:1
 
 m.sl_main_duplicates_target.cflags = -DFOO=1
 m.sl_main_duplicates_target.conlyflags = 
@@ -1195,7 +1221,7 @@ default sl_main_duplicates
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:252:1
+# Defined: build.bp:253:1
 
 m.sl_main_export_static_target.cflags = -DFOO=1
 m.sl_main_export_static_target.conlyflags = 
@@ -1229,7 +1255,7 @@ default sl_main_export_static
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:259:1
+# Defined: build.bp:260:1
 
 m.sl_main_ordered_target.cflags = -DFOO=1
 m.sl_main_ordered_target.conlyflags = 
@@ -1262,7 +1288,7 @@ default sl_main_ordered
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:240:1
+# Defined: build.bp:241:1
 
 m.sl_main_whole_target.cflags = 
 m.sl_main_whole_target.conlyflags = 
@@ -1293,7 +1319,7 @@ default sl_main_whole
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:431:1
+# Defined: build.bp:432:1
 
 m.strict_lib_binary_with_dep_host.cflags = -DFORWARDED_DEFINE
 m.strict_lib_binary_with_dep_host.cxxflags = 
@@ -1328,7 +1354,7 @@ default strict_lib_binary_with_dep
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:422:1
+# Defined: build.bp:423:1
 
 m.strict_lib_binary_with_forward_define_host.cflags = -DFORWARDED_DEFINE
 m.strict_lib_binary_with_forward_define_host.cxxflags = 
@@ -1363,7 +1389,7 @@ default strict_lib_binary_with_forward_define
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:397:1
+# Defined: build.bp:398:1
 
 m.strict_lib_binary_with_transitive_define_host.cflags = -DFORWARDED_DEFINE
 m.strict_lib_binary_with_transitive_define_host.cxxflags = 
@@ -1399,7 +1425,7 @@ default strict_lib_binary_with_transitive_define
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:134:1
+# Defined: build.bp:135:1
 
 m.stripped_binary_target.cflags = -DFUNC_NAME=main
 m.stripped_binary_target.conlyflags = 
@@ -1440,7 +1466,7 @@ default stripped_binary
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:109:1
+# Defined: build.bp:110:1
 
 rule m.use_sharedtest_host_.gen_use_sharedtest_host
     command = LD_LIBRARY_PATH=${g.bob.BuildDir}/host/shared:$$LD_LIBRARY_PATH ${host_bin} ${_out_}
@@ -1463,7 +1489,7 @@ build use_sharedtest_host: phony $
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:116:1
+# Defined: build.bp:117:1
 
 m.use_sharedtest_host_gen_source_target.cflags = 
 m.use_sharedtest_host_gen_source_target.conlyflags = 
@@ -1497,7 +1523,7 @@ default use_sharedtest_host_gen_source
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:46:1
+# Defined: build.bp:47:1
 
 m.utility_host.cflags = 
 m.utility_host.conlyflags = 
@@ -1511,7 +1537,7 @@ build ${g.bob.BuildDir}/host/objects/utility/srcs/main.c.o: g.bob.cc $
 
 build ${g.bob.BuildDir}/host/executable/utility: g.bob.executable $
         ${g.bob.BuildDir}/host/objects/utility/srcs/main.c.o | $
-        ${g.bob.BuildDir}/host/shared/libsharedtest.so.toc || $
+        ${g.bob.BuildDir}/host/shared/libsharedtest.so.1.2.1.toc || $
         ${g.bob.BuildDir}/host/shared/libsharedtest.so
     build_wrapper = 
     ldflags = -Wl,--as-needed
@@ -1528,7 +1554,7 @@ build utility__host: phony ${g.bob.BuildDir}/host/executable/utility
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:46:1
+# Defined: build.bp:47:1
 
 m.utility_target.cflags = 
 m.utility_target.conlyflags = 
@@ -1542,7 +1568,7 @@ build ${g.bob.BuildDir}/target/objects/utility/srcs/main.c.o: g.bob.cc $
 
 build ${g.bob.BuildDir}/target/executable/utility: g.bob.executable $
         ${g.bob.BuildDir}/target/objects/utility/srcs/main.c.o | $
-        ${g.bob.BuildDir}/target/shared/libsharedtest.so.toc || $
+        ${g.bob.BuildDir}/target/shared/libsharedtest.so.1.2.1.toc || $
         ${g.bob.BuildDir}/target/shared/libsharedtest.so
     build_wrapper = 
     ldflags = -Wl,--as-needed


### PR DESCRIPTION
Generated build.ninja from time to time gives different output for versioned libraries. This comes from the `symlink` rules which are grabbed from a map which gives different input of stored data.
Thus the symlink content from a map has to be sorted before adding Blueprint rules.

The change fix the order for generated ninja symlink rules to be deterministic.


Change-Id: Ic1c970ae858fb504d21bf29f3f8f1bf9e3e96602