### PR TITLE
broken `bob_filegroup` dependency & `genrule_bob` generation

### DIFF
--- a/core/androidbp_generated.go
+++ b/core/androidbp_generated.go
@@ -194,6 +194,12 @@ func (g *androidBpGenerator) generateSourceActions(gs *ModuleGenerateSource, ctx
 			return true
 		})
 
+	// Add `filegroup_srcs` and ':module_name' source dependencies.
+	// Both has to be in colon notation (`:module_name`)
+	// as `genrule_bob` does not support `filegroup_srcs`.
+	srcs = append(srcs, utils.PrefixAll(utils.MixedListToBobTargets(gs.ModuleGenerateCommon.Properties.Srcs), ":")...)
+	srcs = append(srcs, utils.PrefixAll(gs.ModuleGenerateCommon.Properties.Filegroup_srcs, ":")...)
+
 	m.AddStringList("srcs", srcs)
 	m.AddStringList("out", gs.Properties.Out)
 	m.AddStringList("implicit_srcs", implicits)

--- a/core/module_generate_source.go
+++ b/core/module_generate_source.go
@@ -104,9 +104,11 @@ func (m *ModuleGenerateSource) GetDirectFiles() file.Paths {
 	return gc.Properties.LegacySourceProps.GetDirectFiles()
 }
 
-func (m *ModuleGenerateSource) GetTargets() []string {
+func (m *ModuleGenerateSource) GetTargets() (tgts []string) {
 	gc, _ := getGenerateCommon(m)
-	return gc.Properties.Generated_sources
+	tgts = append(tgts, gc.Properties.LegacySourceProps.GetTargets()...)
+	tgts = append(tgts, gc.Properties.Generated_sources...)
+	return
 }
 
 func (m *ModuleGenerateSource) OutFiles() file.Paths {

--- a/plugins/genrulebob/genrule.go
+++ b/plugins/genrulebob/genrule.go
@@ -37,7 +37,7 @@ import (
 )
 
 type commonProps struct {
-	Srcs                    []string
+	Srcs                    []string `android:"path"`
 	Export_gen_include_dirs []string
 	Cmd                     string
 	Host_bin                string
@@ -252,6 +252,10 @@ func (m *genrulebobCommon) DepsMutator(ctx android.BottomUpMutatorContext) {
 		ctx.AddFarVariationDependencies(ctx.Config().BuildOSTarget.Variations(),
 			hostToolBinTag, m.Properties.Host_bin)
 	}
+
+	targets := utils.MixedListToBobTargets(m.Properties.Srcs)
+
+	ctx.AddFarVariationDependencies(nil, generatedSourceTag, targets...)
 
 	// `generated_deps` and `generated_sources` can refer not only to source
 	// generation modules, but to binaries and libraries. In this case we

--- a/tests/gendiffer/gensrcs/app/build.bp
+++ b/tests/gendiffer/gensrcs/app/build.bp
@@ -15,12 +15,28 @@
  * limitations under the License.
  */
 
+bob_filegroup {
+    name: "generate_input",
+    srcs: [
+        "before_generate.in",
+    ],
+}
+
+bob_filegroup {
+    name: "generate_input_two",
+    srcs: [
+        "before_generate2.in",
+    ],
+}
+
 bob_generate_source {
     name: "generate_source_multiple_in",
     srcs: [
-        "before_generate.in",
-        "before_generate2.in",
+        ":generate_input",
         "before_generate3.in",
+    ],
+    filegroup_srcs: [
+        "generate_input_two",
     ],
     out: ["multiple_in.cpp"],
 

--- a/tests/gendiffer/gensrcs/out/android/Android.bp.out
+++ b/tests/gendiffer/gensrcs/out/android/Android.bp.out
@@ -59,7 +59,11 @@ filegroup {
 
 genrule_bob {
     name: "generate_source_multiple_in",
-    srcs: ["before_generate3.in"],
+    srcs: [
+        "before_generate3.in",
+        ":generate_input",
+        ":generate_input_two",
+    ],
     out: ["multiple_in.cpp"],
     cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in before_generate2.in before_generate3.in",
     tools: ["generator.py"],

--- a/tests/gendiffer/gensrcs/out/android/Android.bp.out
+++ b/tests/gendiffer/gensrcs/out/android/Android.bp.out
@@ -47,13 +47,19 @@ genrule_bob {
     depfile: false,
 }
 
+filegroup {
+    name: "generate_input",
+    srcs: ["before_generate.in"],
+}
+
+filegroup {
+    name: "generate_input_two",
+    srcs: ["before_generate2.in"],
+}
+
 genrule_bob {
     name: "generate_source_multiple_in",
-    srcs: [
-        "before_generate.in",
-        "before_generate2.in",
-        "before_generate3.in",
-    ],
+    srcs: ["before_generate3.in"],
     out: ["multiple_in.cpp"],
     cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in before_generate2.in before_generate3.in",
     tools: ["generator.py"],

--- a/tests/gendiffer/gensrcs/out/linux/build.ninja.out
+++ b/tests/gendiffer/gensrcs/out/linux/build.ninja.out
@@ -58,7 +58,7 @@ rule g.bootstrap.cp
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:152:1
+# Defined: build.bp:168:1
 
 rule m.gen_source_depfile_.gen_gen_source_depfile
     command = ${tool} -o ${_out_} -d ${depfile} ${in}
@@ -81,7 +81,7 @@ default gen_source_depfile
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:162:1
+# Defined: build.bp:178:1
 
 rule m.gen_source_depfile_with_implicit_outs_.gen_gen_source_depfile_with_implicit_outs
     command = ${tool} --gen-implicit-out -o ${gen_dir}/output.txt -d ${depfile} ${in}
@@ -111,7 +111,7 @@ default gen_source_depfile_with_implicit_outs
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:191:1
+# Defined: build.bp:207:1
 
 rule m.gen_source_globbed_exclude_implicit_sources_.gen_gen_source_globbed_exclude_implicit_sources
     command = python ${tool} --src-dir ${module_dir} --use-c --out ${_out_}
@@ -136,7 +136,7 @@ default gen_source_globbed_exclude_implicit_sources
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:182:1
+# Defined: build.bp:198:1
 
 rule m.gen_source_globbed_implicit_sources_.gen_gen_source_globbed_implicit_sources
     command = python ${tool} --src-dir ${module_dir} --use-a --out ${_out_}
@@ -161,7 +161,7 @@ default gen_source_globbed_implicit_sources
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:18:1
+# Defined: build.bp:32:1
 
 rule m.generate_source_multiple_in_.gen_generate_source_multiple_in
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in before_generate2.in before_generate3.in
@@ -170,8 +170,9 @@ rule m.generate_source_multiple_in_.gen_generate_source_multiple_in
 
 build ${g.bob.BuildDir}/gen/generate_source_multiple_in/multiple_in.cpp: $
         m.generate_source_multiple_in_.gen_generate_source_multiple_in $
-        ${g.bob.SrcDir}/before_generate.in ${g.bob.SrcDir}/before_generate2.in $
-        ${g.bob.SrcDir}/before_generate3.in | ${g.bob.SrcDir}/generator.py
+        ${g.bob.SrcDir}/before_generate3.in $
+        ${g.bob.SrcDir}/before_generate2.in ${g.bob.SrcDir}/before_generate.in $
+        | ${g.bob.SrcDir}/generator.py
     _out_ = ${g.bob.BuildDir}/gen/generate_source_multiple_in/multiple_in.cpp
     tool = ${g.bob.SrcDir}/generator.py
 
@@ -183,7 +184,7 @@ build generate_source_multiple_in: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:45:1
+# Defined: build.bp:61:1
 
 rule m.generate_source_multiple_in_out_.gen_generate_source_multiple_in_out
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in before_generate2.in before_generate3.in
@@ -209,7 +210,7 @@ build generate_source_multiple_in_out: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:31:1
+# Defined: build.bp:47:1
 
 rule m.generate_source_multiple_out_.gen_generate_source_multiple_out
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in
@@ -254,7 +255,7 @@ build generate_source_single: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:104:1
+# Defined: build.bp:120:1
 
 rule m.generate_source_single_dependend_.gen_generate_source_single_dependend
     command = python ${tool} --in ${in} ${generate_source_single_out} --out ${_out_} --expect-in before_generate.in single.cpp
@@ -278,7 +279,7 @@ build generate_source_single_dependend: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:117:1
+# Defined: build.bp:133:1
 
 rule m.generate_source_single_dependend_nested_.gen_generate_source_single_dependend_nested
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in deps.cpp
@@ -301,7 +302,7 @@ build generate_source_single_dependend_nested: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:61:1
+# Defined: build.bp:77:1
 
 rule m.generate_source_single_level1_.gen_generate_source_single_level1
     command = python ${tool} --in ${in} --out ${_out_} --expect-in single.cpp
@@ -323,7 +324,7 @@ build generate_source_single_level1: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:71:1
+# Defined: build.bp:87:1
 
 rule m.generate_source_single_level2_.gen_generate_source_single_level2
     command = python ${tool} --in ${in} --out ${_out_} --expect-in level_1_single.cpp
@@ -345,7 +346,7 @@ build generate_source_single_level2: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:81:1
+# Defined: build.bp:97:1
 
 rule m.generate_source_single_level3_.gen_generate_source_single_level3
     command = python ${tool} --in ${in} --out ${_out_} --expect-in level_2_single.cpp
@@ -367,7 +368,7 @@ build generate_source_single_level3: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:91:1
+# Defined: build.bp:107:1
 
 rule m.generate_source_single_nested_with_extra_.gen_generate_source_single_nested_with_extra
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in level_2_single.cpp
@@ -392,7 +393,7 @@ build generate_source_single_nested_with_extra: phony $
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:213:1
+# Defined: build.bp:229:1
 
 m.host_and_target_supported_binary_host.cflags = 
 m.host_and_target_supported_binary_host.conlyflags = 
@@ -423,7 +424,7 @@ default host_and_target_supported_binary__host
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:213:1
+# Defined: build.bp:229:1
 
 m.host_and_target_supported_binary_target.cflags = 
 m.host_and_target_supported_binary_target.conlyflags = 
@@ -484,7 +485,7 @@ default multiple_tools_generate_sources
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:204:1
+# Defined: build.bp:220:1
 
 m.use_miscellaneous_generated_source_tests_target.cflags = 
 m.use_miscellaneous_generated_source_tests_target.conlyflags = 
@@ -529,7 +530,7 @@ default use_miscellaneous_generated_source_tests
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:225:1
+# Defined: build.bp:241:1
 
 rule m.use_target_specific_library_.gen_use_target_specific_library
     command = test $$(basename ${host_and_target_supported_binary_out}) = host_binary && cp ${host_and_target_supported_binary_out} ${_out_}
@@ -551,7 +552,7 @@ default use_target_specific_library
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:175:1
+# Defined: build.bp:191:1
 
 rule m.validate_install_generate_sources_.gen_validate_install_generate_sources
     command = touch ${_out_}
@@ -573,7 +574,7 @@ default validate_install_generate_sources
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:130:1
+# Defined: build.bp:146:1
 
 m.validate_link_generate_sources_target.cflags = 
 m.validate_link_generate_sources_target.cxxflags = 

--- a/tests/generate_source/build.bp
+++ b/tests/generate_source/build.bp
@@ -21,10 +21,24 @@
 // On Android output path can look like: out/target/product/hikey960/gen/STATIC_LIBRARIES/generate_source_single/single.cpp
 // On Linux output path can look like: build/gen/generate_source_single/single.cpp
 
+bob_filegroup {
+    name: "generate_input",
+    srcs: [
+        "before_generate.in",
+    ],
+}
+
+bob_filegroup {
+    name: "generate_input_two",
+    srcs: [
+        "before_generate2.in",
+    ],
+}
+
 bob_generate_source {
     name: "generate_source_single",
     srcs: [
-        "before_generate.in",
+        ":generate_input",
     ],
     out: ["single.cpp"],
 
@@ -36,8 +50,10 @@ bob_generate_source {
     name: "generate_source_multiple_in",
     srcs: [
         "before_generate.in",
-        "before_generate2.in",
         "before_generate3.in",
+    ],
+    filegroup_srcs: [
+        "generate_input_two",
     ],
     out: ["multiple_in.cpp"],
 

--- a/tests/generate_source/build.bp
+++ b/tests/generate_source/build.bp
@@ -49,7 +49,7 @@ bob_generate_source {
 bob_generate_source {
     name: "generate_source_multiple_in",
     srcs: [
-        "before_generate.in",
+        ":generate_input",
         "before_generate3.in",
     ],
     filegroup_srcs: [


### PR DESCRIPTION
`bob_generate_source` modules could not
properly grab sources while dependency
come from `bob_filegroup` module by
`srcs` property (':module_name' notation)
or deprecated `filegroup_srcs` property.


`bob_generate_source` is transitioned to
`genrule_bob` within Android.bp file.

`bob_generate_source` allows to depend on
`bob_filegroup` dependency by either
`filegroup_srcs` property (deprecated) or
module name in `srcs` property (colon notation).

Neither dependency was placed within `genrule_bob`.

`genrule_bob` does not support `filegroup_srcs`
property or similar thus those will be placed
in `srcs` as module dependency (`:module_name`)
together with other modules from `bob_generate_source.srcs`
property.
