### PR TITLE
chore: use `bob_filegroup` as a tool

### DIFF
--- a/core/androidbp_generated.go
+++ b/core/androidbp_generated.go
@@ -118,7 +118,7 @@ func populateCommonProps(gc *ModuleGenerateCommon, ctx blueprint.ModuleContext, 
 
 	m.AddBool("depfile", proptools.Bool(gc.Properties.Depfile))
 
-	m.AddStringList("generated_deps", getShortNamesForDirectDepsWithTags(ctx, GeneratedTag))
+	m.AddStringList("generated_deps", getShortNamesForDirectDepsWithTagsForNonFilegroup(ctx, GeneratedTag))
 	m.AddStringList("generated_sources", getShortNamesForDirectDepsWithTags(ctx, GeneratedSourcesTag))
 	m.AddStringList("export_gen_include_dirs", gc.Properties.Export_gen_include_dirs)
 	m.AddStringList("cflags", gc.Properties.FlagArgsBuild.Cflags)

--- a/core/generated_common.go
+++ b/core/generated_common.go
@@ -90,6 +90,7 @@ type ModuleGenerateCommon struct {
 		Features
 		FlagArgsBuild Build `blueprint:"mutated"`
 	}
+	deps []string
 }
 
 // ModuleGenerateCommon supports:
@@ -461,7 +462,10 @@ func (m *ModuleGenerateCommon) processPaths(ctx blueprint.BaseModuleContext) {
 	m.Properties.InstallableProps.processPaths(ctx)
 
 	if len(m.Properties.Tools) > 0 {
-		m.Properties.Tools = utils.PrefixDirs(m.Properties.Tools, projectModuleDir(ctx))
+		m.deps = utils.MixedListToBobTargets(m.Properties.Tools)
+		tools_targets := utils.PrefixAll(m.deps, ":")
+		m.Properties.Tools = utils.PrefixDirs(utils.MixedListToFiles(m.Properties.Tools), projectModuleDir(ctx))
+		m.Properties.Tools = append(m.Properties.Tools, tools_targets...)
 	}
 
 	prefix := projectModuleDir(ctx)

--- a/core/install.go
+++ b/core/install.go
@@ -152,6 +152,30 @@ func getShortNamesForDirectDepsWithTags(ctx blueprint.ModuleContext,
 		})
 }
 
+func getShortNamesForDirectDepsWithTagsForNonFilegroup(ctx blueprint.ModuleContext,
+	tags ...DependencyTag) (ret []string) {
+
+	return getShortNamesForDirectDepsIf(ctx,
+		func(m blueprint.Module) bool {
+			tag := ctx.OtherModuleDependencyTag(m)
+
+			// Do not count `ModuleFilegroup` as dependency.
+			// `ModuleFilegroup` are specified by `GeneratedTag`
+			// dependency tag but they are simple file providers
+			// and cannot be considered as `generated_deps`.
+			if _, ok := m.(*ModuleFilegroup); ok {
+				return false
+			}
+
+			for _, i := range tags {
+				if tag == i {
+					return true
+				}
+			}
+			return false
+		})
+}
+
 // InstallGroupProps describes the properties of bob_install_group modules
 type InstallGroupProps struct {
 	Install_path *string

--- a/plugins/genrulebob/genrule.go
+++ b/plugins/genrulebob/genrule.go
@@ -41,7 +41,7 @@ type commonProps struct {
 	Export_gen_include_dirs []string
 	Cmd                     string
 	Host_bin                string
-	Tools                   []string
+	Tools                   []string `android:"path"`
 	Depfile                 bool
 	Generated_deps          []string
 	Generated_sources       []string

--- a/tests/gendiffer/gensrcs/app/build.bp
+++ b/tests/gendiffer/gensrcs/app/build.bp
@@ -29,6 +29,13 @@ bob_filegroup {
     ],
 }
 
+bob_filegroup {
+    name: "generate_tool",
+    srcs: [
+        "generator.py",
+    ],
+}
+
 bob_generate_source {
     name: "generate_source_multiple_in",
     srcs: [
@@ -40,7 +47,7 @@ bob_generate_source {
     ],
     out: ["multiple_in.cpp"],
 
-    tools: ["generator.py"],
+    tools: [":generate_tool"],
     cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in before_generate2.in before_generate3.in",
 }
 

--- a/tests/gendiffer/gensrcs/out/android/Android.bp.out
+++ b/tests/gendiffer/gensrcs/out/android/Android.bp.out
@@ -66,7 +66,7 @@ genrule_bob {
     ],
     out: ["multiple_in.cpp"],
     cmd: "python ${tool} --in ${in} --out ${out} --expect-in before_generate.in before_generate2.in before_generate3.in",
-    tools: ["generator.py"],
+    tools: [":generate_tool"],
     depfile: false,
 }
 
@@ -162,6 +162,11 @@ genrule_bob {
     tools: ["generator.py"],
     depfile: false,
     generated_sources: ["generate_source_single_level2"],
+}
+
+filegroup {
+    name: "generate_tool",
+    srcs: ["generator.py"],
 }
 
 cc_binary_host {

--- a/tests/gendiffer/gensrcs/out/linux/build.ninja.out
+++ b/tests/gendiffer/gensrcs/out/linux/build.ninja.out
@@ -58,7 +58,7 @@ rule g.bootstrap.cp
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:168:1
+# Defined: build.bp:175:1
 
 rule m.gen_source_depfile_.gen_gen_source_depfile
     command = ${tool} -o ${_out_} -d ${depfile} ${in}
@@ -81,7 +81,7 @@ default gen_source_depfile
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:178:1
+# Defined: build.bp:185:1
 
 rule m.gen_source_depfile_with_implicit_outs_.gen_gen_source_depfile_with_implicit_outs
     command = ${tool} --gen-implicit-out -o ${gen_dir}/output.txt -d ${depfile} ${in}
@@ -111,7 +111,7 @@ default gen_source_depfile_with_implicit_outs
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:207:1
+# Defined: build.bp:214:1
 
 rule m.gen_source_globbed_exclude_implicit_sources_.gen_gen_source_globbed_exclude_implicit_sources
     command = python ${tool} --src-dir ${module_dir} --use-c --out ${_out_}
@@ -136,7 +136,7 @@ default gen_source_globbed_exclude_implicit_sources
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:198:1
+# Defined: build.bp:205:1
 
 rule m.gen_source_globbed_implicit_sources_.gen_gen_source_globbed_implicit_sources
     command = python ${tool} --src-dir ${module_dir} --use-a --out ${_out_}
@@ -161,7 +161,7 @@ default gen_source_globbed_implicit_sources
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:32:1
+# Defined: build.bp:39:1
 
 rule m.generate_source_multiple_in_.gen_generate_source_multiple_in
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in before_generate2.in before_generate3.in
@@ -184,7 +184,7 @@ build generate_source_multiple_in: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:61:1
+# Defined: build.bp:68:1
 
 rule m.generate_source_multiple_in_out_.gen_generate_source_multiple_in_out
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in before_generate2.in before_generate3.in
@@ -210,7 +210,7 @@ build generate_source_multiple_in_out: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:47:1
+# Defined: build.bp:54:1
 
 rule m.generate_source_multiple_out_.gen_generate_source_multiple_out
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in
@@ -255,7 +255,7 @@ build generate_source_single: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:120:1
+# Defined: build.bp:127:1
 
 rule m.generate_source_single_dependend_.gen_generate_source_single_dependend
     command = python ${tool} --in ${in} ${generate_source_single_out} --out ${_out_} --expect-in before_generate.in single.cpp
@@ -279,7 +279,7 @@ build generate_source_single_dependend: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:133:1
+# Defined: build.bp:140:1
 
 rule m.generate_source_single_dependend_nested_.gen_generate_source_single_dependend_nested
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in deps.cpp
@@ -302,7 +302,7 @@ build generate_source_single_dependend_nested: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:77:1
+# Defined: build.bp:84:1
 
 rule m.generate_source_single_level1_.gen_generate_source_single_level1
     command = python ${tool} --in ${in} --out ${_out_} --expect-in single.cpp
@@ -324,7 +324,7 @@ build generate_source_single_level1: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:87:1
+# Defined: build.bp:94:1
 
 rule m.generate_source_single_level2_.gen_generate_source_single_level2
     command = python ${tool} --in ${in} --out ${_out_} --expect-in level_1_single.cpp
@@ -346,7 +346,7 @@ build generate_source_single_level2: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:97:1
+# Defined: build.bp:104:1
 
 rule m.generate_source_single_level3_.gen_generate_source_single_level3
     command = python ${tool} --in ${in} --out ${_out_} --expect-in level_2_single.cpp
@@ -368,7 +368,7 @@ build generate_source_single_level3: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:107:1
+# Defined: build.bp:114:1
 
 rule m.generate_source_single_nested_with_extra_.gen_generate_source_single_nested_with_extra
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in level_2_single.cpp
@@ -393,7 +393,7 @@ build generate_source_single_nested_with_extra: phony $
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:229:1
+# Defined: build.bp:236:1
 
 m.host_and_target_supported_binary_host.cflags = 
 m.host_and_target_supported_binary_host.conlyflags = 
@@ -424,7 +424,7 @@ default host_and_target_supported_binary__host
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:229:1
+# Defined: build.bp:236:1
 
 m.host_and_target_supported_binary_target.cflags = 
 m.host_and_target_supported_binary_target.conlyflags = 
@@ -485,7 +485,7 @@ default multiple_tools_generate_sources
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:220:1
+# Defined: build.bp:227:1
 
 m.use_miscellaneous_generated_source_tests_target.cflags = 
 m.use_miscellaneous_generated_source_tests_target.conlyflags = 
@@ -530,7 +530,7 @@ default use_miscellaneous_generated_source_tests
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:241:1
+# Defined: build.bp:248:1
 
 rule m.use_target_specific_library_.gen_use_target_specific_library
     command = test $$(basename ${host_and_target_supported_binary_out}) = host_binary && cp ${host_and_target_supported_binary_out} ${_out_}
@@ -552,7 +552,7 @@ default use_target_specific_library
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:191:1
+# Defined: build.bp:198:1
 
 rule m.validate_install_generate_sources_.gen_validate_install_generate_sources
     command = touch ${_out_}
@@ -574,7 +574,7 @@ default validate_install_generate_sources
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:146:1
+# Defined: build.bp:153:1
 
 m.validate_link_generate_sources_target.cflags = 
 m.validate_link_generate_sources_target.cxxflags = 


### PR DESCRIPTION
`bob_generate_sources` has to be able to use
`bob_filegroup` in its `Tools` property
to fulfill Android generation.

Change adds possibility to use `:module_name`
of `bob_filegroup` in `Tools` property.


Change-Id: I8a5f09b83b85bc5d69462a223bb116e1a446fcb2