### PR TITLE
fix: header tracking on Linux

### DIFF
--- a/core/linux_cclibs.go
+++ b/core/linux_cclibs.go
@@ -45,7 +45,7 @@ var ccRule = pctx.StaticRule("cc",
 	blueprint.RuleParams{
 		Depfile:     "$out.d",
 		Deps:        blueprint.DepsGCC,
-		Command:     "$build_wrapper $ccompiler -c $cflags $conlyflags -MMD -MF $depfile $in -o $out",
+		Command:     "$build_wrapper $ccompiler -c $cflags $conlyflags -MD -MF $depfile $in -o $out",
 		Description: "$out",
 	}, "ccompiler", "cflags", "conlyflags", "build_wrapper", "depfile")
 
@@ -53,7 +53,7 @@ var cxxRule = pctx.StaticRule("cxx",
 	blueprint.RuleParams{
 		Depfile:     "$out.d",
 		Deps:        blueprint.DepsGCC,
-		Command:     "$build_wrapper $cxxcompiler -c $cflags $cxxflags -MMD -MF $depfile $in -o $out",
+		Command:     "$build_wrapper $cxxcompiler -c $cflags $cxxflags -MD -MF $depfile $in -o $out",
 		Description: "$out",
 	}, "cxxcompiler", "cflags", "cxxflags", "build_wrapper", "depfile")
 

--- a/tests/gendiffer/complex_srcs/out/linux/build.ninja.out
+++ b/tests/gendiffer/complex_srcs/out/linux/build.ninja.out
@@ -33,7 +33,7 @@ rule g.bob.copy
     description = ${out}
 
 rule g.bob.cxx
-    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/example/out/linux/build.ninja.out
+++ b/tests/gendiffer/example/out/linux/build.ninja.out
@@ -29,7 +29,7 @@ pool g.bob.link
 builddir = ${g.bootstrap.ninjaBuildDir}
 
 rule g.bob.cxx
-    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/filegroups/out/linux/build.ninja.out
+++ b/tests/gendiffer/filegroups/out/linux/build.ninja.out
@@ -29,7 +29,7 @@ pool g.bob.link
 builddir = ${g.bootstrap.ninjaBuildDir}
 
 rule g.bob.cc
-    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/genhdrs/out/linux/build.ninja.out
+++ b/tests/gendiffer/genhdrs/out/linux/build.ninja.out
@@ -29,7 +29,7 @@ pool g.bob.link
 builddir = ${g.bootstrap.ninjaBuildDir}
 
 rule g.bob.cc
-    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/genlib/out/linux/build.ninja.out
+++ b/tests/gendiffer/genlib/out/linux/build.ninja.out
@@ -33,7 +33,7 @@ pool g.bob.link
 builddir = ${g.bootstrap.ninjaBuildDir}
 
 rule g.bob.cc
-    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/gensrcs/out/linux/build.ninja.out
+++ b/tests/gendiffer/gensrcs/out/linux/build.ninja.out
@@ -29,13 +29,13 @@ pool g.bob.link
 builddir = ${g.bootstrap.ninjaBuildDir}
 
 rule g.bob.cc
-    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}
 
 rule g.bob.cxx
-    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/gensrcs_new/out/linux/build.ninja.out
+++ b/tests/gendiffer/gensrcs_new/out/linux/build.ninja.out
@@ -29,13 +29,13 @@ pool g.bob.link
 builddir = ${g.bootstrap.ninjaBuildDir}
 
 rule g.bob.cc
-    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}
 
 rule g.bob.cxx
-    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/gensrcs_new_tool_files_dep/out/linux/build.ninja.out
+++ b/tests/gendiffer/gensrcs_new_tool_files_dep/out/linux/build.ninja.out
@@ -29,7 +29,7 @@ pool g.bob.link
 builddir = ${g.bootstrap.ninjaBuildDir}
 
 rule g.bob.cxx
-    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/globs/out/linux/build.ninja.out
+++ b/tests/gendiffer/globs/out/linux/build.ninja.out
@@ -29,13 +29,13 @@ pool g.bob.link
 builddir = ${g.bootstrap.ninjaBuildDir}
 
 rule g.bob.cc
-    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}
 
 rule g.bob.cxx
-    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/installdeps/out/linux/build.ninja.out
+++ b/tests/gendiffer/installdeps/out/linux/build.ninja.out
@@ -29,7 +29,7 @@ pool g.bob.link
 builddir = ${g.bootstrap.ninjaBuildDir}
 
 rule g.bob.cc
-    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/libraries/out/linux/build.ninja.out
+++ b/tests/gendiffer/libraries/out/linux/build.ninja.out
@@ -37,13 +37,13 @@ pool g.bob.link
 builddir = ${g.bootstrap.ninjaBuildDir}
 
 rule g.bob.cc
-    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}
 
 rule g.bob.cxx
-    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/matchsrcs/out/linux/build.ninja.out
+++ b/tests/gendiffer/matchsrcs/out/linux/build.ninja.out
@@ -29,13 +29,13 @@ pool g.bob.link
 builddir = ${g.bootstrap.ninjaBuildDir}
 
 rule g.bob.cc
-    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}
 
 rule g.bob.cxx
-    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/simplelib/out/linux/build.ninja.out
+++ b/tests/gendiffer/simplelib/out/linux/build.ninja.out
@@ -35,13 +35,13 @@ rule g.bob.as
     description = ${out}
 
 rule g.bob.cc
-    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}
 
 rule g.bob.cxx
-    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/source_props/out/linux/build.ninja.out
+++ b/tests/gendiffer/source_props/out/linux/build.ninja.out
@@ -29,7 +29,7 @@ pool g.bob.link
 builddir = ${g.bootstrap.ninjaBuildDir}
 
 rule g.bob.cc
-    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/template/out/linux/build.ninja.out
+++ b/tests/gendiffer/template/out/linux/build.ninja.out
@@ -25,7 +25,7 @@ g.bootstrap.srcDir = redacted
 builddir = ${g.bootstrap.ninjaBuildDir}
 
 rule g.bob.cc
-    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${ccompiler} -c ${cflags} ${conlyflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}

--- a/tests/gendiffer/transformsrcs/out/linux/build.ninja.out
+++ b/tests/gendiffer/transformsrcs/out/linux/build.ninja.out
@@ -29,7 +29,7 @@ pool g.bob.link
 builddir = ${g.bootstrap.ninjaBuildDir}
 
 rule g.bob.cxx
-    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MMD -MF ${depfile} ${in} -o ${out}
+    command = ${build_wrapper} ${cxxcompiler} -c ${cflags} ${cxxflags} -MD -MF ${depfile} ${in} -o ${out}
     depfile = ${out}.d
     deps = gcc
     description = ${out}


### PR DESCRIPTION
Bob is using `g++ -MMD -MF` to track
header dependencies. That means system
headers are not tracked. Bob needs to
track system header dependencies too
thus it has to tweaked to use:
`g++ -MD -MF` instead.


Change-Id: I29963f0b325548f46db9eb09205d511fc72ea956