### PR TITLE
chore: add variable to not install Go `std`

### DIFF
--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -41,14 +41,29 @@ then
     exit 1
 fi
 
+if [ -z "${GO120_NO_STD_INSTALL-}" ]; then
+  GO120_NO_STD_INSTALL=0
+fi
+
 go_version=$(go version | { read _ _ v _; echo "${v#go}"; })
 if [ "$(printf "%s\n1.20\n" "$go_version" | sort -t '.' -k 1,1 -k 2,2 -g | head -n 1)" == "1.20" ]; then
   # Since go 1.20, std modules are not installed by default. This breaks Blueprint.
   # Pre-install these modules before proceeding.
   # Should the GOPATH change or be deleted this script may have to be re-run.
-  GODEBUG=installgoroot=all go install std
-fi
+  if [ ${GO120_NO_STD_INSTALL} = 0 ]; then
+    echo 'WARNING: Go >=1.20 is not fully supported by Bob/Blueprint and requires a pre-installed Go `std` package on the system. Attempting workaround. You may disable this workaround by setting `GO120_NO_STD_INSTALL=1`'
 
+    ret=0
+    (GODEBUG=installgoroot=all go install std) || ret=$?
+
+    if [ $ret -eq 126 ]; then
+      echo 'WARNING: Permissions failed when installing Go standard library. Build will proceed assuming a sandboxed envrioment, if you are not in a sandbox with a pre-existing Go `std` library installed please run `GODEBUG=installgoroot=all go install std` with sudo.'
+    elif [ $ret -ne 0 ]; then
+      echo 'ERROR: Unexpected error installing Go `std` package for Go >=1.20. Error code:' $ret
+      exit $ret
+    fi
+  fi
+fi
 
 # Use defaults where we can. Generally the caller should set these.
 if [ -z "${SRCDIR}" ] ; then


### PR DESCRIPTION
GO120_NO_STD_INSTALL=true variable alows to not
install standard libraries `std` if Go >=1.20.

By default GO120_NO_STD_INSTALL is not set
thus when Go >=1.20 `std` will be installed on
bootstrap.

Go >=1.20 in not fully supported by Bob/Blueprint
thus a warning message will be printed.


Change-Id: I55da81106091dfddf16ffca52a9b43536b5370b5