### PR TITLE
Improve Bob modules & gendiffer

### DIFF
--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -526,6 +526,7 @@ func (g *androidBpGenerator) strictLibraryActions(m *ModuleStrictLibrary, ctx bl
 	proxyStaticLib.Properties.EnableableProps.Required = true
 	proxyStaticLib.Properties.Srcs = m.Properties.Srcs
 	proxyStaticLib.Properties.Cflags = proxyCflags(m)
+	proxyStaticLib.Properties.Export_local_system_include_dirs = utils.PrefixDirs(m.Properties.Includes, projectModuleDir(ctx))
 	proxyStaticLib.Properties.Host_supported = m.Properties.Host_supported
 	proxyStaticLib.Properties.Target_supported = m.Properties.Target_supported
 	// TODO: generate target for all supported target types

--- a/core/strict_library.go
+++ b/core/strict_library.go
@@ -57,6 +57,16 @@ type StrictLibraryProps struct {
 	TargetType toolchain.TgtType `blueprint:"mutated"`
 }
 
+// List of include dirs to be added to the compile line.
+//
+// Each string is prepended with `-I` when building the target itself
+// and `-isystem` when building modules who consumes it.
+// Unlike `Copts`, these flags are added for this rule and every
+// rule that depends on it.
+type IncludeProps struct {
+	Includes []string
+}
+
 type ModuleStrictLibrary struct {
 	module.ModuleBase
 	Properties struct {
@@ -67,6 +77,7 @@ type ModuleStrictLibrary struct {
 		EnableableProps
 		SplittableProps
 		InstallableProps
+		IncludeProps
 	}
 }
 
@@ -173,6 +184,11 @@ func (m *ModuleStrictLibrary) FlagsIn() flag.Flags {
 			Tag:          flag.TypeUnset,
 			Factory:      flag.FromDefineOwned,
 		},
+		{
+			PropertyName: "Includes",
+			Tag:          flag.TypeInclude,
+			Factory:      flag.FromIncludePathOwned,
+		},
 	}
 
 	return flag.ParseFromProperties(nil, lut, m.Properties)
@@ -198,6 +214,11 @@ func (m *ModuleStrictLibrary) FlagsOut() flag.Flags {
 			PropertyName: "Defines",
 			Tag:          flag.TypeExported | flag.TypeTransitive,
 			Factory:      flag.FromDefineOwned,
+		},
+		{
+			PropertyName: "Includes",
+			Tag:          flag.TypeExported | flag.TypeTransitive | flag.TypeIncludeSystem,
+			Factory:      flag.FromIncludePathOwned,
 		},
 	}
 

--- a/gendiffer/gendiffer.go
+++ b/gendiffer/gendiffer.go
@@ -120,6 +120,7 @@ func redact(args *generationArgs, data []byte) []byte {
 	data = regexp.MustCompile(args.BobRootAbsolute).ReplaceAll(data, []byte("redacted"))
 	data = regexp.MustCompile(args.ConfigFile).ReplaceAll(data, []byte("%REDACTED_CONFIG_FILE%"))
 	data = regexp.MustCompile(args.ConfigJson).ReplaceAll(data, []byte("%REDACTED_CONFIG_JSON%"))
+	data = regexp.MustCompile("(?m)^(# Defined: .*/?build.bp:)[0-9]+:[0-9]+").ReplaceAll(data, redacted)
 	return data
 }
 

--- a/plugins/genrulebob/genrule.go
+++ b/plugins/genrulebob/genrule.go
@@ -320,6 +320,21 @@ func (m *genrulebobCommon) getArgs(ctx android.ModuleContext) (args map[string]s
 			out := ccmod.OutputFile()
 			dependents = append(dependents, out.Path())
 			args[varName+"_out"] = out.String()
+		} else if gsf, ok := dep.(android.OutputFileProducer); ok {
+			var outNames []string
+			outs, err := gsf.OutputFiles("")
+
+			if err != nil {
+				panic(err)
+			}
+
+			dependents = append(dependents, outs...)
+
+			for _, n := range outs {
+				outNames = append(outNames, n.String())
+			}
+
+			args[varName+"_out"] = utils.Join(outNames)
 		}
 	})
 
@@ -333,6 +348,8 @@ func (m *genrulebobCommon) getModuleSrcs(ctx android.ModuleContext) (srcs []andr
 			srcs = append(srcs, gdep.implicitOutputs().Paths()...)
 		} else if ccmod, ok := dep.(cc.LinkableInterface); ok {
 			srcs = append(srcs, ccmod.OutputFile().Path())
+		} else if gsf, ok := dep.(genrule.SourceFileGenerator); ok {
+			srcs = append(srcs, gsf.GeneratedSourceFiles()...)
 		}
 	})
 	return

--- a/tests/gendiffer/complex_srcs/out/linux/build.ninja.out
+++ b/tests/gendiffer/complex_srcs/out/linux/build.ninja.out
@@ -56,7 +56,7 @@ rule g.bootstrap.cp
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:158:1
+# Defined: nested/build.bp:redacted
 
 m.binary_host.cflags = -I${g.bob.SrcDir} -I${g.bob.SrcDir}/src -I${g.bob.BuildDir}/gen/test_host_configuration/include -I${g.bob.BuildDir}/gen/generated_srcs/include -I${g.bob.BuildDir}/gen/generated_srcs/include/lib
 m.binary_host.cxxflags = 
@@ -223,7 +223,7 @@ build binary: phony ${g.bob.BuildDir}/install/testcases/binary $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:24:1
+# Defined: nested/build.bp:redacted
 
 rule m.config_h_.gen_config_h
     command = bash -ec 'mkdir -p $$(dirname ${_out_}); ${tool} -o ${_out_} ${g.bob.SrcDir}/nested/config2.h.in $$(cat ${g.bob.SrcDir}/nested/config2.h.in) SOME_ARG1=foo SOME_ARG2='
@@ -243,7 +243,7 @@ build config_h: phony ${g.bob.BuildDir}/gen/config_h/include/config.h
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:90:1
+# Defined: nested/build.bp:redacted
 
 rule m.data_inc_.gen_data_inc
     command = LD_LIBRARY_PATH=${g.bob.BuildDir}/shared:$$LD_LIBRARY_PATH bash -c "${host_bin} -create-data  --write-if-changed -I ${src_dir}/. -o ${gen_dir}/lib/data.inc -d ${depfile}"
@@ -266,7 +266,7 @@ build data_inc: phony ${g.bob.BuildDir}/gen/data_inc/lib/data.inc
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:81:1
+# Defined: nested/build.bp:redacted
 
 rule m.file_cpp_.gen_file_cpp
     command = LD_LIBRARY_PATH=${g.bob.BuildDir}/shared:$$LD_LIBRARY_PATH bash -c "${host_bin} --create-source  -I ${src_dir}/. -o ${gen_dir}/source.cpp -d ${depfile}"
@@ -289,7 +289,7 @@ build file_cpp: phony ${g.bob.BuildDir}/gen/file_cpp/source.cpp
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:99:1
+# Defined: nested/build.bp:redacted
 
 rule m.generated_srcs_.gen_generated_srcs
     command = mkdir -p ${gen_dir}/include/lib; cp ${include_0_h_out} ${gen_dir}/include/lib/someheader0.h.inc;mkdir -p ${gen_dir}/include/lib; cp ${include_1_h_out} ${gen_dir}/include/lib/someheader1.h.inc;mkdir -p ${gen_dir}/include/lib; cp ${data_inc_out} ${gen_dir}/include/lib/data.inc;mkdir -p ${gen_dir}/lib; cp ${file_cpp_out} ${gen_dir}/lib/source.cpp;
@@ -324,7 +324,7 @@ build generated_srcs: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:63:1
+# Defined: nested/build.bp:redacted
 
 rule m.include_0_h_.gen_include_0_h
     command = LD_LIBRARY_PATH=${g.bob.BuildDir}/shared:$$LD_LIBRARY_PATH bash -c "${host_bin} -I ${src_dir} -o ${gen_dir}/include/lib/header0.h -d ${depfile}"
@@ -348,7 +348,7 @@ build include_0_h: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:72:1
+# Defined: nested/build.bp:redacted
 
 rule m.include_1_h_.gen_include_1_h
     command = LD_LIBRARY_PATH=${g.bob.BuildDir}/shared:$$LD_LIBRARY_PATH bash -c "${host_bin} -I ${src_dir} -o ${gen_dir}/include/lib/header1.h -d ${depfile}"
@@ -372,7 +372,7 @@ build include_1_h: phony $
 # Variant: host
 # Type:    bob_generate_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:3:1
+# Defined: build.bp:redacted
 
 rule m.special-tool_host.gen_special-tool
     pool = console
@@ -408,7 +408,7 @@ build special-tool: phony ${g.bob.BuildDir}/install/testcases/special-tool $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:13:1
+# Defined: nested/build.bp:redacted
 
 rule m.test_config_h_.gen_test_config_h
     command = bash -ec 'mkdir -p $$(dirname ${_out_}); ${tool} -o ${_out_} ${g.bob.SrcDir}/nested/config1.h.in $$(cat ${g.bob.SrcDir}/nested/config1.h.in) SOME_ARG1=foo SOME_ARG2='
@@ -429,7 +429,7 @@ build test_config_h: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:49:1
+# Defined: nested/build.bp:redacted
 
 rule m.test_host_configuration_.gen_test_host_configuration
     command = ${tool} -t ${gen_dir} ${test_config_h_out} ${config_h_out}
@@ -458,7 +458,7 @@ build test_host_configuration: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:35:1
+# Defined: nested/build.bp:redacted
 
 rule m.test_target_configuration_.gen_test_target_configuration
     command = ${tool} -t ${gen_dir} ${test_config_h_out} ${config_h_out}

--- a/tests/gendiffer/example/out/linux/build.ninja.out
+++ b/tests/gendiffer/example/out/linux/build.ninja.out
@@ -52,7 +52,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:23:1
+# Defined: build.bp:redacted
 
 m.hello_world_target.cflags = -Wall -pedantic
 m.hello_world_target.cxxflags = 

--- a/tests/gendiffer/filegroups/out/linux/build.ninja.out
+++ b/tests/gendiffer/filegroups/out/linux/build.ninja.out
@@ -52,7 +52,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:94:1
+# Defined: build.bp:redacted
 
 m.bin_target.cflags = 
 m.bin_target.conlyflags = 
@@ -158,7 +158,7 @@ default bin
 # Variant:
 # Type:    bob_alias
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:106:1
+# Defined: build.bp:redacted
 
 build bob_tests: phony genrule generated_source nested_generated_source $
         transform_source nested_transform_source glob lib bin
@@ -168,7 +168,7 @@ build bob_tests: phony genrule generated_source nested_generated_source $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:33:1
+# Defined: build.bp:redacted
 
 rule m.generated_source_.gen_generated_source
     command = touch ${_out_}
@@ -187,7 +187,7 @@ build generated_source: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:18:1
+# Defined: build.bp:redacted
 
 rule m.genrule_.gen_genrule
     command = touch ${_out_}
@@ -210,7 +210,7 @@ build genrule: phony ${g.bob.BuildDir}/gen/genrule/genrule_dummy01.c $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:82:1
+# Defined: build.bp:redacted
 
 m.lib_target.cflags = 
 m.lib_target.conlyflags = 
@@ -308,7 +308,7 @@ build lib: phony ${g.bob.BuildDir}/target/static/lib.a
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:39:1
+# Defined: build.bp:redacted
 
 rule m.nested_generated_source_.gen_nested_generated_source
     command = touch ${_out_}
@@ -330,7 +330,7 @@ build nested_generated_source: phony $
 # Variant:
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:62:1
+# Defined: build.bp:redacted
 
 rule m.nested_transform_source_.gen_nested_transform_source
     command = some_tool
@@ -368,7 +368,7 @@ build nested_transform_source: phony $
 # Variant:
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:49:1
+# Defined: build.bp:redacted
 
 rule m.transform_source_.gen_transform_source
     command = some_tool

--- a/tests/gendiffer/genhdrs/out/linux/build.ninja.out
+++ b/tests/gendiffer/genhdrs/out/linux/build.ninja.out
@@ -52,7 +52,7 @@ rule g.bootstrap.cp
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:25:1
+# Defined: build.bp:redacted
 
 rule m.generated_header_.gen_generated_header
     command = echo '#define H1 1' > ${_out_}
@@ -70,7 +70,7 @@ build generated_header: phony ${g.bob.BuildDir}/gen/generated_header/h1.h
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:18:1
+# Defined: build.bp:redacted
 
 rule m.generated_header_single_.gen_generated_header_single
     command = echo '#define H2 2' > ${_out_}
@@ -89,7 +89,7 @@ build generated_header_single: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:32:1
+# Defined: build.bp:redacted
 
 m.public_interface_uses_generated_headers_target.cflags = -I${g.bob.BuildDir}/gen/generated_header -I${g.bob.BuildDir}/gen/generated_header_single
 m.public_interface_uses_generated_headers_target.conlyflags = 
@@ -119,7 +119,7 @@ build public_interface_uses_generated_headers: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:47:1
+# Defined: build.bp:redacted
 
 m.reexports_partially_generated_library_target.cflags = -I${g.bob.BuildDir}/gen/generated_header -I${g.bob.BuildDir}/gen/generated_header_single
 m.reexports_partially_generated_library_target.conlyflags = 
@@ -148,7 +148,7 @@ build reexports_partially_generated_library: phony $
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:66:1
+# Defined: build.bp:redacted
 
 m.uses_library_with_private_generated_headers_target.cflags = 
 m.uses_library_with_private_generated_headers_target.conlyflags = 
@@ -183,7 +183,7 @@ default uses_library_with_private_generated_headers
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:41:1
+# Defined: build.bp:redacted
 
 m.uses_partially_generated_library_target.cflags = -I${g.bob.BuildDir}/gen/generated_header -I${g.bob.BuildDir}/gen/generated_header_single
 m.uses_partially_generated_library_target.conlyflags = 
@@ -220,7 +220,7 @@ default uses_partially_generated_library
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:60:1
+# Defined: build.bp:redacted
 
 m.uses_private_generated_headers_target.cflags = -I${g.bob.BuildDir}/gen/generated_header
 m.uses_private_generated_headers_target.conlyflags = 
@@ -247,7 +247,7 @@ build uses_private_generated_headers: phony $
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:54:1
+# Defined: build.bp:redacted
 
 m.uses_reexporting_library_target.cflags = -I${g.bob.BuildDir}/gen/generated_header -I${g.bob.BuildDir}/gen/generated_header_single
 m.uses_reexporting_library_target.conlyflags = 

--- a/tests/gendiffer/genlib/out/linux/build.ninja.out
+++ b/tests/gendiffer/genlib/out/linux/build.ninja.out
@@ -65,7 +65,7 @@ rule g.bootstrap.cp
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:64:1
+# Defined: build.bp:redacted
 
 m.binary_linked_to_gen_shared_host.cflags = -I${g.bob.BuildDir}/gen/libblah_shared/include
 m.binary_linked_to_gen_shared_host.conlyflags = 
@@ -107,7 +107,7 @@ default binary_linked_to_gen_shared
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:92:1
+# Defined: build.bp:redacted
 
 m.binary_linked_to_gen_shared_rename_host.cflags = -I${g.bob.BuildDir}/gen/libblah_shared_rename/include
 m.binary_linked_to_gen_shared_rename_host.conlyflags = 
@@ -145,7 +145,7 @@ default binary_linked_to_gen_shared_rename
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:78:1
+# Defined: build.bp:redacted
 
 m.binary_linked_to_gen_static_host.cflags = -I${g.bob.BuildDir}/gen/libblah_static/include
 m.binary_linked_to_gen_static_host.conlyflags = 
@@ -185,7 +185,7 @@ default binary_linked_to_gen_static
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:83:1
+# Defined: nested/build.bp:redacted
 
 rule m.check_renamed_gen_library_.gen_check_renamed_gen_library
     command = ${tool} --links-to libblah_shared2  ${in} && touch ${_out_}
@@ -208,7 +208,7 @@ default check_renamed_gen_library
 # Variant: host
 # Type:    bob_generate_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:43:1
+# Defined: nested/build.bp:redacted
 
 rule m.generated_binary_host.gen_generated_binary
     command = gcc -fPIE -o ${_out_} ${in}
@@ -235,7 +235,7 @@ default generated_binary
 # Variant: host
 # Type:    bob_generate_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:38:1
+# Defined: build.bp:redacted
 
 rule m.libblah_shared_host.gen_libblah_shared
     command = gcc -fPIC -o ${_out_} -shared ${in}; mkdir -p ${gen_dir}/include; cp ${module_dir}/libblah/libblah.h ${module_dir}/libblah/libblah_feature.h ${gen_dir}/include/.
@@ -273,7 +273,7 @@ build libblah_shared: phony ${g.bob.BuildDir}/gen_sh_lib/libblah_shared.so $
 # Variant: host
 # Type:    bob_generate_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:60:1
+# Defined: nested/build.bp:redacted
 
 rule m.libblah_shared_rename_host.gen_libblah_shared_rename
     command = gcc -fPIC -o ${_out_} -shared ${in}; mkdir -p ${gen_dir}/include; cp ${module_dir}/libblah/libblah.h ${module_dir}/libblah/libblah_feature.h ${gen_dir}/include/.
@@ -309,7 +309,7 @@ build libblah_shared_rename: phony $
 # Variant: host
 # Type:    bob_generate_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:18:1
+# Defined: nested/build.bp:redacted
 
 rule m.libblah_static_host.gen_libblah_static
     command = gcc -c -o ${gen_dir}/libblah.o ${in}; ar rcs ${_out_} ${gen_dir}/libblah.o; mkdir -p ${gen_dir}/include; cp ${module_dir}/libblah/libblah.h ${module_dir}/libblah/libblah_feature.h ${gen_dir}/include/.
@@ -337,7 +337,7 @@ build libblah_static: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:105:1
+# Defined: build.bp:redacted
 
 rule m.shared_library_input_.gen_shared_library_input
     command = ${tool} --links-to libblah_shared2  ${in} && touch ${_out_}

--- a/tests/gendiffer/gensrcs/out/linux/build.ninja.out
+++ b/tests/gendiffer/gensrcs/out/linux/build.ninja.out
@@ -58,7 +58,7 @@ rule g.bootstrap.cp
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:176:1
+# Defined: build.bp:redacted
 
 rule m.gen_source_depfile_.gen_gen_source_depfile
     command = ${tool} -o ${_out_} -d ${depfile} ${in}
@@ -81,7 +81,7 @@ default gen_source_depfile
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:186:1
+# Defined: build.bp:redacted
 
 rule m.gen_source_depfile_with_implicit_outs_.gen_gen_source_depfile_with_implicit_outs
     command = ${tool} --gen-implicit-out -o ${gen_dir}/output.txt -d ${depfile} ${in}
@@ -111,7 +111,7 @@ default gen_source_depfile_with_implicit_outs
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:215:1
+# Defined: build.bp:redacted
 
 rule m.gen_source_globbed_exclude_implicit_sources_.gen_gen_source_globbed_exclude_implicit_sources
     command = python ${tool} --src-dir ${module_dir} --use-c --out ${_out_}
@@ -136,7 +136,7 @@ default gen_source_globbed_exclude_implicit_sources
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:206:1
+# Defined: build.bp:redacted
 
 rule m.gen_source_globbed_implicit_sources_.gen_gen_source_globbed_implicit_sources
     command = python ${tool} --src-dir ${module_dir} --use-a --out ${_out_}
@@ -161,7 +161,7 @@ default gen_source_globbed_implicit_sources
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:257:1
+# Defined: build.bp:redacted
 
 rule m.generate_feature_command_.gen_generate_feature_command
     command = python3 ${tool_1} --in ${in} --out ${_out_} --config linux_config_name
@@ -183,7 +183,7 @@ default generate_feature_command
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:39:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_multiple_in_.gen_generate_source_multiple_in
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in before_generate2.in before_generate3.in
@@ -206,7 +206,7 @@ build generate_source_multiple_in: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:69:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_multiple_in_out_.gen_generate_source_multiple_in_out
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in before_generate2.in before_generate3.in
@@ -232,7 +232,7 @@ build generate_source_multiple_in_out: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:54:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_multiple_out_.gen_generate_source_multiple_out
     command = python ${tool} --in ${in} --out ${_out_} --depfile ${depfile} --config ${bob_config} --out-src ${gen_dir}/common.cpp --expect-in before_generate.in
@@ -262,7 +262,7 @@ build generate_source_multiple_out: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:18:1
+# Defined: nested/build.bp:redacted
 
 rule m.generate_source_single_.gen_generate_source_single
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in
@@ -284,7 +284,7 @@ build generate_source_single: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:128:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_single_dependend_.gen_generate_source_single_dependend
     command = python ${tool} --in ${in} ${generate_source_single_out} --out ${_out_} --expect-in before_generate.in single.cpp
@@ -308,7 +308,7 @@ build generate_source_single_dependend: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:141:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_single_dependend_nested_.gen_generate_source_single_dependend_nested
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in deps.cpp
@@ -331,7 +331,7 @@ build generate_source_single_dependend_nested: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:85:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_single_level1_.gen_generate_source_single_level1
     command = python ${tool} --in ${in} --out ${_out_} --expect-in single.cpp
@@ -353,7 +353,7 @@ build generate_source_single_level1: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:95:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_single_level2_.gen_generate_source_single_level2
     command = python ${tool} --in ${in} --out ${_out_} --expect-in level_1_single.cpp
@@ -375,7 +375,7 @@ build generate_source_single_level2: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:105:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_single_level3_.gen_generate_source_single_level3
     command = python ${tool} --in ${in} --out ${_out_} --expect-in level_2_single.cpp
@@ -397,7 +397,7 @@ build generate_source_single_level3: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:115:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_single_nested_with_extra_.gen_generate_source_single_nested_with_extra
     command = python ${tool} --in ${in} --out ${_out_} --expect-in before_generate.in level_2_single.cpp
@@ -422,7 +422,7 @@ build generate_source_single_nested_with_extra: phony $
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:237:1
+# Defined: build.bp:redacted
 
 m.host_and_target_supported_binary_host.cflags = 
 m.host_and_target_supported_binary_host.conlyflags = 
@@ -453,7 +453,7 @@ default host_and_target_supported_binary__host
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:237:1
+# Defined: build.bp:redacted
 
 m.host_and_target_supported_binary_target.cflags = 
 m.host_and_target_supported_binary_target.conlyflags = 
@@ -486,7 +486,7 @@ default host_and_target_supported_binary__target
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:29:1
+# Defined: nested/build.bp:redacted
 
 rule m.multiple_tools_generate_sources_.gen_multiple_tools_generate_sources
     command = python ${tool_1} --in ${in} --out ${_out_} && python ${tool_2} --in ${_out_}
@@ -514,7 +514,7 @@ default multiple_tools_generate_sources
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:228:1
+# Defined: build.bp:redacted
 
 m.use_miscellaneous_generated_source_tests_target.cflags = 
 m.use_miscellaneous_generated_source_tests_target.conlyflags = 
@@ -559,7 +559,7 @@ default use_miscellaneous_generated_source_tests
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:249:1
+# Defined: build.bp:redacted
 
 rule m.use_target_specific_library_.gen_use_target_specific_library
     command = test $$(basename ${host_and_target_supported_binary_out}) = host_binary && cp ${host_and_target_supported_binary_out} ${_out_}
@@ -581,7 +581,7 @@ default use_target_specific_library
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:199:1
+# Defined: build.bp:redacted
 
 rule m.validate_install_generate_sources_.gen_validate_install_generate_sources
     command = touch ${_out_}
@@ -603,7 +603,7 @@ default validate_install_generate_sources
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:154:1
+# Defined: build.bp:redacted
 
 m.validate_link_generate_sources_target.cflags = 
 m.validate_link_generate_sources_target.cxxflags = 

--- a/tests/gendiffer/gensrcs_new/out/linux/build.ninja.out
+++ b/tests/gendiffer/gensrcs_new/out/linux/build.ninja.out
@@ -58,7 +58,7 @@ rule g.bootstrap.cp
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:168:1
+# Defined: build.bp:redacted
 
 rule m.exclude_support_.gen_exclude_support
     command = touch ${_out_}
@@ -79,7 +79,7 @@ build exclude_support: phony ${g.bob.BuildDir}/gen/exclude_support/input1.out $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:62:1
+# Defined: nested/build.bp:redacted
 
 rule m.gen_source_depfile_new_.gen_gen_source_depfile_new
     command = ${tool_1} -o ${_out_} -d ${depfile} --in ${in}
@@ -102,7 +102,7 @@ build gen_source_depfile_new: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:74:1
+# Defined: nested/build.bp:redacted
 
 rule m.gen_source_depfile_with_implicit_outs_new_.gen_gen_source_depfile_with_implicit_outs_new
     command = ${tool_1} --gen-implicit-out -o ${genDir}/output.txt -d ${depfile} --in ${in}
@@ -134,7 +134,7 @@ build gen_source_depfile_with_implicit_outs_new: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:183:1
+# Defined: build.bp:redacted
 
 rule m.generate_feature_command_new_.gen_generate_feature_command_new
     command = python3 ${tool_1} --in ${in} --out ${_out_} --config linux_config_name
@@ -156,7 +156,7 @@ default generate_feature_command_new
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:18:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_multiple_in_new_.gen_generate_source_multiple_in_new
     command = python ${tool_1} --in ${in} --out ${_out_} --expect-in before_generate.in before_generate2.in before_generate3.in
@@ -178,7 +178,7 @@ build generate_source_multiple_in_new: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:46:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_multiple_in_out_new_.gen_generate_source_multiple_in_out_new
     command = python ${tool_1} --in ${in} --out ${_out_} --expect-in before_generate.in before_generate2.in before_generate3.in
@@ -204,7 +204,7 @@ build generate_source_multiple_in_out_new: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:31:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_multiple_out_new_.gen_generate_source_multiple_out_new
     command = python ${tool_1} --in ${in} --out ${_out_} --config ${bob_config} --depfile ${depfile} --out-src ${genDir}/mali_config.cpp --expect-in before_generate.in ${bob_config_opts}
@@ -235,7 +235,7 @@ build generate_source_multiple_out_new: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:116:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_single_dependend_nested_new_.gen_generate_source_single_dependend_nested_new
     command = python ${tool_1} --in ${in} --out ${_out_} --expect-in before_generate.in deps.cpp
@@ -261,7 +261,7 @@ build generate_source_single_dependend_nested_new: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:104:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_single_dependend_new_.gen_generate_source_single_dependend_new
     command = python ${tool_1} --in ${in} --out ${_out_} --expect-in before_generate.in single.cpp
@@ -285,7 +285,7 @@ build generate_source_single_dependend_new: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:62:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_single_level1_new_.gen_generate_source_single_level1_new
     command = python ${tool_1} --in ${in} --out ${_out_} --expect-in single.cpp
@@ -310,7 +310,7 @@ build generate_source_single_level1_new: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:72:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_single_level2_new_.gen_generate_source_single_level2_new
     command = python ${tool_1} --in ${in} --out ${_out_} --expect-in level_1_single.cpp
@@ -336,7 +336,7 @@ build generate_source_single_level2_new: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:82:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_single_level3_new_.gen_generate_source_single_level3_new
     command = python ${tool_1} --in ${in} --out ${_out_} --expect-in level_2_single.cpp
@@ -362,7 +362,7 @@ build generate_source_single_level3_new: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:92:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_single_nested_with_extra_new_.gen_generate_source_single_nested_with_extra_new
     command = python ${tool_1} --in ${in} --out ${_out_} --expect-in before_generate.in level_2_single.cpp
@@ -389,7 +389,7 @@ build generate_source_single_nested_with_extra_new: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:18:1
+# Defined: nested/build.bp:redacted
 
 rule m.generate_source_single_new_.gen_generate_source_single_new
     command = python ${tool_1} --in ${in} --out ${_out_} --expect-in before_generate.in
@@ -411,7 +411,7 @@ build generate_source_single_new: phony $
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:29:1
+# Defined: nested/build.bp:redacted
 
 m.host_and_target_supported_binary_new_host.cflags = 
 m.host_and_target_supported_binary_new_host.conlyflags = 
@@ -442,7 +442,7 @@ default host_and_target_supported_binary_new__host
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:29:1
+# Defined: nested/build.bp:redacted
 
 m.host_and_target_supported_binary_new_target.cflags = 
 m.host_and_target_supported_binary_new_target.conlyflags = 
@@ -475,7 +475,7 @@ default host_and_target_supported_binary_new__target
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:156:1
+# Defined: build.bp:redacted
 
 rule m.multi_src_tag_.gen_multi_src_tag
     command = python ${tool_1} --in ${in} --out ${_out_} --expect-in before_generate.in ${generate_source_single_new_out}
@@ -498,7 +498,7 @@ build multi_src_tag: phony ${g.bob.BuildDir}/gen/multi_src_tag/deps.cpp
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:47:1
+# Defined: nested/build.bp:redacted
 
 rule m.multi_tool_file_.gen_multi_tool_file
     command = ${tool_1} --gen-implicit-out -o ${genDir}/output.txt -d ${depfile} --in ${tool_2} ${in}
@@ -528,7 +528,7 @@ build multi_tool_file: phony ${g.bob.BuildDir}/gen/multi_tool_file/output.txt $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:40:1
+# Defined: nested/build.bp:redacted
 
 rule m.use_target_specific_library_new_.gen_use_target_specific_library_new
     command = LD_LIBRARY_PATH=${g.bob.BuildDir}/host/shared:$$LD_LIBRARY_PATH test $$(basename ${host_bin}) = host_binary_new && cp ${host_bin} ${_out_}
@@ -549,7 +549,7 @@ build use_target_specific_library_new: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:150:1
+# Defined: build.bp:redacted
 
 rule m.validate_install_generate_sources_new_.gen_validate_install_generate_sources_new
     command = touch ${_out_}
@@ -570,7 +570,7 @@ build validate_install_generate_sources_new: phony $
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:128:1
+# Defined: build.bp:redacted
 
 m.validate_link_generate_sources_new_target.cflags = 
 m.validate_link_generate_sources_new_target.cxxflags = 

--- a/tests/gendiffer/gensrcs_new_tool_files_dep/out/linux/build.ninja.out
+++ b/tests/gendiffer/gensrcs_new_tool_files_dep/out/linux/build.ninja.out
@@ -48,7 +48,7 @@ rule g.bootstrap.cp
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:18:1
+# Defined: build.bp:redacted
 
 rule m.generate_config_.gen_generate_config
     command = python ${tool_1} --in ${in} --out ${_out_} --expect-in before_generate.in
@@ -69,7 +69,7 @@ build generate_config: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:29:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_colon_dep_.gen_generate_source_colon_dep
     command = python ${tool_1} --in ${in} --json ${tool_2} --out ${_out_} --expect-in before_generate.in
@@ -95,7 +95,7 @@ build generate_source_colon_dep: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:61:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_multiple_colon_dep_.gen_generate_source_multiple_colon_dep
     command = python ${tool_1} --in ${in} --tools ${tool_2} --out ${_out_} --expect-in before_generate.in
@@ -122,7 +122,7 @@ build generate_source_multiple_colon_dep: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:45:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_out_dep_.gen_generate_source_out_dep
     command = python ${tool_1} --in ${in} --json ${generate_config_out} --out ${_out_} --expect-in before_generate.in
@@ -148,7 +148,7 @@ build generate_source_out_dep: phony $
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:77:1
+# Defined: build.bp:redacted
 
 m.validate_link_generate_sources_new_target.cflags = 
 m.validate_link_generate_sources_new_target.cxxflags = 

--- a/tests/gendiffer/globs/out/linux/build.ninja.out
+++ b/tests/gendiffer/globs/out/linux/build.ninja.out
@@ -54,7 +54,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:24:1
+# Defined: build.bp:redacted
 
 m.glob_test_target.cflags = 
 m.glob_test_target.conlyflags = 
@@ -116,7 +116,7 @@ default glob_test
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:34:1
+# Defined: build.bp:redacted
 
 m.glob_test_exclude_target.cflags = 
 m.glob_test_exclude_target.cxxflags = 
@@ -157,7 +157,7 @@ default glob_test_exclude
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:29:1
+# Defined: build.bp:redacted
 
 m.glob_test_nested_target.cflags = 
 m.glob_test_nested_target.conlyflags = 
@@ -221,7 +221,7 @@ default glob_test_nested
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: module/build.bp:23:1
+# Defined: module/build.bp:redacted
 
 m.nested_glob_test_target.cflags = 
 m.nested_glob_test_target.conlyflags = 
@@ -285,7 +285,7 @@ default nested_glob_test
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: module/build.bp:28:1
+# Defined: module/build.bp:redacted
 
 m.nested_glob_test_exclude_target.cflags = 
 m.nested_glob_test_exclude_target.cxxflags = 
@@ -327,7 +327,7 @@ default nested_glob_test_exclude
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: module/build.bp:44:1
+# Defined: module/build.bp:redacted
 
 m.nested_test_exclude_srcs_target.cflags = 
 m.nested_test_exclude_srcs_target.cxxflags = 
@@ -369,7 +369,7 @@ default nested_test_exclude_srcs
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:51:1
+# Defined: build.bp:redacted
 
 m.test_exclude_srcs_target.cflags = 
 m.test_exclude_srcs_target.cxxflags = 

--- a/tests/gendiffer/installdeps/out/linux/build.ninja.out
+++ b/tests/gendiffer/installdeps/out/linux/build.ninja.out
@@ -56,7 +56,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:32:1
+# Defined: nested/build.bp:redacted
 
 m.bob_test_install_deps_target.cflags = 
 m.bob_test_install_deps_target.conlyflags = 
@@ -94,7 +94,7 @@ default bob_test_install_deps
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:18:1
+# Defined: nested/build.bp:redacted
 
 m.bob_test_install_deps_binary_target.cflags = 
 m.bob_test_install_deps_binary_target.conlyflags = 
@@ -131,7 +131,7 @@ build bob_test_install_deps_binary: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:11:1
+# Defined: nested/build.bp:redacted
 
 m.bob_test_install_deps_library_target.cflags = 
 m.bob_test_install_deps_library_target.conlyflags = 
@@ -163,7 +163,7 @@ build bob_test_install_deps_library: phony $
 # Variant:
 # Type:    bob_resource
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:25:1
+# Defined: nested/build.bp:redacted
 
 build ${g.bob.BuildDir}/data/resources/bob_test_install_deps_resource.txt: $
         g.bob.install $

--- a/tests/gendiffer/kmod/out/linux/build.ninja.out
+++ b/tests/gendiffer/kmod/out/linux/build.ninja.out
@@ -48,7 +48,7 @@ rule g.bootstrap.cp
 # Variant:
 # Type:    bob_kernel_module
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:28:1
+# Defined: build.bp:redacted
 
 build ${g.bob.BuildDir}/target/kernel_modules/test_module1/test_module1.ko: $
         g.bob.kbuild ${g.bob.SrcDir}/Kbuild ${g.bob.SrcDir}/test_module1.c | $
@@ -81,7 +81,7 @@ default test_module1
 # Variant:
 # Type:    bob_kernel_module
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:47:1
+# Defined: build.bp:redacted
 
 build ${g.bob.BuildDir}/target/kernel_modules/test_module2/test_module2.ko: $
         g.bob.kbuild ${g.bob.SrcDir}/Kbuild ${g.bob.SrcDir}/test_module2.c $

--- a/tests/gendiffer/ldlibs_export/out/linux/build.ninja.out
+++ b/tests/gendiffer/ldlibs_export/out/linux/build.ninja.out
@@ -66,7 +66,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:51:1
+# Defined: build.bp:redacted
 
 m.binary_has_indirect_ldlibs_target.cflags = 
 m.binary_has_indirect_ldlibs_target.conlyflags = 
@@ -100,7 +100,7 @@ default binary_has_indirect_ldlibs
 # Variant: target
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:45:1
+# Defined: build.bp:redacted
 
 m.libshared_has_indirect_ldlibs_target.cflags = 
 m.libshared_has_indirect_ldlibs_target.conlyflags = 
@@ -139,7 +139,7 @@ build libshared_has_indirect_ldlibs: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:18:1
+# Defined: build.bp:redacted
 
 m.libstatic_with_ldlibs1_target.cflags = 
 m.libstatic_with_ldlibs1_target.conlyflags = 
@@ -165,7 +165,7 @@ build libstatic_with_ldlibs1: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:31:1
+# Defined: build.bp:redacted
 
 m.libstatic_with_ldlibs2_target.cflags = 
 m.libstatic_with_ldlibs2_target.conlyflags = 
@@ -191,7 +191,7 @@ build libstatic_with_ldlibs2: phony $
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:57:1
+# Defined: build.bp:redacted
 
 m.uses_shared_target.cflags = 
 m.uses_shared_target.conlyflags = 

--- a/tests/gendiffer/libraries/app/build.bp
+++ b/tests/gendiffer/libraries/app/build.bp
@@ -419,6 +419,7 @@ bob_library {
     srcs: ["src/libs/lib.cpp"],
     hdrs: ["src/libs/lib.h"],
     local_defines: ["LOCAL_DEFINE"],
+    includes: ["internal/include"],
     defines: ["FORWARDED_DEFINE"],
 }
 

--- a/tests/gendiffer/libraries/out/android/Android.bp.out
+++ b/tests/gendiffer/libraries/out/android/Android.bp.out
@@ -64,6 +64,8 @@ cc_library_host_static {
         "-DLOCAL_DEFINE",
         "-DFORWARDED_DEFINE",
     ],
+    local_include_dirs: ["internal/include"],
+    export_system_include_dirs : ["internal/include"],
 }
 
 cc_library_host_static {

--- a/tests/gendiffer/libraries/out/linux/build.ninja.out
+++ b/tests/gendiffer/libraries/out/linux/build.ninja.out
@@ -92,7 +92,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:481:1
+# Defined: build.bp:redacted
 
 m.bob_test_local_consumer_target.cflags = -Wconversion -Werror -isystem ${g.bob.SrcDir}/public
 m.bob_test_local_consumer_target.conlyflags = 
@@ -126,7 +126,7 @@ default bob_test_local_consumer
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:471:1
+# Defined: build.bp:redacted
 
 m.bob_test_local_libconsumer_target.cflags = -Wconversion -Werror -isystem ${g.bob.SrcDir}/public
 m.bob_test_local_libconsumer_target.conlyflags = 
@@ -156,7 +156,7 @@ build bob_test_local_libconsumer: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:452:1
+# Defined: build.bp:redacted
 
 m.bob_test_local_libpublic_target.cflags = -Wconversion -I${g.bob.SrcDir}/include -I${g.bob.SrcDir}/public
 m.bob_test_local_libpublic_target.conlyflags = 
@@ -183,7 +183,7 @@ build bob_test_local_libpublic: phony $
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:514:1
+# Defined: build.bp:redacted
 
 m.bob_test_target_specific_link_host.cflags = 
 m.bob_test_target_specific_link_host.conlyflags = 
@@ -216,7 +216,7 @@ default bob_test_target_specific_link__host
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:514:1
+# Defined: build.bp:redacted
 
 m.bob_test_target_specific_link_target.cflags = 
 m.bob_test_target_specific_link_target.conlyflags = 
@@ -250,7 +250,7 @@ default bob_test_target_specific_link__target
 # Variant: host
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:62:1
+# Defined: build.bp:redacted
 
 rule m.gen_output_host.gen_gen_output
     command = LD_LIBRARY_PATH=${g.bob.BuildDir}/host/shared:$$LD_LIBRARY_PATH ${tool} -u ${host_bin} -i ${in} -o ${_out_}
@@ -283,7 +283,7 @@ build gen_output: phony ${g.bob.BuildDir}/gen/gen_output/input_one.gen $
 # Variant: host
 # Type:    bob_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:426:1
+# Defined: build.bp:redacted
 
 build ${g.bob.BuildDir}/host/static/lib_dep.a: g.bob.static_library
     ar = ar
@@ -297,7 +297,7 @@ default lib_dep
 # Variant: host
 # Type:    bob_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:417:1
+# Defined: build.bp:redacted
 
 m.lib_forward_defines_host.cflags = -DLOCAL_DEFINE -DFORWARDED_DEFINE -Iinternal/include
 m.lib_forward_defines_host.cxxflags = 
@@ -323,7 +323,7 @@ build lib_forward_defines: phony $
 # Variant: host
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:400:1
+# Defined: build.bp:redacted
 
 build ${g.bob.BuildDir}/host/static/lib_transitive_define.a: $
         g.bob.static_library
@@ -339,7 +339,7 @@ default lib_transitive_define
 # Variant: host
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:491:1
+# Defined: build.bp:redacted
 
 m.libonly_works_on_target_host.cflags = -DFAIL=1
 m.libonly_works_on_target_host.conlyflags = 
@@ -366,7 +366,7 @@ build libonly_works_on_target__host: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:491:1
+# Defined: build.bp:redacted
 
 m.libonly_works_on_target_target.cflags = -DFAIL=0
 m.libonly_works_on_target_target.conlyflags = 
@@ -393,7 +393,7 @@ build libonly_works_on_target__target: phony $
 # Variant: host
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:38:1
+# Defined: build.bp:redacted
 
 m.libsharedtest_host.cflags = -fPIC
 m.libsharedtest_host.conlyflags = 
@@ -439,7 +439,7 @@ build libsharedtest__host: phony $
 # Variant: target
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:38:1
+# Defined: build.bp:redacted
 
 m.libsharedtest_target.cflags = -fPIC
 m.libsharedtest_target.conlyflags = 
@@ -485,7 +485,7 @@ build libsharedtest__target: phony $
 # Variant: host
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:78:1
+# Defined: build.bp:redacted
 
 m.libsharedtest_installed_host.cflags = -DFUNC_NAME=sharedtest_installed
 m.libsharedtest_installed_host.conlyflags = 
@@ -526,7 +526,7 @@ build libsharedtest_installed__host: phony $
 # Variant: target
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:78:1
+# Defined: build.bp:redacted
 
 m.libsharedtest_installed_target.cflags = -DFUNC_NAME=sharedtest_installed
 m.libsharedtest_installed_target.conlyflags = 
@@ -567,7 +567,7 @@ build libsharedtest_installed__target: phony $
 # Variant: host
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:97:1
+# Defined: build.bp:redacted
 
 m.libsharedtest_not_installed_host.cflags = -DFUNC_NAME=sharedtest_not_installed
 m.libsharedtest_not_installed_host.conlyflags = 
@@ -604,7 +604,7 @@ build libsharedtest_not_installed__host: phony $
 # Variant: target
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:97:1
+# Defined: build.bp:redacted
 
 m.libsharedtest_not_installed_target.cflags = -DFUNC_NAME=sharedtest_not_installed
 m.libsharedtest_not_installed_target.conlyflags = 
@@ -641,7 +641,7 @@ build libsharedtest_not_installed__target: phony $
 # Variant: target
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:132:1
+# Defined: build.bp:redacted
 
 m.libstripped_library_target.cflags = -DFUNC_NAME=func
 m.libstripped_library_target.conlyflags = 
@@ -686,7 +686,7 @@ build libstripped_library: phony $
 # Variant: host
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:504:1
+# Defined: build.bp:redacted
 
 m.libuses_target_specific_link_host.cflags = 
 m.libuses_target_specific_link_host.conlyflags = 
@@ -712,7 +712,7 @@ build libuses_target_specific_link__host: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:504:1
+# Defined: build.bp:redacted
 
 m.libuses_target_specific_link_target.cflags = 
 m.libuses_target_specific_link_target.conlyflags = 
@@ -738,7 +738,7 @@ build libuses_target_specific_link__target: phony $
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:107:1
+# Defined: build.bp:redacted
 
 m.sharedtest_host.cflags = 
 m.sharedtest_host.conlyflags = 
@@ -771,7 +771,7 @@ build sharedtest__host: phony ${g.bob.BuildDir}/host/executable/sharedtest
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:107:1
+# Defined: build.bp:redacted
 
 m.sharedtest_target.cflags = 
 m.sharedtest_target.conlyflags = 
@@ -805,7 +805,7 @@ default sharedtest__target
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:184:1
+# Defined: build.bp:redacted
 
 m.sl_liba_target.cflags = -fPIC -DFOO=1
 m.sl_liba_target.conlyflags = 
@@ -829,7 +829,7 @@ build sl_liba: phony ${g.bob.BuildDir}/target/static/sl_liba.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:375:1
+# Defined: build.bp:redacted
 
 m.sl_liba_duplicates_target.cflags = -DFOO=1
 m.sl_liba_duplicates_target.conlyflags = 
@@ -863,7 +863,7 @@ build sl_liba_duplicates: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:384:1
+# Defined: build.bp:redacted
 
 build ${g.bob.BuildDir}/target/static/sl_liba_duplicates_2.a: $
         g.bob.whole_static_library | ${g.bob.whole_static_tool} $
@@ -880,7 +880,7 @@ build sl_liba_duplicates_2: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:209:1
+# Defined: build.bp:redacted
 
 m.sl_libb_target.cflags = -fPIC -DFOO=1
 m.sl_libb_target.conlyflags = 
@@ -904,7 +904,7 @@ build sl_libb: phony ${g.bob.BuildDir}/target/static/sl_libb.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:257:1
+# Defined: build.bp:redacted
 
 m.sl_libb_export_static_target.cflags = -DFOO=1
 m.sl_libb_export_static_target.conlyflags = 
@@ -930,7 +930,7 @@ build sl_libb_export_static: phony $
 # Variant: target
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:238:1
+# Defined: build.bp:redacted
 
 build ${g.bob.BuildDir}/target/shared/sl_libb_shared.so: g.bob.shared_library $
         | ${g.bob.BuildDir}/target/static/sl_libb.a $
@@ -955,7 +955,7 @@ build sl_libb_shared: phony ${g.bob.BuildDir}/target/shared/sl_libb_shared.so
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:193:1
+# Defined: build.bp:redacted
 
 m.sl_libb_whole_inclusion_target.cflags = -fPIC -DFOO=1
 m.sl_libb_whole_inclusion_target.conlyflags = 
@@ -983,7 +983,7 @@ build sl_libb_whole_inclusion: phony $
 # Variant: target
 # Type:    bob_shared_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:226:1
+# Defined: build.bp:redacted
 
 build ${g.bob.BuildDir}/target/shared/sl_libb_whole_shared.so: $
         g.bob.shared_library | $
@@ -1009,7 +1009,7 @@ build sl_libb_whole_shared: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:291:1
+# Defined: build.bp:redacted
 
 m.sl_libc_target.cflags = -DFUNCTION=do_c -DCALL1=do_e1 -DCALL2=do_f
 m.sl_libc_target.conlyflags = 
@@ -1033,7 +1033,7 @@ build sl_libc: phony ${g.bob.BuildDir}/target/static/sl_libc.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:305:1
+# Defined: build.bp:redacted
 
 m.sl_libd_target.cflags = -DFUNCTION=do_d -DCALL1=do_g1 -DCALL2=do_h
 m.sl_libd_target.conlyflags = 
@@ -1057,7 +1057,7 @@ build sl_libd: phony ${g.bob.BuildDir}/target/static/sl_libd.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:339:1
+# Defined: build.bp:redacted
 
 m.sl_libe_target.cflags = -DFUNCTION=do_e
 m.sl_libe_target.conlyflags = 
@@ -1081,7 +1081,7 @@ build sl_libe: phony ${g.bob.BuildDir}/target/static/sl_libe.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:319:1
+# Defined: build.bp:redacted
 
 m.sl_libf_target.cflags = -DFUNCTION=do_f -DCALL=do_g2
 m.sl_libf_target.conlyflags = 
@@ -1105,7 +1105,7 @@ build sl_libf: phony ${g.bob.BuildDir}/target/static/sl_libf.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:347:1
+# Defined: build.bp:redacted
 
 m.sl_libg_target.cflags = -DFUNCTION=do_g
 m.sl_libg_target.conlyflags = 
@@ -1129,7 +1129,7 @@ build sl_libg: phony ${g.bob.BuildDir}/target/static/sl_libg.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:329:1
+# Defined: build.bp:redacted
 
 m.sl_libh_target.cflags = -DFUNCTION=do_h -DCALL=do_e2
 m.sl_libh_target.conlyflags = 
@@ -1153,7 +1153,7 @@ build sl_libh: phony ${g.bob.BuildDir}/target/static/sl_libh.a
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:355:1
+# Defined: build.bp:redacted
 
 m.sl_main_dd_target.cflags = 
 m.sl_main_dd_target.conlyflags = 
@@ -1189,7 +1189,7 @@ default sl_main_dd
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:389:1
+# Defined: build.bp:redacted
 
 m.sl_main_duplicates_target.cflags = -DFOO=1
 m.sl_main_duplicates_target.conlyflags = 
@@ -1221,7 +1221,7 @@ default sl_main_duplicates
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:263:1
+# Defined: build.bp:redacted
 
 m.sl_main_export_static_target.cflags = -DFOO=1
 m.sl_main_export_static_target.conlyflags = 
@@ -1255,7 +1255,7 @@ default sl_main_export_static
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:270:1
+# Defined: build.bp:redacted
 
 m.sl_main_ordered_target.cflags = -DFOO=1
 m.sl_main_ordered_target.conlyflags = 
@@ -1288,7 +1288,7 @@ default sl_main_ordered
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:251:1
+# Defined: build.bp:redacted
 
 m.sl_main_whole_target.cflags = 
 m.sl_main_whole_target.conlyflags = 
@@ -1319,7 +1319,7 @@ default sl_main_whole
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:443:1
+# Defined: build.bp:redacted
 
 m.strict_lib_binary_with_dep_host.cflags = -DFORWARDED_DEFINE -isystem internal/include
 m.strict_lib_binary_with_dep_host.cxxflags = 
@@ -1354,7 +1354,7 @@ default strict_lib_binary_with_dep
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:434:1
+# Defined: build.bp:redacted
 
 m.strict_lib_binary_with_forward_define_host.cflags = -DFORWARDED_DEFINE -isystem internal/include
 m.strict_lib_binary_with_forward_define_host.cxxflags = 
@@ -1388,7 +1388,7 @@ default strict_lib_binary_with_forward_define
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:408:1
+# Defined: build.bp:redacted
 
 m.strict_lib_binary_with_transitive_define_host.cflags = -DFORWARDED_DEFINE -isystem internal/include
 m.strict_lib_binary_with_transitive_define_host.cxxflags = 
@@ -1424,7 +1424,7 @@ default strict_lib_binary_with_transitive_define
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:145:1
+# Defined: build.bp:redacted
 
 m.stripped_binary_target.cflags = -DFUNC_NAME=main
 m.stripped_binary_target.conlyflags = 
@@ -1465,7 +1465,7 @@ default stripped_binary
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:120:1
+# Defined: build.bp:redacted
 
 rule m.use_sharedtest_host_.gen_use_sharedtest_host
     command = LD_LIBRARY_PATH=${g.bob.BuildDir}/host/shared:$$LD_LIBRARY_PATH ${host_bin} ${_out_}
@@ -1488,7 +1488,7 @@ build use_sharedtest_host: phony $
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:127:1
+# Defined: build.bp:redacted
 
 m.use_sharedtest_host_gen_source_target.cflags = 
 m.use_sharedtest_host_gen_source_target.conlyflags = 
@@ -1522,7 +1522,7 @@ default use_sharedtest_host_gen_source
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:52:1
+# Defined: build.bp:redacted
 
 m.utility_host.cflags = 
 m.utility_host.conlyflags = 
@@ -1553,7 +1553,7 @@ build utility__host: phony ${g.bob.BuildDir}/host/executable/utility
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:52:1
+# Defined: build.bp:redacted
 
 m.utility_target.cflags = 
 m.utility_target.conlyflags = 

--- a/tests/gendiffer/libraries/out/linux/build.ninja.out
+++ b/tests/gendiffer/libraries/out/linux/build.ninja.out
@@ -92,7 +92,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:480:1
+# Defined: build.bp:481:1
 
 m.bob_test_local_consumer_target.cflags = -Wconversion -Werror -isystem ${g.bob.SrcDir}/public
 m.bob_test_local_consumer_target.conlyflags = 
@@ -126,7 +126,7 @@ default bob_test_local_consumer
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:470:1
+# Defined: build.bp:471:1
 
 m.bob_test_local_libconsumer_target.cflags = -Wconversion -Werror -isystem ${g.bob.SrcDir}/public
 m.bob_test_local_libconsumer_target.conlyflags = 
@@ -156,7 +156,7 @@ build bob_test_local_libconsumer: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:451:1
+# Defined: build.bp:452:1
 
 m.bob_test_local_libpublic_target.cflags = -Wconversion -I${g.bob.SrcDir}/include -I${g.bob.SrcDir}/public
 m.bob_test_local_libpublic_target.conlyflags = 
@@ -183,7 +183,7 @@ build bob_test_local_libpublic: phony $
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:513:1
+# Defined: build.bp:514:1
 
 m.bob_test_target_specific_link_host.cflags = 
 m.bob_test_target_specific_link_host.conlyflags = 
@@ -216,7 +216,7 @@ default bob_test_target_specific_link__host
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:513:1
+# Defined: build.bp:514:1
 
 m.bob_test_target_specific_link_target.cflags = 
 m.bob_test_target_specific_link_target.conlyflags = 
@@ -283,7 +283,7 @@ build gen_output: phony ${g.bob.BuildDir}/gen/gen_output/input_one.gen $
 # Variant: host
 # Type:    bob_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:425:1
+# Defined: build.bp:426:1
 
 build ${g.bob.BuildDir}/host/static/lib_dep.a: g.bob.static_library
     ar = ar
@@ -299,7 +299,7 @@ default lib_dep
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
 # Defined: build.bp:417:1
 
-m.lib_forward_defines_host.cflags = -DLOCAL_DEFINE -DFORWARDED_DEFINE
+m.lib_forward_defines_host.cflags = -DLOCAL_DEFINE -DFORWARDED_DEFINE -Iinternal/include
 m.lib_forward_defines_host.cxxflags = 
 
 build ${g.bob.BuildDir}/host/objects/lib_forward_defines/src/libs/lib.cpp.o: $
@@ -339,7 +339,7 @@ default lib_transitive_define
 # Variant: host
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:490:1
+# Defined: build.bp:491:1
 
 m.libonly_works_on_target_host.cflags = -DFAIL=1
 m.libonly_works_on_target_host.conlyflags = 
@@ -366,7 +366,7 @@ build libonly_works_on_target__host: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:490:1
+# Defined: build.bp:491:1
 
 m.libonly_works_on_target_target.cflags = -DFAIL=0
 m.libonly_works_on_target_target.conlyflags = 
@@ -686,7 +686,7 @@ build libstripped_library: phony $
 # Variant: host
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:503:1
+# Defined: build.bp:504:1
 
 m.libuses_target_specific_link_host.cflags = 
 m.libuses_target_specific_link_host.conlyflags = 
@@ -712,7 +712,7 @@ build libuses_target_specific_link__host: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:503:1
+# Defined: build.bp:504:1
 
 m.libuses_target_specific_link_target.cflags = 
 m.libuses_target_specific_link_target.conlyflags = 
@@ -1319,9 +1319,9 @@ default sl_main_whole
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:442:1
+# Defined: build.bp:443:1
 
-m.strict_lib_binary_with_dep_host.cflags = -DFORWARDED_DEFINE
+m.strict_lib_binary_with_dep_host.cflags = -DFORWARDED_DEFINE -isystem internal/include
 m.strict_lib_binary_with_dep_host.cxxflags = 
 
 build $
@@ -1354,9 +1354,9 @@ default strict_lib_binary_with_dep
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:433:1
+# Defined: build.bp:434:1
 
-m.strict_lib_binary_with_forward_define_host.cflags = -DFORWARDED_DEFINE
+m.strict_lib_binary_with_forward_define_host.cflags = -DFORWARDED_DEFINE -isystem internal/include
 m.strict_lib_binary_with_forward_define_host.cxxflags = 
 
 build $
@@ -1390,7 +1390,7 @@ default strict_lib_binary_with_forward_define
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
 # Defined: build.bp:408:1
 
-m.strict_lib_binary_with_transitive_define_host.cflags = -DFORWARDED_DEFINE
+m.strict_lib_binary_with_transitive_define_host.cflags = -DFORWARDED_DEFINE -isystem internal/include
 m.strict_lib_binary_with_transitive_define_host.cxxflags = 
 
 build $

--- a/tests/gendiffer/matchsrcs/out/linux/build.ninja.out
+++ b/tests/gendiffer/matchsrcs/out/linux/build.ninja.out
@@ -54,7 +54,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:28:1
+# Defined: build.bp:redacted
 
 m.match_source_bin_target.cflags = -include ${g.bob.SrcDir}/cflags.h
 m.match_source_bin_target.conlyflags = -include ${g.bob.SrcDir}/conlyflags.h
@@ -105,7 +105,7 @@ default match_source_bin
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:18:1
+# Defined: build.bp:redacted
 
 rule m.match_source_gen_.gen_match_source_gen
     command = cat ${g.bob.SrcDir}/function_def.txt ${g.bob.SrcDir}/main.c > ${_out_}

--- a/tests/gendiffer/nested_defaults/out/linux/build.ninja.out
+++ b/tests/gendiffer/nested_defaults/out/linux/build.ninja.out
@@ -48,7 +48,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:43:1
+# Defined: build.bp:redacted
 
 m.binary_target.cflags = -fno-exceptions -fexceptions -fno-exceptions
 m.binary_target.cxxflags = 

--- a/tests/gendiffer/override_configs/out/linux/build.ninja.out
+++ b/tests/gendiffer/override_configs/out/linux/build.ninja.out
@@ -52,7 +52,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:23:1
+# Defined: build.bp:redacted
 
 m.hello_world_target.cflags = -Wall -pedantic
 m.hello_world_target.cxxflags = 

--- a/tests/gendiffer/reexport/out/linux/build.ninja.out
+++ b/tests/gendiffer/reexport/out/linux/build.ninja.out
@@ -60,7 +60,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:157:1
+# Defined: build.bp:redacted
 
 m.lib_a_target.cflags = -DHAVE_A -DHAVE_B -DHAVE_C -DHAVE_D -DHAVE_E
 m.lib_a_target.cxxflags = 
@@ -87,7 +87,7 @@ build lib_a: phony ${g.bob.BuildDir}/target/static/lib_a.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:168:1
+# Defined: build.bp:redacted
 
 m.lib_b_target.cflags = -DHAVE_B -DHAVE_D
 m.lib_b_target.cxxflags = 
@@ -113,7 +113,7 @@ build lib_b: phony ${g.bob.BuildDir}/target/static/lib_b.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:176:1
+# Defined: build.bp:redacted
 
 m.lib_c_target.cflags = -DHAVE_C -DHAVE_E
 m.lib_c_target.cxxflags = 
@@ -139,7 +139,7 @@ build lib_c: phony ${g.bob.BuildDir}/target/static/lib_c.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:184:1
+# Defined: build.bp:redacted
 
 m.lib_d_target.cflags = -DHAVE_D
 m.lib_d_target.cxxflags = 
@@ -163,7 +163,7 @@ build lib_d: phony ${g.bob.BuildDir}/target/static/lib_d.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:190:1
+# Defined: build.bp:redacted
 
 m.lib_e_target.cflags = -DHAVE_E
 m.lib_e_target.cxxflags = 
@@ -187,7 +187,7 @@ build lib_e: phony ${g.bob.BuildDir}/target/static/lib_e.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:18:1
+# Defined: build.bp:redacted
 
 m.lib_internal_target.cflags = -DSHOW_HIDDEN -I${g.bob.SrcDir}/hidden
 m.lib_internal_target.cxxflags = 
@@ -211,7 +211,7 @@ build lib_internal: phony ${g.bob.BuildDir}/target/static/lib_internal.a
 # Variant: host
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:94:1
+# Defined: build.bp:redacted
 
 m.lib_internal_host_host.cflags = -DSHOW_HIDDEN -DME_HOST -I${g.bob.SrcDir}/hidden
 m.lib_internal_host_host.cxxflags = 
@@ -236,7 +236,7 @@ build lib_internal_host__host: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:94:1
+# Defined: build.bp:redacted
 
 m.lib_internal_host_target.cflags = -DSHOW_HIDDEN -DME_HOST -I${g.bob.SrcDir}/hidden
 m.lib_internal_host_target.cxxflags = 
@@ -262,7 +262,7 @@ build lib_internal_host__target: phony $
 # Variant: host
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:119:1
+# Defined: build.bp:redacted
 
 m.lib_internal_target_host.cflags = -DSHOW_HIDDEN -DME_TARGET -I${g.bob.SrcDir}/hidden
 m.lib_internal_target_host.cxxflags = 
@@ -288,7 +288,7 @@ build lib_internal_target__host: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:119:1
+# Defined: build.bp:redacted
 
 m.lib_internal_target_target.cflags = -DSHOW_HIDDEN -DME_TARGET -I${g.bob.SrcDir}/hidden
 m.lib_internal_target_target.cxxflags = 
@@ -314,7 +314,7 @@ build lib_internal_target__target: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:46:1
+# Defined: build.bp:redacted
 
 m.lib_no_reexport_target.cflags = -DSHOW_HIDDEN -I${g.bob.SrcDir}/hidden
 m.lib_no_reexport_target.cxxflags = 
@@ -342,7 +342,7 @@ build lib_no_reexport: phony ${g.bob.BuildDir}/target/static/lib_no_reexport.a
 # Variant: host
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:105:1
+# Defined: build.bp:redacted
 
 m.lib_reexport_host_host.cflags = -DSHOW_HIDDEN -DME_HOST -I${g.bob.SrcDir}/hidden
 m.lib_reexport_host_host.cxxflags = 
@@ -371,7 +371,7 @@ build lib_reexport_host__host: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:105:1
+# Defined: build.bp:redacted
 
 m.lib_reexport_host_target.cflags = -DSHOW_HIDDEN -DME_HOST -I${g.bob.SrcDir}/hidden
 m.lib_reexport_host_target.cxxflags = 
@@ -400,7 +400,7 @@ build lib_reexport_host__target: phony $
 # Variant: host
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:130:1
+# Defined: build.bp:redacted
 
 m.lib_reexport_host_2_host.cflags = -DSHOW_HIDDEN -DME_HOST -I${g.bob.SrcDir}/hidden
 m.lib_reexport_host_2_host.cxxflags = 
@@ -429,7 +429,7 @@ build lib_reexport_host_2__host: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:130:1
+# Defined: build.bp:redacted
 
 m.lib_reexport_host_2_target.cflags = -DSHOW_HIDDEN -DME_TARGET -I${g.bob.SrcDir}/hidden
 m.lib_reexport_host_2_target.cxxflags = 
@@ -458,7 +458,7 @@ build lib_reexport_host_2__target: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:25:1
+# Defined: build.bp:redacted
 
 m.lib_reexport_level_1_target.cflags = -DSHOW_HIDDEN -I${g.bob.SrcDir}/hidden
 m.lib_reexport_level_1_target.cxxflags = 
@@ -487,7 +487,7 @@ build lib_reexport_level_1: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:32:1
+# Defined: build.bp:redacted
 
 m.lib_reexport_level_2_target.cflags = -DSHOW_HIDDEN -I${g.bob.SrcDir}/hidden
 m.lib_reexport_level_2_target.cxxflags = 
@@ -516,7 +516,7 @@ build lib_reexport_level_2: phony $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:39:1
+# Defined: build.bp:redacted
 
 m.lib_reexport_level_3_target.cflags = -DSHOW_HIDDEN -I${g.bob.SrcDir}/hidden
 m.lib_reexport_level_3_target.cxxflags = 
@@ -545,7 +545,7 @@ build lib_reexport_level_3: phony $
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:88:1
+# Defined: build.bp:redacted
 
 m.test_no_reexport_target.cflags = 
 m.test_no_reexport_target.cxxflags = 
@@ -577,7 +577,7 @@ default test_no_reexport
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:58:1
+# Defined: build.bp:redacted
 
 m.test_reexport_cflags_level_1_target.cflags = -DSHOW_HIDDEN -I${g.bob.SrcDir}/hidden
 m.test_reexport_cflags_level_1_target.cxxflags = 
@@ -611,7 +611,7 @@ default test_reexport_cflags_level_1
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:70:1
+# Defined: build.bp:redacted
 
 m.test_reexport_cflags_level_2_target.cflags = -DSHOW_HIDDEN -I${g.bob.SrcDir}/hidden
 m.test_reexport_cflags_level_2_target.cxxflags = 
@@ -645,7 +645,7 @@ default test_reexport_cflags_level_2
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:82:1
+# Defined: build.bp:redacted
 
 m.test_reexport_cflags_level_3_target.cflags = -DSHOW_HIDDEN -I${g.bob.SrcDir}/hidden
 m.test_reexport_cflags_level_3_target.cxxflags = 
@@ -679,7 +679,7 @@ default test_reexport_cflags_level_3
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:113:1
+# Defined: build.bp:redacted
 
 m.test_reexport_host_target.cflags = -DSHOW_HIDDEN -DME_HOST -I${g.bob.SrcDir}/hidden
 m.test_reexport_host_target.cxxflags = 
@@ -711,7 +711,7 @@ default test_reexport_host
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:144:1
+# Defined: build.bp:redacted
 
 m.test_reexport_host_2_host.cflags = -DSHOW_HIDDEN -DME_HOST -I${g.bob.SrcDir}/hidden
 m.test_reexport_host_2_host.cxxflags = 
@@ -742,7 +742,7 @@ build test_reexport_host_2__host: phony $
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:144:1
+# Defined: build.bp:redacted
 
 m.test_reexport_host_2_target.cflags = -DSHOW_HIDDEN -DME_TARGET -I${g.bob.SrcDir}/hidden
 m.test_reexport_host_2_target.cxxflags = 
@@ -775,7 +775,7 @@ default test_reexport_host_2__target
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:52:1
+# Defined: build.bp:redacted
 
 m.test_reexport_include_level_1_target.cflags = -DSHOW_HIDDEN -I${g.bob.SrcDir}/hidden
 m.test_reexport_include_level_1_target.cxxflags = 
@@ -809,7 +809,7 @@ default test_reexport_include_level_1
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:64:1
+# Defined: build.bp:redacted
 
 m.test_reexport_include_level_2_target.cflags = -DSHOW_HIDDEN -I${g.bob.SrcDir}/hidden
 m.test_reexport_include_level_2_target.cxxflags = 
@@ -843,7 +843,7 @@ default test_reexport_include_level_2
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:76:1
+# Defined: build.bp:redacted
 
 m.test_reexport_include_level_3_target.cflags = -DSHOW_HIDDEN -I${g.bob.SrcDir}/hidden
 m.test_reexport_include_level_3_target.cxxflags = 
@@ -877,7 +877,7 @@ default test_reexport_include_level_3
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:151:1
+# Defined: build.bp:redacted
 
 m.test_reexport_passing_up_target.cflags = -DHAVE_A -DHAVE_B -DHAVE_D
 m.test_reexport_passing_up_target.cxxflags = 

--- a/tests/gendiffer/resource/out/linux/build.ninja.out
+++ b/tests/gendiffer/resource/out/linux/build.ninja.out
@@ -37,7 +37,7 @@ rule g.bootstrap.cp
 # Variant:
 # Type:    bob_resource
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:51:1
+# Defined: build.bp:redacted
 
 build ${g.bob.BuildDir}/install/bin/bob_tests/bob_resource_test_script.sh: $
         g.bob.install ${g.bob.SrcDir}/bob_resource_test_script.sh
@@ -55,7 +55,7 @@ default bob_test_resource_in_bin
 # Variant:
 # Type:    bob_resource
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:38:1
+# Defined: build.bp:redacted
 
 build ${g.bob.BuildDir}/install/testcases/y/main.c: g.bob.install $
         ${g.bob.SrcDir}/main.c
@@ -68,7 +68,7 @@ default bob_test_resources
 # Variant:
 # Type:    bob_alias
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:62:1
+# Defined: build.bp:redacted
 
 build bob_tests: phony bob_test_resources bob_test_resource_in_bin
 

--- a/tests/gendiffer/simplelib/out/linux/build.ninja.out
+++ b/tests/gendiffer/simplelib/out/linux/build.ninja.out
@@ -64,7 +64,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:124:1
+# Defined: build.bp:redacted
 
 m.bin_consumer_target.asflags = -DASFLAGS_BIN
 m.bin_consumer_target.cflags = -DCFLAGS_BIN -DCFLAGS_PROVIDER_EXPORT -DEXTERNAL_SHARED -I${g.bob.SrcDir}/local/include/bin/consumer -Iinclude/bin/consumer -I${g.bob.SrcDir}/export/local/include/lib/provider -isystem ${g.bob.SrcDir}/export/local/system/include/lib/provider -I${g.bob.SrcDir}/export/local/include/lib/consumer -isystem ${g.bob.SrcDir}/export/local/system/include/lib/consumer
@@ -113,7 +113,7 @@ default bin_consumer
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:81:1
+# Defined: build.bp:redacted
 
 m.lib_consumer_target.asflags = -DASFLAGS_LIB
 m.lib_consumer_target.cflags = -DCFLAGS_LIB -DCFLAGS_PROVIDER_EXPORT -DEXTERNAL_SHARED -I${g.bob.SrcDir}/local/include/lib/consumer -I${g.bob.SrcDir}/export/local/include/lib/consumer -I${g.bob.SrcDir}/export/local/system/include/lib/consumer -Iinclude/lib/consumer -I${g.bob.SrcDir}/export/local/include/lib/provider -isystem ${g.bob.SrcDir}/export/local/system/include/lib/provider
@@ -154,7 +154,7 @@ build lib_consumer: phony ${g.bob.BuildDir}/target/static/lib_consumer.a
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:35:1
+# Defined: build.bp:redacted
 
 m.lib_provider_target.asflags = -DASFLAGS_PROVIDER_LIB
 m.lib_provider_target.cflags = -DCFLAGS_PROVIDER_LIB -DCFLAGS_PROVIDER_EXPORT -DEXTERNAL_SHARED -I${g.bob.SrcDir}/local/include/lib/provider -I${g.bob.SrcDir}/export/local/include/lib/provider -I${g.bob.SrcDir}/export/local/system/include/lib/provider -Iinclude/lib/provider

--- a/tests/gendiffer/source_props/out/linux/build.ninja.out
+++ b/tests/gendiffer/source_props/out/linux/build.ninja.out
@@ -52,7 +52,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:108:1
+# Defined: build.bp:redacted
 
 m.bin_target.cflags = 
 m.bin_target.conlyflags = 
@@ -156,7 +156,7 @@ default bin
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:32:1
+# Defined: build.bp:redacted
 
 rule m.generated_source_.gen_generated_source
     command = touch ${_out_}
@@ -175,7 +175,7 @@ build generated_source: phony $
 # Variant:
 # Type:    bob_genrule
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:18:1
+# Defined: build.bp:redacted
 
 rule m.genrule_.gen_genrule
     command = touch ${_out_}
@@ -196,7 +196,7 @@ build genrule: phony ${g.bob.BuildDir}/gen/genrule/genrule_dummy01.c $
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:96:1
+# Defined: build.bp:redacted
 
 m.lib_target.cflags = 
 m.lib_target.conlyflags = 
@@ -294,7 +294,7 @@ build lib: phony ${g.bob.BuildDir}/target/static/lib.a
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:38:1
+# Defined: build.bp:redacted
 
 rule m.nested_generated_source_.gen_nested_generated_source
     command = touch ${_out_}
@@ -314,7 +314,7 @@ build nested_generated_source: phony $
 # Variant:
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:58:1
+# Defined: build.bp:redacted
 
 rule m.nested_transform_source_.gen_nested_transform_source
     command = some_tool
@@ -352,7 +352,7 @@ build nested_transform_source: phony $
 # Variant:
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:45:1
+# Defined: build.bp:redacted
 
 rule m.transform_source_.gen_transform_source
     command = some_tool

--- a/tests/gendiffer/template/out/linux/build.ninja.out
+++ b/tests/gendiffer/template/out/linux/build.ninja.out
@@ -43,7 +43,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_static_library
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:18:1
+# Defined: build.bp:redacted
 
 m.bob_test_templates_target.cflags = -DTEMPLATE_TEST_VALUE=6 -DTEMPLATE_TEST_VALUE_TARGET=6
 m.bob_test_templates_target.conlyflags = 

--- a/tests/gendiffer/transformsrcs/out/linux/build.ninja.out
+++ b/tests/gendiffer/transformsrcs/out/linux/build.ninja.out
@@ -48,7 +48,7 @@ rule g.bootstrap.cp
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:95:1
+# Defined: build.bp:redacted
 
 rule m.combine_sources_.gen_combine_sources
     command = ${tool} --out ${_out_} ${in}
@@ -83,7 +83,7 @@ build combine_sources: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:74:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_generated_sources_only_.gen_generate_source_generated_sources_only
     command = echo '// Dummy File' > ${_out_}
@@ -102,7 +102,7 @@ build generate_source_generated_sources_only: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:39:1
+# Defined: build.bp:redacted
 
 rule m.generate_source_to_transform_.gen_generate_source_to_transform
     command = echo '// Dummy File' > ${_out_}
@@ -121,7 +121,7 @@ build generate_source_to_transform: phony $
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:67:1
+# Defined: build.bp:redacted
 
 rule m.generate_template_source_used_by_transform_.gen_generate_template_source_used_by_transform
     command = python ${tool} ${_out_}
@@ -144,7 +144,7 @@ build generate_template_source_used_by_transform: phony $
 # Variant:
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:36:1
+# Defined: nested/build.bp:redacted
 
 rule m.transform_source_generated_deps_.gen_transform_source_generated_deps
     command = python ${tool} --in ${in} --gen ${_out_} --src-template ${generate_template_source_used_by_transform_out}
@@ -170,7 +170,7 @@ build transform_source_generated_deps: phony $
 # Variant:
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:80:1
+# Defined: build.bp:redacted
 
 rule m.transform_source_generated_sources_only_.gen_transform_source_generated_sources_only
     command = python ${tool} --in ${in} --gen ${_out_} --gen-implicit-header
@@ -197,7 +197,7 @@ default transform_source_generated_sources_only
 # Variant:
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:45:1
+# Defined: build.bp:redacted
 
 rule m.transform_source_multiple_in_.gen_transform_source_multiple_in
     command = python ${tool} --in ${in} --gen ${_out_} --gen-implicit-header
@@ -240,7 +240,7 @@ build transform_source_multiple_in: phony $
 # Variant:
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:18:1
+# Defined: build.bp:redacted
 
 rule m.transform_source_single_.gen_transform_source_single
     command = python ${tool} --in ${in} --gen ${_out_} --gen-implicit-header
@@ -263,7 +263,7 @@ build transform_source_single: phony $
 # Variant:
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: nested/build.bp:18:1
+# Defined: nested/build.bp:redacted
 
 rule m.transform_source_single_dir_.gen_transform_source_single_dir
     command = python ${tool} --in ${in} --gen ${_out_} --gen-implicit-header
@@ -286,7 +286,7 @@ build transform_source_single_dir: phony $
 # Variant:
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:121:1
+# Defined: build.bp:redacted
 
 rule m.validate_install_transform_source_.gen_validate_install_transform_source
     command = touch ${_out_}
@@ -317,7 +317,7 @@ default validate_install_transform_source
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:109:1
+# Defined: build.bp:redacted
 
 m.validate_link_transform_source_target.cflags = -I${g.bob.BuildDir}/gen/transform_source_single_dir/single/transform_source -I${g.bob.BuildDir}/gen/transform_source_single/transform_source -I${g.bob.BuildDir}/gen/transform_source_multiple_in/generate_source_to_transform -I${g.bob.BuildDir}/gen/transform_source_multiple_in/transform_source -I${g.bob.BuildDir}/gen/transform_source_generated_deps
 m.validate_link_transform_source_target.cxxflags = 
@@ -384,7 +384,7 @@ default validate_link_transform_source
 # Variant:
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:151:1
+# Defined: build.bp:redacted
 
 rule m.validate_transform_source_flattened_output_.gen_validate_transform_source_flattened_output
     command = echo '${_out_}:' > ${depfile} && cat $$(cat ${rspfile}) > ${_out_}
@@ -417,7 +417,7 @@ default validate_transform_source_flattened_output
 # Variant:
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:135:1
+# Defined: build.bp:redacted
 
 rule m.validate_transform_source_nested_output_.gen_validate_transform_source_nested_output
     command = echo '${_out_}:' > ${depfile} && cat $$(cat ${rspfile}) > ${_out_}

--- a/tests/gendiffer/transformsrcs_new/app/build.bp
+++ b/tests/gendiffer/transformsrcs_new/app/build.bp
@@ -124,6 +124,37 @@ bob_gensrcs {
     build_by_default: true,
 }
 
+bob_generate_source {
+    name: "gen_new_out",
+    generated_sources: [
+        "verify_tools",
+    ],
+    generated_deps: [
+        "verify_tools",
+    ],
+    out: ["gen_new_out.cpp"],
+    cmd: "cp ${in} ${out} && echo ${verify_tools_out}",
+    build_by_default: true,
+}
+
+bob_transform_source {
+    name: "gen_new_transform_out",
+    generated_sources: [
+        "verify_tools",
+    ],
+    generated_deps: [
+        "verify_tools",
+    ],
+    out: {
+        match: "(.+)\\.cpp",
+        replace: [
+            "$1.dep",
+        ],
+    },
+    cmd: "cp ${in} ${out} && echo ${verify_tools_out}",
+    build_by_default: true,
+}
+
 bob_alias {
     name: "bob_test_gensrcs",
     srcs: [

--- a/tests/gendiffer/transformsrcs_new/out/android/Android.bp.out
+++ b/tests/gendiffer/transformsrcs_new/out/android/Android.bp.out
@@ -44,6 +44,27 @@ cc_binary {
     cppflags: ["-fno-exceptions"],
 }
 
+genrule_bob {
+    name: "gen_new_out",
+    out: ["gen_new_out.cpp"],
+    cmd: "cp ${in} ${out} && echo ${verify_tools_out}",
+    depfile: false,
+    generated_deps: ["verify_tools"],
+    generated_sources: ["verify_tools"],
+}
+
+gensrcs_bob {
+    name: "gen_new_transform_out",
+    cmd: "cp ${in} ${out} && echo ${verify_tools_out}",
+    depfile: false,
+    generated_deps: ["verify_tools"],
+    generated_sources: ["verify_tools"],
+    out: {
+        match: "(.+)\\.cpp",
+        replace: ["$1.dep"],
+    },
+}
+
 filegroup {
     name: "generator",
     srcs: ["generator.py"],

--- a/tests/gendiffer/transformsrcs_new/out/linux/build.ninja.out
+++ b/tests/gendiffer/transformsrcs_new/out/linux/build.ninja.out
@@ -48,7 +48,7 @@ rule g.bootstrap.cp
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:80:1
+# Defined: build.bp:redacted
 
 m.bin_validate_gensrcs_target.cflags = -I${g.bob.BuildDir}/gen/gensrcs_single_cpp -I${g.bob.BuildDir}/gen/gensrcs_multiple_cpp -I${g.bob.BuildDir}/gen/gensrcs_single_h -I${g.bob.BuildDir}/gen/gensrcs_multiple_h
 m.bin_validate_gensrcs_target.cxxflags = 
@@ -119,7 +119,7 @@ default bin_validate_gensrcs
 # Variant:
 # Type:    bob_alias
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:158:1
+# Defined: build.bp:redacted
 
 build bob_test_gensrcs: phony bin_validate_gensrcs gen_host_bin__host
 
@@ -128,7 +128,7 @@ build bob_test_gensrcs: phony bin_validate_gensrcs gen_host_bin__host
 # Variant: host
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:104:1
+# Defined: build.bp:redacted
 
 m.gen_host_bin_host.cflags = 
 m.gen_host_bin_host.cxxflags = -std=c++17 -fno-exceptions
@@ -158,7 +158,7 @@ default gen_host_bin__host
 # Variant: target
 # Type:    bob_binary
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:104:1
+# Defined: build.bp:redacted
 
 m.gen_host_bin_target.cflags = 
 m.gen_host_bin_target.cxxflags = -std=c++17 -fno-exceptions
@@ -189,7 +189,7 @@ default gen_host_bin__target
 # Variant:
 # Type:    bob_generate_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:127:1
+# Defined: build.bp:redacted
 
 rule m.gen_new_out_.gen_gen_new_out
     command = cp ${in} ${_out_} && echo ${verify_tools_out}
@@ -211,7 +211,7 @@ default gen_new_out
 # Variant:
 # Type:    bob_transform_source
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:140:1
+# Defined: build.bp:redacted
 
 rule m.gen_new_transform_out_.gen_gen_new_transform_out
     command = cp ${in} ${_out_} && echo ${verify_tools_out}
@@ -234,7 +234,7 @@ default gen_new_transform_out
 # Variant:
 # Type:    bob_gensrcs
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:51:1
+# Defined: build.bp:redacted
 
 rule m.gensrcs_multiple_cpp_.gen_gensrcs_multiple_cpp
     command = python ${tool_1} --in ${in} --depfile ${depfile} --gen ${_out_}
@@ -264,7 +264,7 @@ build gensrcs_multiple_cpp: phony $
 # Variant:
 # Type:    bob_gensrcs
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:66:1
+# Defined: build.bp:redacted
 
 rule m.gensrcs_multiple_h_.gen_gensrcs_multiple_h
     command = python ${tool_1} --in ${in} --gen ${_out_}
@@ -291,7 +291,7 @@ build gensrcs_multiple_h: phony ${g.bob.BuildDir}/gen/gensrcs_multiple_h/f2.h $
 # Variant:
 # Type:    bob_gensrcs
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:25:1
+# Defined: build.bp:redacted
 
 rule m.gensrcs_single_cpp_.gen_gensrcs_single_cpp
     command = python ${tool_1} --in ${in} --gen ${_out_}
@@ -312,7 +312,7 @@ build gensrcs_single_cpp: phony $
 # Variant:
 # Type:    bob_gensrcs
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:38:1
+# Defined: build.bp:redacted
 
 rule m.gensrcs_single_h_.gen_gensrcs_single_h
     command = python ${tool_1} --in ${in} --gen ${_out_}
@@ -332,7 +332,7 @@ build gensrcs_single_h: phony ${g.bob.BuildDir}/gen/gensrcs_single_h/f1.h
 # Variant:
 # Type:    bob_gensrcs
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:93:1
+# Defined: build.bp:redacted
 
 rule m.verify_output_name_.gen_verify_output_name
     command = python ${tool_1} ${in} ${_out_} f4.cpp
@@ -354,7 +354,7 @@ default verify_output_name
 # Variant:
 # Type:    bob_gensrcs
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:116:1
+# Defined: build.bp:redacted
 
 rule m.verify_tools_.gen_verify_tools
     command = LD_LIBRARY_PATH=${g.bob.BuildDir}/host/shared:$$LD_LIBRARY_PATH ${host_bin} ${_out_}

--- a/tests/gendiffer/transformsrcs_new/out/linux/build.ninja.out
+++ b/tests/gendiffer/transformsrcs_new/out/linux/build.ninja.out
@@ -119,7 +119,7 @@ default bin_validate_gensrcs
 # Variant:
 # Type:    bob_alias
 # Factory: github.com/ARM-software/bob-build/core.Main.func1.1
-# Defined: build.bp:127:1
+# Defined: build.bp:158:1
 
 build bob_test_gensrcs: phony bin_validate_gensrcs gen_host_bin__host
 
@@ -183,6 +183,51 @@ build ${g.bob.BuildDir}/target/executable/gen_host_bin: g.bob.executable $
 build gen_host_bin__target: phony $
         ${g.bob.BuildDir}/target/executable/gen_host_bin
 default gen_host_bin__target
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Module:  gen_new_out
+# Variant:
+# Type:    bob_generate_source
+# Factory: github.com/ARM-software/bob-build/core.Main.func1.1
+# Defined: build.bp:127:1
+
+rule m.gen_new_out_.gen_gen_new_out
+    command = cp ${in} ${_out_} && echo ${verify_tools_out}
+    description = ${out}
+    restat = true
+
+build ${g.bob.BuildDir}/gen/gen_new_out/gen_new_out.cpp: $
+        m.gen_new_out_.gen_gen_new_out $
+        ${g.bob.BuildDir}/gen/verify_tools/f5.cpp | $
+        ${g.bob.BuildDir}/gen/verify_tools/f5.cpp
+    _out_ = ${g.bob.BuildDir}/gen/gen_new_out/gen_new_out.cpp
+    verify_tools_out = ${g.bob.BuildDir}/gen/verify_tools/f5.cpp
+
+build gen_new_out: phony ${g.bob.BuildDir}/gen/gen_new_out/gen_new_out.cpp
+default gen_new_out
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Module:  gen_new_transform_out
+# Variant:
+# Type:    bob_transform_source
+# Factory: github.com/ARM-software/bob-build/core.Main.func1.1
+# Defined: build.bp:140:1
+
+rule m.gen_new_transform_out_.gen_gen_new_transform_out
+    command = cp ${in} ${_out_} && echo ${verify_tools_out}
+    description = ${out}
+    restat = true
+
+build ${g.bob.BuildDir}/gen/gen_new_transform_out/verify_tools/f5.dep: $
+        m.gen_new_transform_out_.gen_gen_new_transform_out $
+        ${g.bob.BuildDir}/gen/verify_tools/f5.cpp | $
+        ${g.bob.BuildDir}/gen/verify_tools/f5.cpp
+    _out_ = ${g.bob.BuildDir}/gen/gen_new_transform_out/verify_tools/f5.dep
+    verify_tools_out = ${g.bob.BuildDir}/gen/verify_tools/f5.cpp
+
+build gen_new_transform_out: phony $
+        ${g.bob.BuildDir}/gen/gen_new_transform_out/verify_tools/f5.dep
+default gen_new_transform_out
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Module:  gensrcs_multiple_cpp

--- a/tests/strict_libs/static/build.bp
+++ b/tests/strict_libs/static/build.bp
@@ -7,6 +7,7 @@ bob_library {
     name: "lib_forward_defines",
     srcs: ["src/libs/lib.cpp"],
     hdrs: ["src/libs/lib.h"],
+    includes: ["internal/include"],
     local_defines: ["LOCAL_DEFINE"],
     defines: ["FORWARDED_DEFINE"],
 }

--- a/tests/transform_source_new/build.bp
+++ b/tests/transform_source_new/build.bp
@@ -124,6 +124,37 @@ bob_gensrcs {
     build_by_default: true,
 }
 
+bob_generate_source {
+    name: "gen_new_out",
+    generated_sources: [
+        "verify_tools",
+    ],
+    generated_deps: [
+        "verify_tools",
+    ],
+    out: ["gen_new_out.cpp"],
+    cmd: "cp ${in} ${out} && echo ${verify_tools_out}",
+    build_by_default: true,
+}
+
+bob_transform_source {
+    name: "gen_new_transform_out",
+    generated_sources: [
+        "verify_tools",
+    ],
+    generated_deps: [
+        "verify_tools",
+    ],
+    out: {
+        match: "(.+)\\.cpp",
+        replace: [
+            "$1.dep",
+        ],
+    },
+    cmd: "cp ${in} ${out} && echo ${verify_tools_out}",
+    build_by_default: true,
+}
+
 bob_alias {
     name: "bob_test_gensrcs",
     srcs: [


### PR DESCRIPTION
This PR adds new `includes` property for the `bob_library` as also allows to use
Android's native modules (i.e. `genrule` & `gensrcs`) within  `genrule_bob` and
`gensrcs_bob` modules handled by `genrulebob` plugin.

Additionally an improvement to `gendiffer` is done to redact `build.bp` line/column
number. 