### PR TITLE
fix(gendiffer): fixes crashes on whitespace changes

### DIFF
--- a/gendiffer/gendiffer.go
+++ b/gendiffer/gendiffer.go
@@ -141,6 +141,7 @@ func checkFileContents(args *generationArgs, filename string, data []byte) error
 		return err
 	}
 
+	// Early out in case the files are identical
 	if bytes.Equal(actual, data) {
 		return nil
 	}
@@ -148,6 +149,10 @@ func checkFileContents(args *generationArgs, filename string, data []byte) error
 	patch, err := diff(filename, actual, data)
 	if err != nil {
 		return err
+	} else if patch == nil {
+		// If the patch is nil it means the byte level files differ but not
+		// substantially enough to fail the tests. Refer to the diff flags for details.
+		return nil
 	}
 
 	_, suffix := split(patch, "\n")


### PR DESCRIPTION
It is possible for the files to differ in raw bytes but not provide a meaningful diff based on the flags used. This fix checks if the diff run reports the files to be the same and returns without error.

In our particular configuration this was causing a crash when a change resulted in a single space character diff between files which then resulted in out of bounds access after spliting the empty diff slice.

Change-Id: Id3dd0b6bb4870e40281bc6fc8787308e3da04822