### PR TITLE
chore: clean `Featues` when not need anymore

### DIFF
--- a/core/feature.go
+++ b/core/feature.go
@@ -104,6 +104,13 @@ func (f *Features) Init(properties *config.Properties, list ...interface{}) {
 
 }
 
+// Set internal `BlueprintEmbed` field to nil.
+//
+// Use it carefully as features won't be available anymore.
+func (f *Features) DeInit() {
+	f.BlueprintEmbed = nil
+}
+
 // coalesceTypes will squash multiple types to new type. This has different result
 // than Go composition of structs.
 //

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -170,7 +170,6 @@ func Main() {
 	ctx.RegisterBottomUpMutator("default_deps1", DefaultDepsStage1Mutator).Parallel()
 	ctx.RegisterBottomUpMutator("default_deps2", DefaultDepsStage2Mutator).Parallel()
 	ctx.RegisterTopDownMutator("features_applier", featureApplierMutator).Parallel()
-	ctx.RegisterTopDownMutator("template_applier", templateApplierMutator).Parallel()
 	ctx.RegisterBottomUpMutator("check_lib_fields", checkLibraryFieldsMutator).Parallel()
 	ctx.RegisterBottomUpMutator("check_genrule_fields", checkGenruleFieldsMutator).Parallel()
 	ctx.RegisterBottomUpMutator("strip_empty_components", stripEmptyComponentsMutator).Parallel()


### PR DESCRIPTION
Created `Features` after applying features
together with templates (i.e. `featureApplierMutator` and `templateApplierMutator`) are not used anymore thus should be released to free the memeory.

Clearing features should be done with care
as those won't be available anymore.


Change-Id: Ica2e12252f895dd6580f2d30df35f4ea6fa2dff0