### PR TITLE
Clean up file module

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -148,6 +148,7 @@ bootstrap_go_package {
     srcs: [
         "core/file/file.go",
         "core/file/filegroup.go",
+        "core/file/provider.go",
     ],
     testSrcs: [
         "core/file/file_test.go",

--- a/Blueprints
+++ b/Blueprints
@@ -150,6 +150,7 @@ bootstrap_go_package {
         "core/file/file.go",
         "core/file/filegroup.go",
         "core/file/provider.go",
+        "core/file/resolver.go",
     ],
     testSrcs: [
         "core/file/file_test.go",

--- a/Blueprints
+++ b/Blueprints
@@ -146,6 +146,7 @@ bootstrap_go_package {
         "bob-backend",
     ],
     srcs: [
+        "core/file/consumer.go",
         "core/file/file.go",
         "core/file/filegroup.go",
         "core/file/provider.go",

--- a/core/binary.go
+++ b/core/binary.go
@@ -13,7 +13,7 @@ type ModuleBinary struct {
 type binaryInterface interface {
 	stripable
 	linkableModule
-	FileProvider // A binary can provide itself as a source
+	file.Provider // A binary can provide itself as a source
 }
 
 var _ binaryInterface = (*ModuleBinary)(nil)  // impl check

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ARM-software/bob-build/core/backend"
 	"github.com/ARM-software/bob-build/core/config"
+	"github.com/ARM-software/bob-build/core/file"
 	"github.com/ARM-software/bob-build/core/toolchain"
 	"github.com/ARM-software/bob-build/internal/utils"
 )
@@ -329,7 +330,7 @@ func dependerMutator(ctx blueprint.BottomUpMutatorContext) {
 		}
 	}
 
-	if m, ok := ctx.Module().(FileProvider); ok {
+	if m, ok := ctx.Module().(file.Provider); ok {
 		ctx.AddDependency(ctx.Module(), FilegroupTag, m.OutFileTargets()...)
 	}
 

--- a/core/build_structs.go
+++ b/core/build_structs.go
@@ -334,7 +334,7 @@ func dependerMutator(ctx blueprint.BottomUpMutatorContext) {
 		ctx.AddDependency(ctx.Module(), FilegroupTag, m.OutFileTargets()...)
 	}
 
-	if m, ok := ctx.Module().(FileConsumer); ok {
+	if m, ok := ctx.Module().(file.Consumer); ok {
 		ctx.AddDependency(ctx.Module(), FilegroupTag, m.GetTargets()...)
 	}
 

--- a/core/file/BUILD.bazel
+++ b/core/file/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "file",
     srcs = [
+        "consumer.go",
         "file.go",
         "filegroup.go",
         "provider.go",
@@ -12,6 +13,7 @@ go_library(
     deps = [
         "//core/backend",
         "//core/toolchain",
+        "@com_github_google_blueprint//:blueprint",
     ],
 )
 

--- a/core/file/BUILD.bazel
+++ b/core/file/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "file.go",
         "filegroup.go",
         "provider.go",
+        "resolver.go",
     ],
     importpath = "github.com/ARM-software/bob-build/core/file",
     visibility = ["//visibility:public"],

--- a/core/file/BUILD.bazel
+++ b/core/file/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "file.go",
         "filegroup.go",
+        "provider.go",
     ],
     importpath = "github.com/ARM-software/bob-build/core/file",
     visibility = ["//visibility:public"],

--- a/core/file/consumer.go
+++ b/core/file/consumer.go
@@ -1,0 +1,30 @@
+package file
+
+import (
+	"github.com/google/blueprint"
+)
+
+// `Consumer` interface describes a module that is capable of consuming sources for its actions.
+// Example of this include:
+//   - bob_binary
+//   - bob{_static_,_shared_,_}library
+//
+// This interface can retrieve the required source file for this module only via `GetSrcs`, note that
+// each provider needs to be ready by the time these are accessed. This means, `GetSrcs` should be called
+// after `ResolveOutFiles` and `processPaths` for each of the dependant modules.
+//
+// The exception to this is `ResolveOutFiles` which may depend on other dynamic providers, in this case a bottom up
+// mutator is used to ensure the downstream dependencies of each module are ready.
+type Consumer interface {
+
+	// Returns all sources this module consumes. At this point assumes all providers are ready.
+	// Paths will be fully resolved.
+	GetFiles(blueprint.BaseModuleContext) Paths
+
+	// Returns a list of targets this consumer directly requires
+	GetTargets() []string
+
+	// Returns filepaths for current module only.
+	// Context is required for backend information but the accessor should only read current module.
+	GetDirectFiles() Paths
+}

--- a/core/file/provider.go
+++ b/core/file/provider.go
@@ -1,0 +1,26 @@
+package file
+
+// A `Provider` describes a class capable of providing source files,
+// either dynamically generated or by reference to other modules. For example:
+//   - bob_glob
+//   - bob_filegroup
+//   - bob_{generate,transform}_source
+//   - bob_genrule
+//
+// A provider interface outputs it's source files for other modules, it can also optionally forward it's source targets
+// as is the case for `bob_filegroup`.
+//
+// `OutSrcs` is not context aware, this is because it is called from a context aware visitor (`GetSrcs`).
+// This means its output needs to be resolved prior to this call. This is typically done via `processPaths` for
+// static sources, and `ResolveOutFiles` for sources which use a dynamic pathing.
+//
+// `processPaths` should not require context and only operate on the current module.
+type Provider interface {
+	// Sources to be forwarded to other modules
+	// Expected to be called from a context of another module.
+	OutFiles() Paths
+
+	// Targets to be forwarded to other modules
+	// Expected to be called from a context of another module.
+	OutFileTargets() []string
+}

--- a/core/file/provider.go
+++ b/core/file/provider.go
@@ -1,5 +1,7 @@
 package file
 
+import "github.com/google/blueprint"
+
 // A `Provider` describes a class capable of providing source files,
 // either dynamically generated or by reference to other modules. For example:
 //   - bob_glob
@@ -23,4 +25,15 @@ type Provider interface {
 	// Targets to be forwarded to other modules
 	// Expected to be called from a context of another module.
 	OutFileTargets() []string
+}
+
+// A dynamic source provider is a module which needs to compute the output file names.
+//
+// `ResolveOutFiles`, is context aware, and runs bottom up in the dep graph. This means however it cannot run
+// in parallel, fortunately this is __only__ used for `bob_transform_source`.
+//
+// `ResolveOutFiles` is context aware specifically because it can depend on other dynamic providers.
+type DynamicProvider interface {
+	Provider
+	ResolveOutFiles(blueprint.BaseModuleContext)
 }

--- a/core/file/resolver.go
+++ b/core/file/resolver.go
@@ -12,3 +12,11 @@ type Resolver interface {
 	// TODO: This may not be neccessary.
 	ResolveFiles(blueprint.BaseModuleContext)
 }
+
+// TransformSources needs to figure out the output names based on it's inputs.
+// Since this cannot be done at `OutSrcs` time due to lack of module context we use a seperate mutator stage.
+func ResolveFilesMutator(ctx blueprint.BottomUpMutatorContext) {
+	if m, ok := ctx.Module().(Resolver); ok {
+		m.ResolveFiles(ctx)
+	}
+}

--- a/core/file/resolver.go
+++ b/core/file/resolver.go
@@ -1,0 +1,14 @@
+package file
+
+import "github.com/google/blueprint"
+
+// `processPaths` needs to run separately to `SourceFileResolver`.
+// This is due to how the defaults are resolved and applied, meaning only defaultable properties will be merged.
+// The current flow is:
+//   - `processPaths` prepends the module subdirectory to source file.
+//   - `DefaultApplierMutator` runs, merging source attributes.
+//   - `ResolveSrcs` runs, setting up filepaths for distribution.
+type Resolver interface {
+	// TODO: This may not be neccessary.
+	ResolveFiles(blueprint.BaseModuleContext)
+}

--- a/core/filegroup.go
+++ b/core/filegroup.go
@@ -18,7 +18,7 @@ type ModuleFilegroup struct {
 // All interfaces supported by filegroup
 type filegroupInterface interface {
 	pathProcessor
-	FileResolver
+	file.Resolver
 	file.Provider
 }
 

--- a/core/filegroup.go
+++ b/core/filegroup.go
@@ -19,7 +19,7 @@ type ModuleFilegroup struct {
 type filegroupInterface interface {
 	pathProcessor
 	FileResolver
-	FileProvider
+	file.Provider
 }
 
 var _ filegroupInterface = (*ModuleFilegroup)(nil) // impl check

--- a/core/gen_binary.go
+++ b/core/gen_binary.go
@@ -10,7 +10,7 @@ type generateBinary struct {
 }
 
 // Verify that the following interfaces are implemented
-var _ FileProvider = (*generateBinary)(nil)
+var _ file.Provider = (*generateBinary)(nil)
 var _ generateLibraryInterface = (*generateBinary)(nil)
 var _ singleOutputModule = (*generateBinary)(nil)
 var _ splittable = (*generateBinary)(nil)

--- a/core/gen_library.go
+++ b/core/gen_library.go
@@ -44,7 +44,7 @@ var _ FileConsumer = (*generateLibrary)(nil)
 type generateLibraryInterface interface {
 	blueprint.Module
 	dependentInterface
-	FileProvider
+	file.Provider
 	FileConsumer
 
 	libExtension() string

--- a/core/gen_library.go
+++ b/core/gen_library.go
@@ -37,7 +37,7 @@ type generateLibrary struct {
 // Verify that the following interfaces are implemented
 var _ phonyInterface = (*generateLibrary)(nil)
 var _ splittable = (*generateLibrary)(nil)
-var _ FileConsumer = (*generateLibrary)(nil)
+var _ file.Consumer = (*generateLibrary)(nil)
 
 // Modules implementing generateLibraryInterface support arbitrary commands
 // that either produce a static library, shared library or binary.
@@ -45,7 +45,7 @@ type generateLibraryInterface interface {
 	blueprint.Module
 	dependentInterface
 	file.Provider
-	FileConsumer
+	file.Consumer
 
 	libExtension() string
 	outputFileName() string

--- a/core/gen_shared.go
+++ b/core/gen_shared.go
@@ -12,7 +12,7 @@ type generateSharedLibrary struct {
 }
 
 // Verify that the following interfaces are implemented
-var _ FileProvider = (*generateSharedLibrary)(nil)
+var _ file.Provider = (*generateSharedLibrary)(nil)
 var _ generateLibraryInterface = (*generateSharedLibrary)(nil)
 var _ singleOutputModule = (*generateSharedLibrary)(nil)
 var _ sharedLibProducer = (*generateSharedLibrary)(nil)

--- a/core/gen_static.go
+++ b/core/gen_static.go
@@ -11,7 +11,7 @@ type generateStaticLibrary struct {
 }
 
 // Verify that the following interfaces are implemented
-var _ FileProvider = (*generateStaticLibrary)(nil)
+var _ file.Provider = (*generateStaticLibrary)(nil)
 var _ generateLibraryInterface = (*generateStaticLibrary)(nil)
 var _ singleOutputModule = (*generateStaticLibrary)(nil)
 var _ splittable = (*generateStaticLibrary)(nil)

--- a/core/glob.go
+++ b/core/glob.go
@@ -40,7 +40,7 @@ type ModuleGlob struct {
 // All interfaces supported by moduleGlob
 type moduleGlobInterface interface {
 	pathProcessor
-	FileResolver
+	file.Resolver
 	file.Provider
 }
 

--- a/core/glob.go
+++ b/core/glob.go
@@ -41,7 +41,7 @@ type ModuleGlob struct {
 type moduleGlobInterface interface {
 	pathProcessor
 	FileResolver
-	FileProvider
+	file.Provider
 }
 
 var _ moduleGlobInterface = (*ModuleGlob)(nil) // impl check

--- a/core/install.go
+++ b/core/install.go
@@ -211,7 +211,7 @@ type ModuleResource struct {
 type resourceInterface interface {
 	pathProcessor
 	FileResolver
-	FileConsumer
+	file.Consumer
 }
 
 var _ resourceInterface = (*ModuleResource)(nil) // impl check

--- a/core/install.go
+++ b/core/install.go
@@ -210,7 +210,7 @@ type ModuleResource struct {
 
 type resourceInterface interface {
 	pathProcessor
-	FileResolver
+	file.Resolver
 	file.Consumer
 }
 

--- a/core/kernel_module.go
+++ b/core/kernel_module.go
@@ -64,7 +64,7 @@ type kernelModuleInterface interface {
 	enableable  // module enabling/disabling
 	aliasable   // appending to aliases
 	pathProcessor
-	FileResolver
+	file.Resolver
 }
 
 var _ kernelModuleInterface = (*ModuleKernelObject)(nil) // impl check

--- a/core/legacy_source_props.go
+++ b/core/legacy_source_props.go
@@ -29,7 +29,7 @@ type LegacySourceProps struct {
 // All interfaces supported by LegacySourceProps
 type LegacySourcePropsInterface interface {
 	pathProcessor
-	FileConsumer
+	file.Consumer
 	FileResolver
 }
 

--- a/core/legacy_source_props.go
+++ b/core/legacy_source_props.go
@@ -30,7 +30,7 @@ type LegacySourceProps struct {
 type LegacySourcePropsInterface interface {
 	pathProcessor
 	file.Consumer
-	FileResolver
+	file.Resolver
 }
 
 var _ LegacySourcePropsInterface = (*LegacySourceProps)(nil) // impl check

--- a/core/library.go
+++ b/core/library.go
@@ -427,7 +427,7 @@ func GetGeneratedHeadersFiles(ctx blueprint.ModuleContext) (orderOnly []string) 
 				// The source file _will_ be rebuilt if it uses the header (since that is registered in the
 				// depfile). Note that this means that generated headers cannot change which headers are used
 				// (by aliasing another header).
-				if provider, ok := child.(FileProvider); ok {
+				if provider, ok := child.(file.Provider); ok {
 					provider.OutFiles().ForEachIf(
 						func(fp file.Path) bool {
 							return (fp.IsType(file.TypeGenerated) || fp.IsType(file.TypeImplicit)) &&

--- a/core/library.go
+++ b/core/library.go
@@ -42,7 +42,7 @@ type libraryInterface interface {
 	matchSourceInterface
 	propertyEscapeInterface
 	SharedLibraryExporter
-	FileConsumer
+	file.Consumer
 	flag.Consumer
 }
 

--- a/core/linux_backend.go
+++ b/core/linux_backend.go
@@ -267,7 +267,7 @@ func (g *linuxGenerator) install(m interface{}, ctx blueprint.ModuleContext) []s
 		installedFiles = append(installedFiles, dest)
 	}
 
-	if provider, ok := m.(FileProvider); ok {
+	if provider, ok := m.(file.Provider); ok {
 		provider.OutFiles().ForEachIf(
 			func(fp file.Path) bool { return fp.IsSymLink() },
 			func(fp file.Path) bool {

--- a/core/linux_cclibs.go
+++ b/core/linux_cclibs.go
@@ -147,7 +147,7 @@ func GetWholeStaticLibs(ctx blueprint.ModuleContext) []string {
 	ctx.VisitDirectDepsIf(
 		func(m blueprint.Module) bool { return ctx.OtherModuleDependencyTag(m) == WholeStaticTag },
 		func(m blueprint.Module) {
-			if provider, ok := m.(FileProvider); ok {
+			if provider, ok := m.(file.Provider); ok {
 				libs = append(libs, provider.OutFiles().ToStringSliceIf(
 					func(p file.Path) bool { return p.IsType(file.TypeArchive) },
 					func(p file.Path) string { return p.BuildPath() })...)
@@ -165,7 +165,7 @@ func (m *ModuleLibrary) GetStaticLibs(ctx blueprint.ModuleContext) []string {
 		if dep == nil {
 			utils.Die("%s has no dependency on static lib %s", m.Name(), moduleName)
 		}
-		if provider, ok := dep.(FileProvider); ok {
+		if provider, ok := dep.(file.Provider); ok {
 			libs = append(libs, provider.OutFiles().ToStringSliceIf(
 				func(p file.Path) bool { return p.IsType(file.TypeArchive) },
 				func(p file.Path) string { return p.BuildPath() })...)
@@ -205,7 +205,7 @@ type Archivable interface {
 	dependentInterface // For phony targets
 	flag.Consumer      // Modules which are compilable need to support flags
 	FileConsumer       // Compilable objects must match the file consumer interface
-	FileProvider       // Must create valid output files
+	file.Provider      // Must create valid output files
 
 	GetBuildWrapperAndDeps(blueprint.ModuleContext) (string, []string)
 }
@@ -323,7 +323,7 @@ func (g *linuxGenerator) getSharedLibTocPaths(ctx blueprint.ModuleContext) (libs
 		func(m blueprint.Module) bool { return ctx.OtherModuleDependencyTag(m) == SharedTag },
 		func(m blueprint.Module) {
 			if _, ok := m.(sharedLibProducer); ok { //Remove this check and replace it with an API call
-				if m, ok := m.(FileProvider); ok {
+				if m, ok := m.(file.Provider); ok {
 					if toc, ok := m.OutFiles().FindSingle(
 						func(p file.Path) bool { return p.IsType(file.TypeToc) }); ok {
 						libs = append(libs, toc.BuildPath())
@@ -412,7 +412,7 @@ func (g *linuxGenerator) getSharedLibFlags(m BackendCommonLibraryInterface, ctx 
 
 // Temporary interface to make library handlers generic between legacy and strict libraries
 type BackendCommonLibraryInterface interface {
-	FileProvider
+	file.Provider
 	flag.Consumer
 	targetableModule
 	linkableModule

--- a/core/linux_cclibs.go
+++ b/core/linux_cclibs.go
@@ -48,7 +48,7 @@ type Compilable interface {
 	flag.Consumer // Modules which are compilable need to support flags
 	flag.Provider // Required for AOSP backend to check for exported flags
 
-	FileConsumer // Compilable objects must match the file consumer interface
+	file.Consumer // Compilable objects must match the file consumer interface
 	targetableModule
 	phonyInterface
 	GetBuildWrapperAndDeps(blueprint.ModuleContext) (string, []string)
@@ -204,7 +204,7 @@ type Archivable interface {
 	enableable         // For build by default
 	dependentInterface // For phony targets
 	flag.Consumer      // Modules which are compilable need to support flags
-	FileConsumer       // Compilable objects must match the file consumer interface
+	file.Consumer      // Compilable objects must match the file consumer interface
 	file.Provider      // Must create valid output files
 
 	GetBuildWrapperAndDeps(blueprint.ModuleContext) (string, []string)

--- a/core/metadata.go
+++ b/core/metadata.go
@@ -41,7 +41,7 @@ func metaDataCollector(ctx blueprint.BottomUpMutatorContext) {
 
 	meta := ModuleMeta{}
 
-	if s, ok := ctx.Module().(FileConsumer); ok {
+	if s, ok := ctx.Module().(file.Consumer); ok {
 		s.GetFiles(ctx).ForEach(
 			func(fp file.Path) bool {
 				meta.Srcs = append(meta.Srcs, fp.UnScopedPath())

--- a/core/module_generate_source.go
+++ b/core/module_generate_source.go
@@ -36,7 +36,7 @@ type generateSourceInterface interface {
 	pathProcessor
 	FileResolver
 	file.Provider
-	FileConsumer
+	file.Consumer
 }
 
 var _ generateSourceInterface = (*ModuleGenerateSource)(nil) // impl check

--- a/core/module_generate_source.go
+++ b/core/module_generate_source.go
@@ -35,7 +35,7 @@ type generateSourceInterface interface {
 	installable
 	pathProcessor
 	FileResolver
-	FileProvider
+	file.Provider
 	FileConsumer
 }
 

--- a/core/module_generate_source.go
+++ b/core/module_generate_source.go
@@ -34,7 +34,7 @@ type ModuleGenerateSource struct {
 type generateSourceInterface interface {
 	installable
 	pathProcessor
-	FileResolver
+	file.Resolver
 	file.Provider
 	file.Consumer
 }

--- a/core/module_genrule.go
+++ b/core/module_genrule.go
@@ -33,7 +33,7 @@ type ModuleGenrule struct {
 }
 
 type ModuleGenruleInterface interface {
-	FileConsumer
+	file.Consumer
 	FileResolver
 	pathProcessor
 }

--- a/core/module_genrule.go
+++ b/core/module_genrule.go
@@ -34,7 +34,7 @@ type ModuleGenrule struct {
 
 type ModuleGenruleInterface interface {
 	file.Consumer
-	FileResolver
+	file.Resolver
 	pathProcessor
 }
 

--- a/core/module_gensrcs.go
+++ b/core/module_gensrcs.go
@@ -36,7 +36,7 @@ type ModuleGensrcs struct {
 }
 
 type ModuleGensrcsInterface interface {
-	FileConsumer
+	file.Consumer
 	FileResolver
 	pathProcessor
 }

--- a/core/module_gensrcs.go
+++ b/core/module_gensrcs.go
@@ -37,7 +37,7 @@ type ModuleGensrcs struct {
 
 type ModuleGensrcsInterface interface {
 	file.Consumer
-	FileResolver
+	file.Resolver
 	pathProcessor
 }
 

--- a/core/module_transform_source.go
+++ b/core/module_transform_source.go
@@ -72,7 +72,7 @@ type ModuleTransformSource struct {
 type transformSourceInterface interface {
 	installable
 	DynamicFileProvider
-	FileConsumer
+	file.Consumer
 	FileResolver
 }
 

--- a/core/module_transform_source.go
+++ b/core/module_transform_source.go
@@ -71,7 +71,7 @@ type ModuleTransformSource struct {
 // All interfaces supported by filegroup
 type transformSourceInterface interface {
 	installable
-	DynamicFileProvider
+	file.DynamicProvider
 	file.Consumer
 	FileResolver
 }

--- a/core/module_transform_source.go
+++ b/core/module_transform_source.go
@@ -73,7 +73,7 @@ type transformSourceInterface interface {
 	installable
 	file.DynamicProvider
 	file.Consumer
-	FileResolver
+	file.Resolver
 }
 
 var _ transformSourceInterface = (*ModuleTransformSource)(nil) // impl check

--- a/core/source_props.go
+++ b/core/source_props.go
@@ -113,17 +113,6 @@ func resolveDynamicFileOutputs(ctx blueprint.BottomUpMutatorContext) {
 	}
 }
 
-// `processPaths` needs to run seperately to `SourceFileResolver`.
-// This is due to how the defaults are resolved and applied, meaning only defaultable properties will be merged.
-// The current flow is:
-//   - `processPaths` prepends the module subdirectory to source file.
-//   - `DefaultApplierMutator` runs, merging source attributes.
-//   - `ResolveSrcs` runs, setting up filepaths for distribution.
-type FileResolver interface {
-	// TODO: This may not be neccessary.
-	ResolveFiles(blueprint.BaseModuleContext)
-}
-
 func (s *SourceProps) ResolveFiles(ctx blueprint.BaseModuleContext) {
 	// Since globbing is supported we must call a resolver.
 	files := file.Paths{}
@@ -139,7 +128,7 @@ func (s *SourceProps) ResolveFiles(ctx blueprint.BaseModuleContext) {
 // TransformSources needs to figure out the output names based on it's inputs.
 // Since this cannot be done at `OutSrcs` time due to lack of module context we use a seperate mutator stage.
 func resolveFilesMutator(ctx blueprint.BottomUpMutatorContext) {
-	if m, ok := ctx.Module().(FileResolver); ok {
+	if m, ok := ctx.Module().(file.Resolver); ok {
 		m.ResolveFiles(ctx)
 	}
 }

--- a/core/source_props.go
+++ b/core/source_props.go
@@ -44,7 +44,7 @@ type SourceProps struct {
 
 // Reusable baseline implementation. Each module should match this interface.
 var _ pathProcessor = (*SourceProps)(nil)
-var _ FileConsumer = (*SourceProps)(nil)
+var _ file.Consumer = (*SourceProps)(nil)
 
 // Helper function to process source paths for Modules using `SourceProps`
 func (s *SourceProps) processPaths(ctx blueprint.BaseModuleContext) {
@@ -62,31 +62,6 @@ func (s *SourceProps) processPaths(ctx blueprint.BaseModuleContext) {
 	s.Srcs = append(utils.PrefixDirs(srcs, prefix), utils.PrefixAll(targets, ":")...)
 }
 
-// `SourceFileConsumer` interface describes a module that is capable of consuming sources for its actions.
-// Example of this include:
-//   - bob_binary
-//   - bob{_static_,_shared_,_}library
-//
-// This interface can retrieve the required source file for this module only via `GetSrcs`, note that
-// each provider needs to be ready by the time these are accessed. This means, `GetSrcs` should be called
-// after `ResolveOutFiles` and `processPaths` for each of the dependant modules.
-//
-// The exception to this is `ResolveOutFiles` which may depend on other dynamic providers, in this case a bottom up
-// mutator is used to ensure the downstream dependencies of each module are ready.
-type FileConsumer interface {
-
-	// Returns all sources this module consumes. At this point assumes all providers are ready.
-	// Paths will be fully resolved.
-	GetFiles(blueprint.BaseModuleContext) file.Paths
-
-	// Returns a list of targets this consumer directly requires
-	GetTargets() []string
-
-	// Returns filepaths for current module only.
-	// Context is required for backend information but the accessor should only read current module.
-	GetDirectFiles() file.Paths
-}
-
 // Basic common implementation, certain targets will custmize this.
 func (s *SourceProps) GetTargets() []string {
 	return utils.MixedListToBobTargets(s.Srcs)
@@ -97,7 +72,7 @@ func ReferenceGetFilesImpl(ctx blueprint.BaseModuleContext) (srcs file.Paths) {
 	ctx.WalkDeps(
 		func(child, parent blueprint.Module) bool {
 			isFilegroup := ctx.OtherModuleDependencyTag(child) == FilegroupTag
-			_, isConsumer := child.(FileConsumer)
+			_, isConsumer := child.(file.Consumer)
 			_, isProvider := child.(file.Provider)
 
 			if isFilegroup && isProvider {

--- a/core/source_props.go
+++ b/core/source_props.go
@@ -124,11 +124,3 @@ func (s *SourceProps) ResolveFiles(ctx blueprint.BaseModuleContext) {
 
 	s.ResolvedSrcs = files
 }
-
-// TransformSources needs to figure out the output names based on it's inputs.
-// Since this cannot be done at `OutSrcs` time due to lack of module context we use a seperate mutator stage.
-func resolveFilesMutator(ctx blueprint.BottomUpMutatorContext) {
-	if m, ok := ctx.Module().(file.Resolver); ok {
-		m.ResolveFiles(ctx)
-	}
-}

--- a/core/source_props.go
+++ b/core/source_props.go
@@ -105,21 +105,10 @@ func (s *SourceProps) GetFiles(ctx blueprint.BaseModuleContext) file.Paths {
 	return s.GetDirectFiles().Merge(ReferenceGetFilesImpl(ctx))
 }
 
-// A dynamic source provider is a module which needs to compute the output file names.
-//
-// `ResolveOutFiles`, is context aware, and runs bottom up in the dep graph. This means however it cannot run
-// in parallel, fortunately this is __only__ used for `bob_transform_source`.
-//
-// `ResolveOutFiles` is context aware specifically because it can depend on other dynamic providers.
-type DynamicFileProvider interface {
-	file.Provider
-	ResolveOutFiles(blueprint.BaseModuleContext)
-}
-
 // TransformSources needs to figure out the output names based on it's inputs.
 // Since this cannot be done at `OutSrcs` time due to lack of module context we use a seperate mutator stage.
 func resolveDynamicFileOutputs(ctx blueprint.BottomUpMutatorContext) {
-	if m, ok := ctx.Module().(DynamicFileProvider); ok {
+	if m, ok := ctx.Module().(file.DynamicProvider); ok {
 		m.ResolveOutFiles(ctx)
 	}
 }

--- a/core/standalone.go
+++ b/core/standalone.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ARM-software/bob-build/core/backend"
 	"github.com/ARM-software/bob-build/core/config"
+	"github.com/ARM-software/bob-build/core/file"
 	"github.com/ARM-software/bob-build/core/toolchain"
 	"github.com/ARM-software/bob-build/internal/graph"
 	"github.com/ARM-software/bob-build/internal/utils"
@@ -169,7 +170,7 @@ func Main() {
 	ctx.RegisterBottomUpMutator("generic_depender", ResolveGenericDepsMutator).Parallel()
 
 	// First resolve providers which are not dependant on other modules.
-	ctx.RegisterBottomUpMutator("resolve_files", resolveFilesMutator).Parallel()
+	ctx.RegisterBottomUpMutator("resolve_files", file.ResolveFilesMutator).Parallel()
 
 	// Now we can resolve remaining, dynamic file providers.
 	ctx.RegisterBottomUpMutator("resolve_dynamic_src_outputs", resolveDynamicFileOutputs) // Cannot be parallel.

--- a/core/strict_binary.go
+++ b/core/strict_binary.go
@@ -12,7 +12,7 @@ type ModuleStrictBinary struct {
 type strictBinaryInterface interface {
 	splittable
 	enableable
-	FileConsumer
+	file.Consumer
 }
 
 var _ strictLibraryInterface = (*ModuleStrictBinary)(nil)

--- a/core/strict_generate_common.go
+++ b/core/strict_generate_common.go
@@ -28,7 +28,7 @@ type ModuleStrictGenerateCommon struct {
 
 type StrictGenerateCommonInterface interface {
 	pathProcessor
-	FileConsumer
+	file.Consumer
 	FileResolver
 }
 

--- a/core/strict_generate_common.go
+++ b/core/strict_generate_common.go
@@ -29,7 +29,7 @@ type ModuleStrictGenerateCommon struct {
 type StrictGenerateCommonInterface interface {
 	pathProcessor
 	file.Consumer
-	FileResolver
+	file.Resolver
 }
 
 var _ StrictGenerateCommonInterface = (*ModuleStrictGenerateCommon)(nil)

--- a/core/strict_generate_props.go
+++ b/core/strict_generate_props.go
@@ -24,7 +24,7 @@ type StrictGenerateProps struct {
 
 type StrictGeneratePropsInterface interface {
 	pathProcessor
-	FileConsumer
+	file.Consumer
 	FileResolver
 }
 

--- a/core/strict_generate_props.go
+++ b/core/strict_generate_props.go
@@ -25,7 +25,7 @@ type StrictGenerateProps struct {
 type StrictGeneratePropsInterface interface {
 	pathProcessor
 	file.Consumer
-	FileResolver
+	file.Resolver
 }
 
 var _ StrictGeneratePropsInterface = (*StrictGenerateProps)(nil) // impl check

--- a/core/strict_library.go
+++ b/core/strict_library.go
@@ -322,7 +322,7 @@ func (m *ModuleStrictLibrary) GetStaticLibs(ctx blueprint.ModuleContext) (libs [
 	ctx.VisitDirectDepsIf(
 		func(m blueprint.Module) bool { return ctx.OtherModuleDependencyTag(m) == StaticTag },
 		func(m blueprint.Module) {
-			if provider, ok := m.(FileProvider); ok {
+			if provider, ok := m.(file.Provider); ok {
 				libs = append(libs, provider.OutFiles().ToStringSliceIf(
 					func(p file.Path) bool { return p.IsType(file.TypeArchive) },
 					func(p file.Path) string { return p.BuildPath() })...)

--- a/core/strict_library.go
+++ b/core/strict_library.go
@@ -69,7 +69,7 @@ type ModuleStrictLibrary struct {
 type strictLibraryInterface interface {
 	targetSpecificLibrary
 	dependentInterface
-	FileConsumer
+	file.Consumer
 	FileResolver
 	enableable
 	Featurable

--- a/core/strict_library.go
+++ b/core/strict_library.go
@@ -70,7 +70,7 @@ type strictLibraryInterface interface {
 	targetSpecificLibrary
 	dependentInterface
 	file.Consumer
-	FileResolver
+	file.Resolver
 	enableable
 	Featurable
 }


### PR DESCRIPTION
Similarly to the `Flag`, the `File` module should contain all the interface definitions needed.