### PR TITLE
chore: make `bob_executable` build by default

### DIFF
--- a/core/install.go
+++ b/core/install.go
@@ -44,10 +44,14 @@ func isBuiltByDefault(e enableable) bool {
 	}
 
 	switch m := e.(type) {
-	case *ModuleBinary:
-		if m.Properties.TargetType == toolchain.TgtTypeTarget {
-			return true
+	case *ModuleBinary, *ModuleStrictBinary:
+		var tgt toolchain.TgtType = toolchain.TgtTypeUnknown
+
+		if m, ok := m.(splittable); ok {
+			tgt = m.getTarget()
 		}
+
+		return tgt == toolchain.TgtTypeTarget
 	case *ModuleKernelObject:
 		return true
 	}

--- a/tests/gendiffer/strict_binary/out/android/Android.bp.out
+++ b/tests/gendiffer/strict_binary/out/android/Android.bp.out
@@ -21,6 +21,12 @@ cc_binary {
     },
 }
 
+cc_binary {
+    name: "bob_executable_install_group",
+    srcs: ["hello_world.cpp"],
+    compile_multilib: "both",
+}
+
 cc_binary_host {
     name: "simple_bob_executable_host",
     srcs: ["src.cpp"],

--- a/tests/gendiffer/strict_binary/out/linux/build.ninja.out
+++ b/tests/gendiffer/strict_binary/out/linux/build.ninja.out
@@ -119,6 +119,7 @@ build ${g.bob.BuildDir}/out/bin/bob_executable_install_group: g.bob.install $
 build bob_executable_install_group: phony $
         ${g.bob.BuildDir}/out/bin/bob_executable_install_group $
         ${g.bob.BuildDir}/target/executable/bob_executable_install_group
+default bob_executable_install_group
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Module:  simple_bob_executable_host


### PR DESCRIPTION
`bob_executable`s `build_by_default` should be
`true` by default.


Change-Id: I216282b23c31af36c115ac624e1a1b648dc27339