### PR TITLE
Remove `load()` statement workaround

### DIFF
--- a/gazelle/MODULE.bazel
+++ b/gazelle/MODULE.bazel
@@ -23,6 +23,7 @@ single_version_override(
         "//patches:gazelle/0002-Add-the-new-Merger-interface.patch",
         "//patches:gazelle/0003-Implement-Merge-for-SortedStrings-UnsortedStrings.patch",
         "//patches:gazelle/0004-Expose-the-MergeList-MergeDict-helpers.patch",
+        "//patches:gazelle/0005-fix-correct-rule-s-kind-stmt.patch",
     ],
     version = "0.32.0",
 )

--- a/gazelle/WORKSPACE
+++ b/gazelle/WORKSPACE
@@ -32,6 +32,7 @@ http_archive(
         "//patches:gazelle/0002-Add-the-new-Merger-interface.patch",
         "//patches:gazelle/0003-Implement-Merge-for-SortedStrings-UnsortedStrings.patch",
         "//patches:gazelle/0004-Expose-the-MergeList-MergeDict-helpers.patch",
+        "//patches:gazelle/0005-fix-correct-rule-s-kind-stmt.patch",
     ],
     sha256 = "29218f8e0cebe583643cbf93cae6f971be8a2484cdcfa1e45057658df8d54002",
     urls = [

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -55,34 +55,6 @@ func (e *BobExtension) GenerateRules(args language.GenerateArgs) language.Genera
 	rel := filepath.Clean(args.Rel)
 	rules := generateConfigs(e.registry, rel)
 
-	// FIXME: Gazelle does not support load statements when macros are packaged
-	// into a struct.
-	// Temporarily add load statement for `selects.config_setting_group`
-	// when it's generated.
-	for _, r := range rules {
-		if strings.HasPrefix(r.Kind(), "selects.") {
-			if args.File != nil {
-				var load *rule.Load
-				for _, l := range args.File.Loads {
-					if l.Name() == ruleSelectsBzl {
-						load = l
-						load.Add("selects")
-						break
-					}
-				}
-
-				// Add new `load` statement
-				if load == nil {
-					load = rule.NewLoad(ruleSelectsBzl)
-					load.Add("selects")
-					load.Insert(args.File, len(args.File.Loads))
-				}
-			}
-
-			break
-		}
-	}
-
 	if regs, ok := e.registry.retrieveByPath(rel); ok {
 		// To properly test generation of multiple modules
 		// at once the order needs to be preserved

--- a/gazelle/kinds.go
+++ b/gazelle/kinds.go
@@ -76,6 +76,12 @@ var bobLoads = []rule.LoadInfo{
 			"int_flag",
 		},
 	},
+	{
+		Name: "@bazel_skylib//lib:selects.bzl",
+		Symbols: []string{
+			"selects",
+		},
+	},
 }
 
 // Kinds returns a map of maps rule names (kinds) and information on how to

--- a/gazelle/patches/gazelle/0005-fix-correct-rule-s-kind-stmt.patch
+++ b/gazelle/patches/gazelle/0005-fix-correct-rule-s-kind-stmt.patch
@@ -1,0 +1,86 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sebastian Birunt <sebastian.birunt@arm.com>
+Date: Thu, 17 Aug 2023 11:23:59 +0200
+Subject: fix: correct rule's kind & stmt
+
+Created rule with `NewRule()` is different
+to the rule created with `ruleFromExpr()`
+(when parsing input data).
+
+In the first case (`NewRule()`) kind is set to
+`build.Ident{Name: string}` while it's parsed
+expression in the second case (`ruleFromExpr()`).
+
+For rules packed in a struct like
+`selects.config_setting_group` there is no way
+to create/generate the same rule as the one
+parsed from the file as both will have
+different kinds.
+
+This change unifies kinds for two ways of
+creating rules and correctly sets the identifier
+while fixing loads (`FixLoads()`).
+
+diff --git a/rule/rule.go b/rule/rule.go
+index 502698f..82c14bb 100644
+--- a/rule/rule.go
++++ b/rule/rule.go
+@@ -730,8 +730,20 @@ type attrValue struct {
+ 
+ // NewRule creates a new, empty rule with the given kind and name.
+ func NewRule(kind, name string) *Rule {
++	var call *bzl.CallExpr
+ 	kindIdent := &bzl.Ident{Name: kind}
+-	call := &bzl.CallExpr{X: kindIdent}
++
++	parts := strings.Split(kind, ".")
++	if len(parts) > 1 {
++		// Create the same `CallExpr` like parser does
++		call = &bzl.CallExpr{X: &bzl.DotExpr{
++			Name: strings.Join(parts[1:], "."),
++			X:    &bzl.Ident{Name: parts[0]},
++		}}
++	} else {
++		call = &bzl.CallExpr{X: kindIdent}
++	}
++
+ 	r := &Rule{
+ 		stmt:    stmt{expr: call},
+ 		kind:    kindIdent,
+@@ -771,11 +783,12 @@ func ruleFromExpr(index int, expr bzl.Expr) *Rule {
+ 		return nil
+ 	}
+ 
+-	kind := call.X
+-	if !isNestedDotOrIdent(kind) {
++	if !isNestedDotOrIdent(call.X) {
+ 		return nil
+ 	}
+ 
++	kind := &bzl.Ident{Name: bzl.FormatString(call.X)}
++
+ 	var args []bzl.Expr
+ 	attrs := make(map[string]attrValue)
+ 	for _, arg := range call.List {
+@@ -999,7 +1012,17 @@ func (r *Rule) sync() {
+ 	}
+ 
+ 	call := r.expr.(*bzl.CallExpr)
+-	call.X = r.kind
++
++	// update `call.X` (e.g.: "# gazelle:map_kind")
++	parts := strings.Split(r.Kind(), ".")
++	if len(parts) > 1 {
++		call.X = &bzl.DotExpr{
++			Name: strings.Join(parts[1:], "."),
++			X:    &bzl.Ident{Name: parts[0]},
++		}
++	} else {
++		call.X = &bzl.Ident{Name: r.Kind()}
++	}
+ 
+ 	if len(r.attrs) > 1 {
+ 		call.ForceMultiLine = true
+-- 
+2.25.1
+


### PR DESCRIPTION
Remove workaround for `load()` statements. 
Change also applies the patches of Gazelle's [PR#1613](https://github.com/bazelbuild/bazel-gazelle/pull/1613).