### PR TITLE
chore: add convience snapshot script

### DIFF
--- a/gendiffer/tests/BUILD.bazel
+++ b/gendiffer/tests/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//gendiffer:gendiffer.bzl", "bob_generation_test")
-load("@rules_multirun//:defs.bzl", "multirun")
 
 [bob_generation_test(
     name = file[0:-len("/WORKSPACE")],
@@ -9,14 +8,16 @@ load("@rules_multirun//:defs.bzl", "multirun")
     ),
 ) for file in glob(["**/WORKSPACE"])]
 
-multirun(
-    name = "verify_snapshots",
-    commands = [
-        (file[0:-len("/WORKSPACE")] + platform)
-        for platform in [
-            "_android",
-            "_linux",
-        ]
-        for file in glob(["**/WORKSPACE"])
-    ],
-)
+# This target is currently broken. It executes the binary in the current path, unlike running a test directly,
+# which outputs all the files in the local work tree with incorrect permissions.
+# multirun(
+#     name = "verify_snapshots",
+#     commands = [
+#         (file[0:-len("/WORKSPACE")] + platform)
+#         for platform in [
+#             "_android",
+#             "_linux",
+#         ]
+#         for file in glob(["**/WORKSPACE"])
+#     ],
+# )

--- a/gendiffer/tests/update_failed.sh
+++ b/gendiffer/tests/update_failed.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Updates all failed snapshots.
+# Note, there is no way to currently parallize this as each invocation will lock the Bazel workspace.
+bazelisk test //gendiffer/... |
+	grep '//gendiffer/tests.*FAILED' |
+	sed 's/\s.*$//' |
+	while read target; do UPDATE_SNAPSHOTS=true bazelisk run $target; done


### PR DESCRIPTION
The `:verify_snapshots` target does not work as expected currently. For now, remove it and provide a shell
script to easily update any failing snapshots.

This is useful when mass adding large amounts of
test cases and saves time by not running the update on passing test cases.

Change-Id: Ib91d1f0be2f7f5afabb0776102cfec602ef89855