### PR TITLE
fix "go install std error" when cross build

### DIFF
--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -42,7 +42,7 @@ if [ "$(printf "%s\n1.20\n" "$go_version" | sort -t '.' -k 1,1 -k 2,2 -g | head 
     echo 'WARNING: Go >=1.20 is not fully supported by Bob/Blueprint and requires a pre-installed Go `std` package on the system. Attempting workaround. You may disable this workaround by setting `GO120_NO_STD_INSTALL=1`'
 
     ret=0
-    (GODEBUG=installgoroot=all go install std) || ret=$?
+    (GODEBUG=installgoroot=all CC="gcc" go install std) || ret=$?
 
     if [ $ret -eq 126 ]; then
       echo 'WARNING: Permissions failed when installing Go standard library. Build will proceed assuming a sandboxed envrioment, if you are not in a sandbox with a pre-existing Go `std` library installed please run `GODEBUG=installgoroot=all go install std` with sudo.'


### PR DESCRIPTION
meet below error when cross build which has the environment "CC=aarch64-poky-linux-gcc".

| In /opt/mickledore/build/tmp/work/armv8a-mx8-poky-linux/imx-gpu-mali/1.0.0-r0/git: ['driver/product/bldsys/bootstrap_linux.bash', '-b', 'driver/product/build']
| *** Error ***
| stderr contents:
| b"# runtime/cgo\naarch64-poky-linux-gcc: error: unrecognized command-line option '-m64'\n"