### PR TITLE
fix: remove `export_{system_}include_dirs` from `cc_binary`

### DIFF
--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -527,8 +527,14 @@ func addCompilableProps(mod bpwriter.Module, m Compilable, ctx blueprint.ModuleC
 
 	mod.AddStringList("include_dirs", include_dirs)
 	mod.AddStringList("local_include_dirs", local_include_dirs)
-	mod.AddStringList("export_include_dirs", export_include_dirs)
-	mod.AddStringList("export_system_include_dirs ", export_system_include_dirs)
+
+	// only `cc_library` contains those properties
+	_, ok1 := ctx.Module().(*ModuleStrictBinary)
+	_, ok2 := ctx.Module().(*ModuleTest)
+	if !ok1 && !ok2 {
+		mod.AddStringList("export_include_dirs", export_include_dirs)
+		mod.AddStringList("export_system_include_dirs ", export_system_include_dirs)
+	}
 
 	mod.AddStringList("shared_libs", shared_libs)
 	mod.AddStringList("static_libs", static_libs)

--- a/gendiffer/tests/executable/featureable/out/android/Android.bp.out
+++ b/gendiffer/tests/executable/featureable/out/android/Android.bp.out
@@ -15,10 +15,6 @@ cc_binary_host {
         "android_app/includes",
         "android_app/host/includes",
     ],
-    export_system_include_dirs : [
-        "android_app/includes",
-        "android_app/host/includes",
-    ],
 }
 
 cc_binary {
@@ -26,10 +22,6 @@ cc_binary {
     stem: "hello",
     srcs: ["hello.cpp"],
     local_include_dirs: [
-        "android_app/includes",
-        "android_app/target/includes",
-    ],
-    export_system_include_dirs : [
         "android_app/includes",
         "android_app/target/includes",
     ],


### PR DESCRIPTION
Android's `cc_binary` does not have `export_include_dirs` and `export_system_include_dirs` properties and cannot be generated to it.
Generate those flags only for `cc_library`.


Change-Id: I757cac5eaf00cbdf52eccab744a1afd875d85a51