### PR TITLE
fix: install path for 64BitOnly

### DIFF
--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -309,7 +309,11 @@ func addCcLibraryProps(mod bpwriter.Module, m ModuleLibrary, ctx blueprint.Modul
 
 	_, installRel, ok := getSoongInstallPath(m.getInstallableProps())
 	if ok && installRel != "" {
-		mod.AddString("relative_install_path", installRel)
+		if backend.Get().GetToolchain(toolchain.TgtTypeTarget).Is64BitOnly() {
+			mod.AddString("relative_install_path", installRel+"64")
+		} else {
+			mod.AddString("relative_install_path", installRel)
+		}
 	}
 
 	addProvenanceProps(ctx, mod, &m)

--- a/core/androidbp_resource.go
+++ b/core/androidbp_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ARM-software/bob-build/core/backend"
 	"github.com/ARM-software/bob-build/core/file"
+	"github.com/ARM-software/bob-build/core/toolchain"
 	"github.com/ARM-software/bob-build/internal/bpwriter"
 	"github.com/ARM-software/bob-build/internal/utils"
 )
@@ -30,7 +31,14 @@ func writeDataResourceModule(m bpwriter.Module, src, installRel, linkName string
 func writeCodeResourceModule(m bpwriter.Module, src, installRel, linkName string) {
 	m.AddStringList("srcs", []string{src})
 	m.AddString("stem", filepath.Base(src))
-	m.AddString("relative_install_path", installRel)
+
+	if installRel != "" {
+		if backend.Get().GetToolchain(toolchain.TgtTypeTarget).Is64BitOnly() {
+			m.AddString("relative_install_path", installRel+"64")
+		} else {
+			m.AddString("relative_install_path", installRel)
+		}
+	}
 }
 
 func (m *ModuleResource) getAndroidbpResourceName(src string) string {


### PR DESCRIPTION
Place the `64` suffix for the relative install path when the Android target is 64Bit only.
