### PR TITLE
Revert "fix: install path for 64BitOnly"

### DIFF
--- a/core/androidbp_cclibs.go
+++ b/core/androidbp_cclibs.go
@@ -309,11 +309,7 @@ func addCcLibraryProps(mod bpwriter.Module, m ModuleLibrary, ctx blueprint.Modul
 
 	_, installRel, ok := getSoongInstallPath(m.getInstallableProps())
 	if ok && installRel != "" {
-		if backend.Get().GetToolchain(toolchain.TgtTypeTarget).Is64BitOnly() {
-			mod.AddString("relative_install_path", installRel+"64")
-		} else {
-			mod.AddString("relative_install_path", installRel)
-		}
+		mod.AddString("relative_install_path", installRel)
 	}
 
 	addProvenanceProps(ctx, mod, &m)

--- a/core/androidbp_resource.go
+++ b/core/androidbp_resource.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ARM-software/bob-build/core/backend"
 	"github.com/ARM-software/bob-build/core/file"
-	"github.com/ARM-software/bob-build/core/toolchain"
 	"github.com/ARM-software/bob-build/internal/bpwriter"
 	"github.com/ARM-software/bob-build/internal/utils"
 )
@@ -31,14 +30,7 @@ func writeDataResourceModule(m bpwriter.Module, src, installRel, linkName string
 func writeCodeResourceModule(m bpwriter.Module, src, installRel, linkName string) {
 	m.AddStringList("srcs", []string{src})
 	m.AddString("stem", filepath.Base(src))
-
-	if installRel != "" {
-		if backend.Get().GetToolchain(toolchain.TgtTypeTarget).Is64BitOnly() {
-			m.AddString("relative_install_path", installRel+"64")
-		} else {
-			m.AddString("relative_install_path", installRel)
-		}
-	}
+	m.AddString("relative_install_path", installRel)
 }
 
 func (m *ModuleResource) getAndroidbpResourceName(src string) string {


### PR DESCRIPTION
This reverts commit c62f3778284836be958d13982a01bfdb0829c747.

Adding `64` suffix to `installRel` makes it wrong. `installRel` should be exactly as it is provided in the rule.


Change-Id: Ie396901ddda1fb0ae86b7e292418b49267cd5d1c