### PR TITLE
fix: toolchain flag test

### DIFF
--- a/tests/build.bp
+++ b/tests/build.bp
@@ -74,5 +74,6 @@ bob_alias {
         "bob_test_version_script",
         "bob_test_system_includes",
         "bob_test_strict_bins",
+        "bob_test_toolchain_flags",
     ],
 }

--- a/tests/toolchain_flags/build.bp
+++ b/tests/toolchain_flags/build.bp
@@ -59,8 +59,18 @@ bob_library {
     target: {
         install_group: "IG_libs",
     },
-
+    copts: [
+        "-fPIC",
+    ],
     host_supported: true,
     target_supported: true,
     build_by_default: true,
+}
+
+bob_alias {
+    name: "bob_test_toolchain_flags",
+    srcs: [
+        "foo:host",
+        "foo:target",
+    ],
 }


### PR DESCRIPTION
Fix single build and add toolchain flag test to
be run with `build_tests.sh`.


Change-Id: Iaa00923b46a06eb21f2539821a909b4ea102d807