### PR TITLE
chore: drop the support for `go` <1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,19 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go:
-          [
-            "1.11",
-            "1.12",
-            "1.13",
-            "1.14",
-            "1.15",
-            "1.16",
-            "1.17",
-            "1.18",
-            "1.19",
-            "1.20",
-          ]
+        go: ["1.18", "1.19", "1.20"]
         os: [ubuntu-latest]
         include:
           - go: "1.18"
@@ -153,19 +141,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go:
-          [
-            "1.11",
-            "1.12",
-            "1.13",
-            "1.14",
-            "1.15",
-            "1.16",
-            "1.17",
-            "1.18",
-            "1.19",
-            "1.20",
-          ]
+        go: ["1.18", "1.19", "1.20"]
         os: [ubuntu-latest]
         python: ["3.x"]
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ do the heavy lifting. As such it has similarities with
 
 To use Bob you will need:
 
-- golang (>=1.11)
+- golang (>=1.18)
 - ninja-build (>=1.8)
 - python3 (>=3.6)
 - python3-ply


### PR DESCRIPTION
Bob now requires `go` >=1.18.
Lower versions are not supported anymore.


Change-Id: I2ad513adb745091385ea080b0c62f4555c5dd2c0