### PR TITLE
fix: bring back `set_config_if_prompt`

### DIFF
--- a/tests/Mconfig
+++ b/tests/Mconfig
@@ -288,3 +288,15 @@ config KERNEL_CC
 config KERNEL_CLANG_TRIPLE
 	string "Kernel Clang triple"
 	default "x86_64-linux-gnu" if ANDROID
+
+config USER_SETTING_1
+    bool "User setting 1"
+    default n
+
+config USER_SETTING_2
+    bool "User setting 2"
+    default n
+
+config NON_USER_SETTABLE
+    bool
+    default n

--- a/tests/bootstrap_linux
+++ b/tests/bootstrap_linux
@@ -73,6 +73,7 @@ export BLUEPRINT_LIST_FILE="${SRCDIR}/bplist"
 export BOB_LOG_WARNINGS_FILE="${BUILDDIR}/.bob.warnings.csv"
 export BOB_META_FILE="${BUILDDIR}/.bob.meta.json"
 export BOB_LOG_WARNINGS="DeprecatedFilegroupSrcs:W"
+export BOB_CONFIG_PLUGINS="${SRCDIR}/plugins/test_plugin"
 
 "${SCRIPT_DIR}/bob/bootstrap_linux.bash"
 

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -1,0 +1,24 @@
+import logging
+
+from config_system import get_config_bool, set_config
+
+logger = logging.getLogger(__name__)
+
+
+def plugin_exec():
+    is_linux = get_config_bool("LINUX")
+    if is_linux:
+        set_config("USER_SETTING_1", "y")
+    else:
+        set_config("USER_SETTING_2", "y")
+
+    set_config("NON_USER_SETTABLE", "y")  # should not be set
+
+    configs = {
+        "USER_SETTING_1": is_linux,
+        "USER_SETTING_2": not is_linux,
+        "NON_USER_SETTABLE": False,
+    }
+
+    for k, v in configs.items():
+        assert get_config_bool(f"{k}") == v, f"'{k}' should be '{v}'"


### PR DESCRIPTION
There is a need to fall back `set_config_if_prompt` function in `system_config` module as deprecated. This is to allow easier transition to the newer API. 

Bob tests does not check if allowed plugins can properly work with config system. Change also adds simple test plugin which sets config option and verifies that. 