### PR TITLE
fix: include namepace in rule name

### DIFF
--- a/plugins/genrulebob/genrule.go
+++ b/plugins/genrulebob/genrule.go
@@ -378,7 +378,13 @@ func (m *genrulebobCommon) writeNinjaRules(ctx android.ModuleContext, args map[s
 		ruleparams.Deps = blueprint.DepsGCC
 	}
 
-	rule := ctx.Rule(pctx, "bob_gen_"+ctx.ModuleName(), ruleparams, keys...)
+	var namespacePrefix string
+	namespace := ctx.Namespace().Path
+	if namespace != "." {
+		namespacePrefix = strings.ReplaceAll(namespace, "/", "_") + "_"
+	}
+
+	rule := ctx.Rule(pctx, "bob_gen_"+namespacePrefix+ctx.ModuleName(), ruleparams, keys...)
 
 	for _, io := range m.inouts {
 		// `args` is slightly different for each inout, but blueprint's


### PR DESCRIPTION
Bob's `genrule` plugin for Soong needs to consider namespace within the rule name to avoid duplication for module with the same name but from different
Soong namespaces.


Change-Id: I5cc2bf6dce3878ea589e6cc67e1d6c1f3dbae8d3